### PR TITLE
Agency js editor

### DIFF
--- a/src/onegov/agency/app.py
+++ b/src/onegov/agency/app.py
@@ -9,6 +9,8 @@ from onegov.core import utils
 from onegov.form import FormApp
 from onegov.org import OrgApp
 from onegov.org.app import get_i18n_localedirs as get_org_i18n_localedirs
+from onegov.org.app import get_editor_asset as editor_assets
+from onegov.org.app import get_redactor_asset as redactor_assets
 
 
 class AgencyApp(OrgApp, FormApp):
@@ -124,3 +126,13 @@ def get_sortable_multi_checkbox_asset():
     yield 'jquery.js'
     yield 'sortable.js'
     yield 'sortable-multi-checkbox.js'
+
+
+@AgencyApp.webasset('redactor', filters={'js': None})
+def get_redactor_asserts():
+    yield from redactor_assets()
+
+
+@AgencyApp.webasset('editor')
+def get_editor_assets():
+    yield from editor_assets()

--- a/src/onegov/agency/cli.py
+++ b/src/onegov/agency/cli.py
@@ -12,7 +12,6 @@ from onegov.agency.excel_export import export_person_xlsx
 from onegov.agency.models import ExtendedAgencyMembership
 from onegov.core.cli import command_group
 from onegov.core.cli import pass_group_context
-from onegov.core.filestorage import FilestorageFile
 from onegov.core.html import html_to_text
 from onegov.people.collections import AgencyCollection
 from onegov.people.collections import PersonCollection

--- a/src/onegov/agency/cli.py
+++ b/src/onegov/agency/cli.py
@@ -28,9 +28,10 @@ cli = command_group()
 @click.option('--skip-download/--no-skip-download', default=False)
 @click.option('--dry-run/--no-dry-run', default=False)
 @click.option('--visualize/--no-visualize', default=False)
+@click.option('--strip-portrait-html/--leave-portrait-html', default=False)
 @pass_group_context
 def import_agencies(group_context, file, clear, skip_root, skip_download,
-                    dry_run, visualize):
+                    dry_run, visualize, strip_portrait_html):
     """ Import data from a seantis.agencies export. For example:
 
         onegov-people \
@@ -115,12 +116,15 @@ def import_agencies(group_context, file, clear, skip_root, skip_download,
             # We use our own, internal IDs which are auto-incremented
             external_id = int(sheet.cell_value(row, 0))
 
-            # Remove the HTML code from the portrait, prepend the description
-            portrait = '\n'.join((
-                sheet.cell_value(row, 3).strip(),
-                html_to_text(cleaner.clean(sheet.cell_value(row, 4)))
-            ))
-            portrait = portrait.replace('\n\n', '\n').strip()
+            # Leave input as html for redactor.js , prepend the description
+            if strip_portrait_html:
+                portrait = '\n'.join((
+                    sheet.cell_value(row, 3).strip(),
+                    html_to_text(cleaner.clean(sheet.cell_value(row, 4)))
+                ))
+                portrait = portrait.replace('\n\n', '\n').strip()
+            else:
+                portrait = sheet.cell_value(row, 4)
 
             # Re-map the export fields
             export_fields = sheet.cell_value(row, 7) or 'role,title'

--- a/src/onegov/agency/cli.py
+++ b/src/onegov/agency/cli.py
@@ -264,7 +264,6 @@ def create_pdf(group_context, root, recursive):
     def _create_pdf(request, app):
         session = app.session()
         agencies = ExtendedAgencyCollection(session)
-        root_pdf = FilestorageFile('/root_pdf')
 
         if root:
             app.root_pdf = app.pdf_class.from_agencies(

--- a/src/onegov/agency/cli.py
+++ b/src/onegov/agency/cli.py
@@ -124,7 +124,8 @@ def import_agencies(group_context, file, clear, skip_root, skip_download,
                 ))
                 portrait = portrait.replace('\n\n', '\n').strip()
             else:
-                portrait = sheet.cell_value(row, 4)
+                portrait = f'<p>{sheet.cell_value(row, 3).strip()}</p>' +\
+                           sheet.cell_value(row, 4)
 
             # Re-map the export fields
             export_fields = sheet.cell_value(row, 7) or 'role,title'

--- a/src/onegov/agency/collections/agencies.py
+++ b/src/onegov/agency/collections/agencies.py
@@ -10,5 +10,3 @@ class ExtendedAgencyCollection(AgencyCollection):
     def __init__(self, session, root_pdf_modified=None):
         super(ExtendedAgencyCollection, self).__init__(session)
         self.root_pdf_modified = root_pdf_modified
-
-

--- a/src/onegov/agency/collections/people.py
+++ b/src/onegov/agency/collections/people.py
@@ -20,7 +20,8 @@ class ExtendedPersonCollection(PersonCollection, Pagination):
     def model_class(self):
         return ExtendedPerson
 
-    def __init__(self, session, page=0, letter=None, agency=None, xlsx_modified=None):
+    def __init__(self, session, page=0, letter=None, agency=None,
+                 xlsx_modified=None):
         self.session = session
         self.page = page
         self.letter = letter.upper() if letter else None

--- a/src/onegov/agency/forms/agency.py
+++ b/src/onegov/agency/forms/agency.py
@@ -74,6 +74,8 @@ class ExtendedAgencyForm(Form):
         result = super(ExtendedAgencyForm, self).get_useful_data(exclude)
         if self.organigram.data:
             result['organigram_file'] = self.organigram.raw_data[-1].file
+        if self.portrait.data:
+            result['portrait'] = linkify(self.portrait.data, escape=False)
         return result
 
     def update_model(self, model):

--- a/src/onegov/agency/forms/agency.py
+++ b/src/onegov/agency/forms/agency.py
@@ -78,7 +78,7 @@ class ExtendedAgencyForm(Form):
 
     def update_model(self, model):
         model.title = self.title.data
-        model.portrait = self.portrait.data
+        model.portrait = linkify(self.portrait.data, escape=False)
         model.export_fields = self.export_fields.data
         if self.organigram.action == 'delete':
             del model.organigram

--- a/src/onegov/agency/forms/agency.py
+++ b/src/onegov/agency/forms/agency.py
@@ -3,8 +3,9 @@ from io import BytesIO
 from onegov.agency import _
 from onegov.agency.collections import ExtendedAgencyCollection
 from onegov.agency.models import ExtendedAgency
+from onegov.core.utils import linkify
 from onegov.form import Form
-from onegov.form.fields import ChosenSelectField
+from onegov.form.fields import ChosenSelectField, HtmlField
 from onegov.form.fields import MultiCheckboxField
 from onegov.form.fields import UploadField
 from onegov.form.validators import FileSizeLimit
@@ -12,7 +13,6 @@ from onegov.form.validators import WhitelistedMimeType
 from sqlalchemy import func
 from sqlalchemy import String
 from wtforms import StringField
-from wtforms import TextAreaField
 from wtforms import validators
 
 
@@ -26,7 +26,7 @@ class ExtendedAgencyForm(Form):
         ],
     )
 
-    portrait = TextAreaField(
+    portrait = HtmlField(
         label=_("Portrait"),
         render_kw={'rows': 10}
     )

--- a/src/onegov/agency/layouts/agency.py
+++ b/src/onegov/agency/layouts/agency.py
@@ -56,6 +56,10 @@ class AgencyCollectionLayout(DefaultLayout, MoveAgencyMixin):
 
 class AgencyLayout(AdjacencyListLayout, MoveAgencyMixin):
 
+    def include_editor(self):
+        self.request.include('redactor')
+        self.request.include('editor')
+
     @cached_property
     def collection(self):
         return ExtendedAgencyCollection(self.request.session)

--- a/src/onegov/agency/models/agency.py
+++ b/src/onegov/agency/models/agency.py
@@ -65,9 +65,10 @@ class ExtendedAgency(Agency, HiddenFromPublicExtension):
 
     @property
     def portrait_html(self):
-        """ Returns the portrait as HTML. """
+        """ Returns the portrait that is saved as HTML from the redactor js
+         plugin. """
 
-        return '<p>{}</p>'.format(linkify(self.portrait).replace('\n', '<br>'))
+        return self.portrait
 
     def proxy(self):
         """ Returns a proxy object to this agency allowing alternative linking

--- a/src/onegov/agency/models/agency.py
+++ b/src/onegov/agency/models/agency.py
@@ -2,7 +2,6 @@ from onegov.agency.models.membership import ExtendedAgencyMembership
 from onegov.core.crypto import random_token
 from onegov.core.orm.abstract import associated
 from onegov.core.orm.mixins import meta_property
-from onegov.core.utils import linkify
 from onegov.core.utils import normalize_for_url
 from onegov.file import File
 from onegov.file.utils import as_fileintent

--- a/src/onegov/agency/path.py
+++ b/src/onegov/agency/path.py
@@ -1,5 +1,3 @@
-from datetime import datetime
-
 from onegov.agency.app import AgencyApp
 from onegov.agency.collections import ExtendedAgencyCollection
 from onegov.agency.collections import ExtendedPersonCollection

--- a/src/onegov/agency/pdf.py
+++ b/src/onegov/agency/pdf.py
@@ -48,6 +48,7 @@ class AgencyPdfDefault(Pdf):
             if agency.is_hidden_from_public:
                 continue
             pdf.agency(agency, exclude,
+                       content_so_far=False,
                        skip_title=title == agency.title,
                        page_break_on_level=page_break_on_level)
         pdf.generate()
@@ -93,7 +94,7 @@ class AgencyPdfDefault(Pdf):
         if data:
             self.table(data, [5.5 * cm, 0.5 * cm, None])
 
-    def agency(self, agency, exclude, level=1,
+    def agency(self, agency, exclude, level=1, content_so_far=False,
                skip_title=False, page_break_on_level=1):
         """ Adds a single agency with the portrait and memberships. """
         if (

--- a/src/onegov/agency/pdf.py
+++ b/src/onegov/agency/pdf.py
@@ -48,7 +48,6 @@ class AgencyPdfDefault(Pdf):
             if agency.is_hidden_from_public:
                 continue
             pdf.agency(agency, exclude,
-                       content_so_far=False,
                        skip_title=title == agency.title,
                        page_break_on_level=page_break_on_level)
         pdf.generate()
@@ -94,7 +93,7 @@ class AgencyPdfDefault(Pdf):
         if data:
             self.table(data, [5.5 * cm, 0.5 * cm, None])
 
-    def agency(self, agency, exclude, level=1, content_so_far=False,
+    def agency(self, agency, exclude, level=1,
                skip_title=False, page_break_on_level=1):
         """ Adds a single agency with the portrait and memberships. """
         if (

--- a/src/onegov/agency/upgrade.py
+++ b/src/onegov/agency/upgrade.py
@@ -3,7 +3,9 @@ upgraded on the server. See :class:`onegov.core.upgrade.upgrade_task`.
 
 """
 from onegov.core.upgrade import upgrade_task
+from onegov.core.utils import linkify
 from onegov.org.models import Organisation
+from onegov.people import Agency
 
 
 @upgrade_task("Add default values for page breaks of PDFs")
@@ -17,3 +19,12 @@ def add_default_value_for_pagebreak_pdf(context):
         for org in session.query(Organisation).all():
             org.meta['page_break_on_level_root_pdf'] = 1
             org.meta['page_break_on_level_org_pdf'] = 1
+
+
+@upgrade_task("Convert Agency.portrait to a html")
+def convert_agency_portrait_to_html(context):
+    session = context.session
+    if context.has_column('agencies', 'portrait'):
+        for agency in session.query(Agency).all():
+            agency.portrait = '<p>{}</p>'.format(
+                linkify(agency.portrait).replace('\n', '<br>'))

--- a/src/onegov/agency/views/agencies.py
+++ b/src/onegov/agency/views/agencies.py
@@ -89,7 +89,6 @@ def add_root_agency(self, request, form):
     layout.breadcrumbs.append(Link(_("New"), '#'))
     layout.include_editor()
 
-
     return {
         'layout': layout,
         'title': _("New agency"),
@@ -256,6 +255,7 @@ def get_root_pdf(self, request):
             normalize_for_url(request.app.org.name)
         )
     )
+
 
 @AgencyApp.form(
     model=ExtendedAgencyCollection,

--- a/src/onegov/agency/views/agencies.py
+++ b/src/onegov/agency/views/agencies.py
@@ -87,6 +87,8 @@ def add_root_agency(self, request, form):
 
     layout = AgencyCollectionLayout(self, request)
     layout.breadcrumbs.append(Link(_("New"), '#'))
+    layout.include_editor()
+
 
     return {
         'layout': layout,
@@ -112,6 +114,7 @@ def add_agency(self, request, form):
 
     layout = AgencyLayout(self, request)
     layout.breadcrumbs.append(Link(_("New"), '#'))
+    layout.include_editor()
 
     return {
         'layout': layout,

--- a/src/onegov/agency/views/agencies.py
+++ b/src/onegov/agency/views/agencies.py
@@ -226,6 +226,7 @@ def move_agency(self, request, form):
         'form': form
     }
 
+
 @AgencyApp.view(
     model=ExtendedAgencyCollection,
     name='pdf',

--- a/src/onegov/agency/views/agencies.py
+++ b/src/onegov/agency/views/agencies.py
@@ -185,6 +185,7 @@ def edit_agency(self, request, form):
 
     layout = AgencyLayout(self, request)
     layout.breadcrumbs.append(Link(_("Edit"), '#'))
+    layout.include_editor()
 
     return {
         'layout': layout,

--- a/tests/onegov/agency/test_cli.py
+++ b/tests/onegov/agency/test_cli.py
@@ -97,7 +97,10 @@ def test_import_agencies(cfg_path, session_manager, file):
         def raise_for_status(self):
             pass
 
-    # Import
+    session_manager.set_current_schema('agency-zug')
+    session = session_manager.session()
+
+    # Import without stripping portrait
     with patch('onegov.agency.cli.get', return_value=DummyResponse()):
         result = runner.invoke(cli, [
             '--config', cfg_path,
@@ -107,6 +110,9 @@ def test_import_agencies(cfg_path, session_manager, file):
         ])
     assert result.exit_code == 0
     assert indent(expected, '  ') in result.output
+    agency = session.query(Agency).filter_by(title="Nationalrat").one()
+    assert agency.portrait == "<p>NR</p><p>2016/2019</p>"
+    assert agency.portrait_html == agency.portrait
 
     # Reimport
     with patch('onegov.agency.cli.get', return_value=DummyResponse()):
@@ -114,7 +120,7 @@ def test_import_agencies(cfg_path, session_manager, file):
             '--config', cfg_path,
             '--select', '/agency/zug',
             'import-agencies', file,
-            '--visualize', '--clear'
+            '--visualize', '--clear', '--strip-portrait-html'
         ])
     assert result.exit_code == 0
     assert "Deleting all agencies" in result.output
@@ -136,8 +142,6 @@ def test_import_agencies(cfg_path, session_manager, file):
     assert "Aborting transaction" in result.output
 
     # Check some additional values
-    session_manager.set_current_schema('agency-zug')
-    session = session_manager.session()
     agency = session.query(Agency).filter_by(title="Nationalrat").one()
     assert agency.portrait == "NR\n2016/2019"
     assert agency.portrait_html == "NR\n2016/2019"

--- a/tests/onegov/agency/test_cli.py
+++ b/tests/onegov/agency/test_cli.py
@@ -140,7 +140,7 @@ def test_import_agencies(cfg_path, session_manager, file):
     session = session_manager.session()
     agency = session.query(Agency).filter_by(title="Nationalrat").one()
     assert agency.portrait == "NR\n2016/2019"
-    assert agency.portrait_html == "<p>NR<br>2016/2019</p>"
+    assert agency.portrait_html == "NR\n2016/2019"
     assert agency.export_fields == [
         'membership.title',
         'person.title',

--- a/tests/onegov/agency/test_models.py
+++ b/tests/onegov/agency/test_models.py
@@ -27,7 +27,7 @@ def test_extended_agency(agency_app):
     assert agency.title == "Test Agency"
     assert agency.name == "test-agency"
     assert agency.portrait == "This is a test\nagency."
-    assert agency.portrait_html == "<p>This is a test<br>agency.</p>"
+    assert agency.portrait_html == "This is a test\nagency."
     assert agency.export_fields == []
     assert agency.pdf is None
     assert agency.pdf_file is None

--- a/tests/onegov/agency/test_views.py
+++ b/tests/onegov/agency/test_views.py
@@ -3,9 +3,10 @@ from PyPDF2 import PdfFileReader
 from xlrd import open_workbook
 
 from onegov.agency.models import ExtendedPerson
+from tests.onegov.core.test_utils import valid_test_phone_numbers
 
 
-def test_views(client):
+def test_views_1(client):
     client.login_admin()
     settings = client.get('/module-settings')
     settings.form['hidden_people_fields'] = ['academic_title', 'born']
@@ -89,14 +90,15 @@ def test_views(client):
 
     assert 'Bundesbehörden' in bund
 
+    tel_nr = valid_test_phone_numbers[0]
     new_agency = bund.click('Organisation', href='new')
     new_agency.form['title'] = 'Nationalrat'
-    new_agency.form['portrait'] = '2016/2019\nZug'
+    new_agency.form['portrait'] = f'2016/2019<br>{tel_nr}'
     new_agency.form['export_fields'] = ['membership.title', 'person.title']
     nr = new_agency.form.submit().follow()
 
     assert 'Nationalrat' in nr
-    assert '<p>2016/2019<br>Zug</p>' in nr
+    assert f'2016/2019<br><a href="tel:{tel_nr}">{tel_nr}</a>' in nr
 
     new_agency = bund.click('Organisation', href='new')
     new_agency.form['title'] = 'Standerat'

--- a/tests/onegov/agency/test_views.py
+++ b/tests/onegov/agency/test_views.py
@@ -1,8 +1,5 @@
 from io import BytesIO
 from PyPDF2 import PdfFileReader
-from xlrd import open_workbook
-
-from onegov.agency.models import ExtendedPerson
 from tests.onegov.core.test_utils import valid_test_phone_numbers
 
 
@@ -453,7 +450,7 @@ def test_excel_export_for_editor(client):
     page = client.get('/people')
     page = page.click('Download Excel Personen')
     assert page.content_type == \
-           'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+        'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
 
 
 def test_excel_export_not_logged_in(client):
@@ -469,5 +466,3 @@ def test_excel_export_not_logged_in(client):
     page = client.get(
         '/people/people-xlsx', expect_errors=True).maybe_follow()
     assert page.status == '403 Forbidden'
-
-


### PR DESCRIPTION
Uses WYSIWYG Editor for portrait field of agencies. Migrates current content to html in the same way it was converted for display. agency.portrait_html was left, but returns agency.portrait now.
Checked the pdf generation with migrated data, all links are still in place.
Bullet points, enumeration are added to PDF, but not images.