### PR TITLE
Zg parties panachage fix

### DIFF
--- a/src/onegov/ballot/models/election/panachage_result.py
+++ b/src/onegov/ballot/models/election/panachage_result.py
@@ -9,7 +9,19 @@ from uuid import uuid4
 
 class PanachageResult(Base, TimestampMixin):
 
-    """ The votes transferred from one list to another. """
+    """ Panachage Results are read in for lists and parties.
+
+    case lists:
+    It represents the votes transferred from one list to another.
+    target represents list.id (UUID) and owner is NULL
+
+    case parties:
+    It represents the total of votes reveived by panachage for a party across
+    all the lists.
+    target represents the party name (as well as source is party name) and
+    the owner is the election.id (a string).
+
+    """
 
     __tablename__ = 'panachage_results'
 
@@ -18,6 +30,7 @@ class PanachageResult(Base, TimestampMixin):
 
     #: the owner of this result, maps to election.id
     # where electon.id is derived from the title
+
     owner = Column(Text, nullable=True)
 
     #: the target this result belongs to, maps to list.id

--- a/src/onegov/election_day/formats/election/internal_proporz.py
+++ b/src/onegov/election_day/formats/election/internal_proporz.py
@@ -363,7 +363,6 @@ def import_election_internal_proporz(election, principal, file, mimetype):
             source=source,
             target=str(list_uids[list_id]),
             votes=votes,
-            owner=election_id
         )
         for list_id in panachage
         for source, votes in panachage[list_id].items()

--- a/src/onegov/election_day/formats/election/internal_proporz.py
+++ b/src/onegov/election_day/formats/election/internal_proporz.py
@@ -165,13 +165,23 @@ def parse_candidate_result(line, errors):
         )
 
 
+def prefix_connection_id(connection_id, parent_connection_id):
+    """Used to distinguish connection ids when they have the same id
+    as a parent_connection. """
+    if not len(connection_id) > len(parent_connection_id):
+        return parent_connection_id + connection_id
+    return connection_id
+
+
 def parse_connection(line, errors, election_id):
     subconnection_id = None
     try:
         connection_id = line.list_connection
         parent_connection_id = line.list_connection_parent
         if parent_connection_id:
-            subconnection_id = connection_id
+            subconnection_id = prefix_connection_id(
+                connection_id, parent_connection_id
+            )
             connection_id = parent_connection_id
     except ValueError:
         errors.append(_("Invalid list connection values"))

--- a/tests/onegov/election_day/formats/election/test_internal_proporz.py
+++ b/tests/onegov/election_day/formats/election/test_internal_proporz.py
@@ -116,7 +116,10 @@ def test_import_internal_proporz_regional_zg(session, import_test_datasets):
 
     panachage_results = session.query(PanachageResult)
     panachage_results = panachage_results.filter_by(owner=election.id).all()
-    assert panachage_results
+    assert not panachage_results, 'Owner of lists pana results must be NULL'
+
+    panachage_results = election.panachage_results
+
     for pa_result in panachage_results:
         assert len(pa_result.target) > 10, 'target must be a casted uuid'
 


### PR DESCRIPTION
- Fixes adding owner for list panachage results
- Adds `parent_connection_id` prefix to `connection_id` to create unique sublist_id's