### PR TITLE
Agency pdf rendering

### DIFF
--- a/src/onegov/agency/cli.py
+++ b/src/onegov/agency/cli.py
@@ -12,6 +12,7 @@ from onegov.agency.excel_export import export_person_xlsx
 from onegov.agency.models import ExtendedAgencyMembership
 from onegov.core.cli import command_group
 from onegov.core.cli import pass_group_context
+from onegov.core.filestorage import FilestorageFile
 from onegov.core.html import html_to_text
 from onegov.people.collections import AgencyCollection
 from onegov.people.collections import PersonCollection
@@ -21,8 +22,6 @@ from xlrd import open_workbook
 
 
 cli = command_group()
-
-
 @cli.command('import-agencies')
 @click.argument('file', type=click.Path(exists=True))
 @click.option('--clear/--no-clear', default=True)
@@ -265,6 +264,7 @@ def create_pdf(group_context, root, recursive):
     def _create_pdf(request, app):
         session = app.session()
         agencies = ExtendedAgencyCollection(session)
+        root_pdf = FilestorageFile('/root_pdf')
 
         if root:
             app.root_pdf = app.pdf_class.from_agencies(

--- a/src/onegov/agency/collections/agencies.py
+++ b/src/onegov/agency/collections/agencies.py
@@ -5,3 +5,11 @@ from onegov.people import AgencyCollection
 class ExtendedAgencyCollection(AgencyCollection):
 
     __listclass__ = ExtendedAgency
+
+    # Used to create link for root pdf based on timestamp
+    def __init__(self, *args, **kwargs):
+        root_pdf_modified = kwargs.pop('root_pdf_modified')
+        super(ExtendedAgencyCollection, self).__init__(*args, **kwargs)
+        self.root_pdf_modified = root_pdf_modified
+
+

--- a/src/onegov/agency/collections/agencies.py
+++ b/src/onegov/agency/collections/agencies.py
@@ -7,9 +7,8 @@ class ExtendedAgencyCollection(AgencyCollection):
     __listclass__ = ExtendedAgency
 
     # Used to create link for root pdf based on timestamp
-    def __init__(self, *args, **kwargs):
-        root_pdf_modified = kwargs.pop('root_pdf_modified')
-        super(ExtendedAgencyCollection, self).__init__(*args, **kwargs)
+    def __init__(self, session, root_pdf_modified=None):
+        super(ExtendedAgencyCollection, self).__init__(session)
         self.root_pdf_modified = root_pdf_modified
 
 

--- a/src/onegov/agency/collections/people.py
+++ b/src/onegov/agency/collections/people.py
@@ -20,12 +20,14 @@ class ExtendedPersonCollection(PersonCollection, Pagination):
     def model_class(self):
         return ExtendedPerson
 
-    def __init__(self, session, page=0, letter=None, agency=None):
+    def __init__(self, session, page=0, letter=None, agency=None, xlsx_modified=None):
         self.session = session
         self.page = page
         self.letter = letter.upper() if letter else None
         self.agency = agency
         self.exclude_hidden = False
+        # Usage for link generation of people excel based on timestamp
+        self.xlsx_modified = xlsx_modified
 
     def subset(self):
         return self.query()

--- a/src/onegov/agency/models/agency.py
+++ b/src/onegov/agency/models/agency.py
@@ -58,14 +58,10 @@ class ExtendedAgency(Agency, HiddenFromPublicExtension):
         """
 
         filename = '{}.pdf'.format(normalize_for_url(self.title))
-        if self.pdf:
-            self.pdf.reference = as_fileintent(value, filename)
-            self.pdf.name = filename
-        else:
-            pdf = AgencyPdf(id=random_token())
-            pdf.reference = as_fileintent(value, filename)
-            pdf.name = filename
-            self.pdf = pdf
+        pdf = AgencyPdf(id=random_token())
+        pdf.reference = as_fileintent(value, filename)
+        pdf.name = filename
+        self.pdf = pdf
 
     @property
     def portrait_html(self):

--- a/src/onegov/agency/path.py
+++ b/src/onegov/agency/path.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from onegov.agency.app import AgencyApp
 from onegov.agency.collections import ExtendedAgencyCollection
 from onegov.agency.collections import ExtendedPersonCollection
@@ -22,9 +24,9 @@ def get_people(app, page=0, letter=None, agency=None):
 
 @AgencyApp.path(
     model=ExtendedAgencyCollection,
-    path='/organizations'
+    path='/organizations',
 )
-def get_agencies(app):
+def get_agencies(app, pdf_modified=None):
     return ExtendedAgencyCollection(app.session())
 
 

--- a/src/onegov/agency/path.py
+++ b/src/onegov/agency/path.py
@@ -18,16 +18,17 @@ from uuid import UUID
     path='/people',
     converters=dict(page=int)
 )
-def get_people(app, page=0, letter=None, agency=None):
-    return ExtendedPersonCollection(app.session(), page, letter, agency)
+def get_people(app, page=0, letter=None, agency=None, xlsx_modified=None):
+    return ExtendedPersonCollection(
+        app.session(), page, letter, agency, xlsx_modified)
 
 
 @AgencyApp.path(
     model=ExtendedAgencyCollection,
     path='/organizations',
 )
-def get_agencies(app, pdf_modified=None):
-    return ExtendedAgencyCollection(app.session())
+def get_agencies(app, root_pdf_modified=None):
+    return ExtendedAgencyCollection(app.session(), root_pdf_modified)
 
 
 @AgencyApp.path(

--- a/src/onegov/agency/views/agencies.py
+++ b/src/onegov/agency/views/agencies.py
@@ -44,7 +44,9 @@ def get_membership_form_class(model, request):
 def view_agencies(self, request):
 
     pdf_link = None
-    if request.app.root_pdf_exists:
+    pdf_modified = request.app.root_pdf_modified
+    if pdf_modified is not None:
+        self.pdf_modified = str(pdf_modified.timestamp())
         pdf_link = request.link(self, name='pdf')
 
     return {
@@ -220,38 +222,6 @@ def move_agency(self, request, form):
         ),
         'form': form
     }
-
-
-@AgencyApp.view(
-    model=ExtendedAgencyCollection,
-    name='pdf',
-    permission=Public
-)
-def get_root_pdf(self, request):
-
-    if not request.app.root_pdf_exists:
-        return Response(status='503 Service Unavailable')
-
-    @request.after
-    def cache_headers(response):
-        last_modified = request.app.root_pdf_modified
-        if last_modified:
-            max_age = 1 * 24 * 60 * 60
-            expires = datetime.now() + timedelta(seconds=max_age)
-            fmt = '%a, %d %b %Y %H:%M:%S GMT'
-
-            response.headers.add('Cache-Control', f'max-age={max_age}, public')
-            response.headers.add('ETag', last_modified.isoformat())
-            response.headers.add('Expires', expires.strftime(fmt))
-            response.headers.add('Last-Modified', last_modified.strftime(fmt))
-
-    return Response(
-        request.app.root_pdf,
-        content_type='application/pdf',
-        content_disposition='inline; filename={}.pdf'.format(
-            normalize_for_url(request.app.org.name)
-        )
-    )
 
 
 @AgencyApp.form(

--- a/src/onegov/agency/views/people.py
+++ b/src/onegov/agency/views/people.py
@@ -37,7 +37,9 @@ def view_people(self, request):
     request.include('people-select')
 
     people_xlsx_link = None
-    if request.app.people_xlsx_exists:
+    last_modified = request.app.people_xlsx_modified
+    if last_modified is not None:
+        self.xlsx_modified = str(last_modified.timestamp())
         people_xlsx_link = request.link(self, name='people-xlsx')
 
     if not request.is_logged_in:

--- a/src/onegov/election_day/layouts/default.py
+++ b/src/onegov/election_day/layouts/default.py
@@ -1,5 +1,3 @@
-import onegov.core
-
 from babel import Locale
 from cached_property import cached_property
 from datetime import datetime


### PR DESCRIPTION
Features more intelligent page breaks as in word. Stores page break settings in Agency.meta class. Adds Form in Settings/Organisation to influence page break.
Fixes link generation for:
- root.pdf. Link will be appended a query param using the timestamp of pdf modification
- same for Excel (is for all persons).
- agency pdfs: Recreates the database entry on every generation