### PR TITLE
Fsi ui improvements

### DIFF
--- a/src/onegov/fsi/assets/js/ifs.js
+++ b/src/onegov/fsi/assets/js/ifs.js
@@ -1,0 +1,26 @@
+function autoResizebyID(id) {
+    var newheight;
+    var newwidth;
+
+    if (document.getElementById) {
+        newheight = document.getElementById(id).contentWindow.document.body.scrollHeight;
+        newwidth = document.getElementById(id).contentWindow.document.body.scrollWidth;
+    }
+
+    document.getElementById(id).height = (newheight) + "px";
+    document.getElementById(id).width = (newwidth) + "px";
+}
+
+function autoResize() {
+    var newheight;
+    var newwidth;
+    var frame;
+    if (document.getElementsByClassName) {
+        for (frame of document.getElementsByClassName('resizeable')) {
+            newheight = frame.contentWindow.document.body.scrollHeight;
+            newwidth = frame.contentWindow.document.body.scrollWidth;
+            frame.height = (newheight) + "px";
+            frame.width = (newwidth) + "px";
+        }
+    }
+}

--- a/src/onegov/fsi/assets/js/ifs.js
+++ b/src/onegov/fsi/assets/js/ifs.js
@@ -1,26 +1,13 @@
-function autoResizebyID(id) {
-    var newheight;
-    var newwidth;
-
-    if (document.getElementById) {
-        newheight = document.getElementById(id).contentWindow.document.body.scrollHeight;
-        newwidth = document.getElementById(id).contentWindow.document.body.scrollWidth;
-    }
-
-    document.getElementById(id).height = (newheight) + "px";
-    document.getElementById(id).width = (newwidth) + "px";
-}
-
 function autoResize() {
     var newheight;
     var newwidth;
     var frame;
-    if (document.getElementsByClassName) {
-        for (frame of document.getElementsByClassName('resizeable')) {
-            newheight = frame.contentWindow.document.body.scrollHeight;
-            newwidth = frame.contentWindow.document.body.scrollWidth;
-            frame.height = (newheight) + "px";
-            frame.width = (newwidth) + "px";
-        }
+
+    for (frame of document.getElementsByClassName('resizeable')) {
+        newheight = frame.contentWindow.document.body.scrollHeight;
+        newwidth = frame.contentWindow.document.body.scrollWidth;
+        frame.height = (newheight) + "px";
+        frame.width = (newwidth) + "px";
     }
+
 }

--- a/src/onegov/fsi/collections/reservation.py
+++ b/src/onegov/fsi/collections/reservation.py
@@ -44,12 +44,13 @@ class ReservationCollection(GenericCollection):
 
     def query(self):
         query = super().query()
-        query = query.join(CourseAttendee).order_by(
-            CourseAttendee.last_name,
-            CourseAttendee.first_name,
-        )
+        # query = query.join(CourseAttendee).order_by(
+        #     CourseAttendee.last_name,
+        #     CourseAttendee.first_name,
+        # )
 
         if self.user_role == 'editor':
+            query = query.join(CourseAttendee)
             query = query.filter(
                 CourseAttendee.organisation.in_(
                     self.permissions,)

--- a/src/onegov/fsi/forms/course_event.py
+++ b/src/onegov/fsi/forms/course_event.py
@@ -84,8 +84,7 @@ class CourseEventForm(Form):
 
     status = ChosenSelectField(
         label=_('Status'),
-        choices=course_status_choices(),
-        default='created'
+        choices=[],
     )
 
     def on_request(self):
@@ -97,6 +96,9 @@ class CourseEventForm(Form):
             self.course_id.choices = tuple(
                 (str(c.id), c.name) for c in collection.query()
             )
+
+        self.status.choices = course_status_choices(self.request)
+        self.status.default = 'created'
 
     def apply_model(self, model):
         self.location.data = model.location

--- a/src/onegov/fsi/layouts/course.py
+++ b/src/onegov/fsi/layouts/course.py
@@ -72,15 +72,9 @@ class CourseCollectionLayout(DefaultLayout):
             dict(
                 title=c.name,
                 content=c.description,
+                # Todo: how to inject html with intercooler?
+                # content_url=self.request.link(c, name='content-json'),
                 url=self.request.link(c),
-                edit_url=self.request.link(c, name='edit'),
-                events_url=self.request.link(
-                    CourseEventCollection(
-                        self.request.session,
-                        course_id=c.id,
-                        upcoming_only=True
-                    )
-                )
             ) for c in self.model.query()
         )
 

--- a/src/onegov/fsi/layouts/reservation.py
+++ b/src/onegov/fsi/layouts/reservation.py
@@ -28,8 +28,10 @@ class ReservationCollectionLayout(DefaultLayout):
         if self.request.view_name == 'add-placeholder':
             return _('Add Placeholder')
         if self.model.course_event_id:
-            return _('Attendees Event ${event}',
-                     mapping={'event': self.model.course_event.name})
+            return _('Attendees Event ${event} - ${date}',
+                     mapping={'event': self.model.course_event.name,
+                              'date': self.format_date(
+                                  self.course_event.start, 'date')})
         if self.for_himself:
             return _('My Event Subscriptions')
         elif self.model.attendee_id:

--- a/src/onegov/fsi/locale/de_CH/LC_MESSAGES/onegov.fsi.po
+++ b/src/onegov/fsi/locale/de_CH/LC_MESSAGES/onegov.fsi.po
@@ -528,7 +528,7 @@ msgid "Course Status"
 msgstr "Kursstatus"
 
 msgid "Course attended"
-msgstr "Am Kurs teilgenommen"
+msgstr "Teilgenommen"
 
 msgid "Last info mail"
 msgstr "Letztes Info-Mail"

--- a/src/onegov/fsi/locale/de_CH/LC_MESSAGES/onegov.fsi.po
+++ b/src/onegov/fsi/locale/de_CH/LC_MESSAGES/onegov.fsi.po
@@ -1,8 +1,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE 1.0\n"
-"POT-Creation-Date: 2019-12-09 14:56+0100\n"
-"PO-Revision-Date: 2019-12-09 14:53+0100\n"
+"POT-Creation-Date: 2019-12-10 13:57+0100\n"
+"PO-Revision-Date: 2019-12-10 13:57+0100\n"
 "Last-Translator: Denis Krienbühl <denis.krienbuehl@seantis.ch>\n"
 "Language-Team: German\n"
 "Language: de_CH\n"
@@ -14,8 +14,8 @@ msgstr ""
 "X-Generator: Poedit 2.2.4\n"
 
 #, python-format
-msgid "Reminder for course: ${name}"
-msgstr "Erinnerung für Kurs: ${name}"
+msgid "Reminder for course event: ${name}"
+msgstr "Erinnerung für Kursveranstaltung: ${name}"
 
 msgid "Profile"
 msgstr "Profile"
@@ -300,8 +300,8 @@ msgid "Add Placeholder"
 msgstr "Platzhalter hinzufügen"
 
 #, python-format
-msgid "Attendees Event ${event}"
-msgstr "Teilnehmer Durchführung ${event}"
+msgid "Attendees Event ${event} - ${date}"
+msgstr "Teilnehmer ${event} - ${date}"
 
 msgid "My Event Subscriptions"
 msgstr "Meine Kursanmeldungen"
@@ -440,7 +440,7 @@ msgid "Remaining seats"
 msgstr "Verbleibende Plätze"
 
 msgid "Description:"
-msgstr "Beschreibung"
+msgstr "Beschreibung:"
 
 msgid "Yes"
 msgstr "Ja"
@@ -494,9 +494,6 @@ msgstr "Untenstehend finden Sie eine Liste der zukünftigen Durchführungen."
 msgid "Event Details"
 msgstr "Details Durchführung"
 
-msgid "Your course management team."
-msgstr "Ihr Kursverwaltungteam"
-
 msgid ""
 "Clicking \"Send\" will send the e-mail below to all selected recipients. You "
 "will receive a copy of the e-mail if you are not already on the recipients "
@@ -507,7 +504,7 @@ msgstr ""
 "erhalten, falls sie noch nicht in der Empfängerliste sind."
 
 msgid "There are subscriptions for this course event."
-msgstr "Für diese Durchführung existieren Anmeldungen"
+msgstr "Für diese Durchführung existieren Anmeldungen."
 
 msgid "Mail Subject"
 msgstr "Email Betreff"
@@ -520,6 +517,9 @@ msgstr "Zuletzt Geändert"
 
 msgid "You can only see subscriptions from attendees fitting your permissions."
 msgstr "Sie können nur Anmeldung sehen, zu denen Sie berechtigt sind."
+
+msgid "Shortcode"
+msgstr "Kürzel"
 
 msgid "Course Name"
 msgstr "Kursname"
@@ -567,15 +567,11 @@ msgstr "Kurs erfolgreich gelöscht"
 
 msgid "This course has events and can not be deleted"
 msgstr ""
-"Dieser Kurs besitzt bereits Durchführungen und kann nicht gelöscht werden."
+"Dieser Kurs besitzt bereits Durchführungen und kann nicht gelöscht werden"
 
 msgid "This event has registrations and can not be deleted"
 msgstr ""
 "Diese Durchführung hat bereits Anmeldungen und kann nicht gelöscht werden"
-
-#, python-format
-msgid "Event cancelled and ${count} emails sent."
-msgstr "Veranstaltung abgesagt und ${count} Email versendet."
 
 msgid "Send E-Mail Now"
 msgstr "Email jetzt senden"
@@ -609,6 +605,18 @@ msgstr "Neue Anmeldungen erfasst"
 
 msgid "Subscription successfully deleted"
 msgstr "Anmeldung erfolgreich gelöscht"
+
+#~ msgid "Attendees Event ${event}"
+#~ msgstr "Teilnehmer Durchführung ${event}"
+
+#~ msgid "Reminder for course: ${name}"
+#~ msgstr "Erinnerung für Kurs: ${name}"
+
+#~ msgid "Your course management team."
+#~ msgstr "Ihr Kursverwaltungteam"
+
+#~ msgid "Event cancelled and ${count} emails sent."
+#~ msgstr "Veranstaltung abgesagt und ${count} Email versendet."
 
 #~ msgid "Dear"
 #~ msgstr "Sehr geehrte(r)"

--- a/src/onegov/fsi/locale/de_CH/LC_MESSAGES/onegov.fsi.po
+++ b/src/onegov/fsi/locale/de_CH/LC_MESSAGES/onegov.fsi.po
@@ -519,7 +519,7 @@ msgid "Last Modified"
 msgstr "Zuletzt Geändert"
 
 msgid "You can only see subscriptions from attendees fitting your permissions."
-msgstr "Sie können nur Anmeldung sehen, zu dene Sie berechtigt sind."
+msgstr "Sie können nur Anmeldung sehen, zu denen Sie berechtigt sind."
 
 msgid "Course Name"
 msgstr "Kursname"

--- a/src/onegov/fsi/models/course_event.py
+++ b/src/onegov/fsi/models/course_event.py
@@ -22,10 +22,17 @@ COURSE_EVENT_STATUSES_TRANSLATIONS = (
 
 
 # for forms...
-def course_status_choices():
+def course_status_choices(request=None):
+
+    if request:
+        translations = (
+            request.translate(v) for v in COURSE_EVENT_STATUSES_TRANSLATIONS)
+    else:
+        translations = COURSE_EVENT_STATUSES_TRANSLATIONS
+
     return tuple(
         (val, key) for val, key in zip(COURSE_EVENT_STATUSES,
-                                       COURSE_EVENT_STATUSES_TRANSLATIONS))
+                                       translations))
 
 
 class CourseEvent(Base, TimestampMixin):

--- a/src/onegov/fsi/templates/course_event.pt
+++ b/src/onegov/fsi/templates/course_event.pt
@@ -12,7 +12,7 @@
                             <h3 i18n:translate="">Details</h3>
                             <tal:b metal:use-macro="layout.macros['course_event_details']" />
 
-                            <tal:b tal:condition="request.is_logged_in" tal:define="registered model.has_reservation(request.attendee_id)">
+                            <tal:b tal:define="registered model.has_reservation(request.attendee_id)">
                                 <tal:b tal:switch="registered">
                                     <button tal:case="True" class="button success disabled"><i class="fa fa-check" aria-hidden="true"></i> <tal:b i18n:translate>Registered</tal:b></button>
                                     <metal:b tal:case="False" tal:condition="model.bookable" use-macro="layout.macros['intercooler_btn']"/>
@@ -20,18 +20,18 @@
 
                                 <p><strong tal:condition="not: model.bookable" i18n:translate="">This course event can't be booked anymore.</strong></p>
                             </tal:b>
-                            <h3 i18n:translate="">Attendees</h3>
 
-                            <tal:b tal:switch="model.reservations.count() == 0">
-                                <p tal:case="True" i18n:translate>No entries found.</p>
-                                <ul tal:case="False">
-                                <tal:b tal:repeat="reservation model.reservations">
-                                    <li tal:attributes="class python: 'grayed-out' if reservation.is_placeholder else ''">${str(reservation)}</li>
-                                </tal:b>
-                            </ul>
-
+                            <tal:b tal:condition="request.is_admin">
+                                <h3 i18n:translate="">Attendees</h3>
+                                    <tal:b tal:switch="model.reservations.count() == 0">
+                                        <p tal:case="True" i18n:translate>No entries found.</p>
+                                        <ul tal:case="False">
+                                            <tal:b tal:repeat="reservation model.reservations">
+                                                <li tal:attributes="class python: 'grayed-out' if reservation.is_placeholder else ''">${str(reservation)}</li>
+                                            </tal:b>
+                                        </ul>
+                                    </tal:b>
                             </tal:b>
-
                         </tal:b>
                     </div>
                 </div>

--- a/src/onegov/fsi/templates/courses.pt
+++ b/src/onegov/fsi/templates/courses.pt
@@ -10,17 +10,7 @@
                         <tal:b tal:define="items layout.accordion_items" tal:switch="items != ()">
                             <span tal:case="False" i18n:translate="">No entries found.</span>
                             <tal:b tal:case="True">
-                                <dl class="accordion" data-accordion>
-                                    <tal:b tal:repeat="item items">
-                                        <dd class="accordion-navigation" tal:define="accordion_id 'accordion-panel-{}'.format(repeat.item.number)">
-                                            <a href="${'#'+ accordion_id}"><i class="fa fa-plus fa-fw" aria-hidden="true"></i> <strong>${item['title']}</strong></a>
-                                            <div id="${accordion_id}" class="content page-text">
-                                                <div tal:content="structure item['content']"/>
-                                                <span tal:condition="item['url']|nothing"><a href="${item['url']}" class="button hollow" i18n:translate>Details / Registration</a></span>
-                                            </div>
-                                        </dd>
-                                    </tal:b>
-                                </dl>
+                                <tal:b metal:use-macro="layout.macros['accordion']" />
                             </tal:b>
                         </tal:b>
                     </div>

--- a/src/onegov/fsi/templates/macros.pt
+++ b/src/onegov/fsi/templates/macros.pt
@@ -128,12 +128,12 @@
             <tal:b tal:condition="events">
                 <table class="tablesaw hover events-table">
                     <thead>
-                        <th i18n:translate="">Date</th>
-                        <th i18n:translate="">Start</th>
-                        <th i18n:translate="">End</th>
-                        <th i18n:translate="">Presenter</th>
-                        <th i18n:translate="" tal:condition="not for_email">Presenter Company</th>
-                        <th i18n:translate="">Free Space</th>
+                        <th i18n:translate class='text-left'>Date</th>
+                        <th i18n:translate class='text-left'>Start</th>
+                        <th i18n:translate class='text-left'>End</th>
+                        <th i18n:translate class='text-left'>Presenter</th>
+                        <th i18n:translate class='text-left' tal:condition="not for_email">Presenter Company</th>
+                        <th i18n:translate class='text-left'>Free Space</th>
                         <th tal:condition="not for_email and request.is_manager" i18n:translate>Hidden</th>
                     </thead>
                     <tbody>

--- a/src/onegov/fsi/templates/macros.pt
+++ b/src/onegov/fsi/templates/macros.pt
@@ -42,7 +42,7 @@
         </dl>
         <dl class="field-display">
             <dt i18n:translate="">Text: </dt>
-            <iframe src="${iframe_link|request.link(mail, name='embed')}" frameborder="0" width="100%" height="600px"></iframe>
+            <iframe class="resizeable" src="${iframe_link|request.link(mail, name='embed')}" frameborder="0" width="100%" height="600px" onload="autoResize()"></iframe>
             <div class="clearfix"></div>
         </dl>
     </tal:b>

--- a/src/onegov/fsi/templates/macros.pt
+++ b/src/onegov/fsi/templates/macros.pt
@@ -18,18 +18,24 @@
 <metal:accordion define-macro="accordion">
     <tal:b tal:condition="items|nothing">
         <dl class="accordion" data-accordion>
-            <tal:b tal:repeat="item items" define="accordion_id 'accordion-panel-{}'.format(repeat.item.number)">
-                <dd class="accordion-navigation">
-                    <a href="${accordion_id}">$item.title</a>
-                    <div id="${accordion_id}" class="content">
-                        <span tal:condition="item.url|nothing"><a href="${item.url}" class="tiny button hollow">Details</a></span>
-                        <span tal:condition="request.is_manager and item.edit_url|nothing"><a href="${item.edit_url}" class="tiny button hollow">Edit</a></span>
-                            ${item.content}
+            <tal:b tal:repeat="item items">
+                <dd class="accordion-navigation"
+                    tal:define="accordion_id 'accordion-panel-{}'.format(repeat.item.number)"
+                    tal:attributes="ic-get-from item['content_url']|nothing; ic-target '#' + accordion_id + 'content';"
+                    ic-trigger-on="click"
+                >
+                    <a href="${'#'+ accordion_id}"><i class="fa fa-plus fa-fw" aria-hidden="true"></i> <strong>${item['title']}</strong></a>
+                    <div id="${accordion_id}" class="content page-text">
+                        <tal:b tal:switch="python:True if item.get('content_url') else False">
+                            <div tal:case="False" tal:condition="item['content']" tal:content="structure item['content']"/>
+                            <div tal:case="True" id="${accordion_id + 'content'}"></div>
+                        </tal:b>
+
+                        <span tal:condition="item['url']|nothing"><a href="${item['url']}" class="button hollow" i18n:translate>Details / Registration</a></span>
                     </div>
                 </dd>
             </tal:b>
         </dl>
-
     </tal:b>
 </metal:accordion>
 
@@ -64,7 +70,13 @@
 
 <metal:confirmation_slider define-macro="confirmation_slider" tal:define="completed reservation.event_completed">
     <div tal:condition="not: reservation.is_placeholder" tal:attributes="class python: 'switch round tiny confirmation-switch' + (' print-checked' if completed else ' print-unchecked')">
-        <input id="${switch_id}" type="checkbox" tal:attributes="disabled python:not reservation.course_event.is_past or not request.is_admin; checked completed; ic-post-to url|nothing">
+        <input
+                id="${switch_id}"
+                type="checkbox"
+                tal:attributes="disabled python:not reservation.course_event.is_past or not request.is_admin; checked completed; ic-post-to url|nothing"
+                ic_target="${switch_id}"
+                ic-trigger-on="click"
+        >
         <label for="${switch_id}"></label>
     </div>
 </metal:confirmation_slider>

--- a/src/onegov/fsi/templates/macros.pt
+++ b/src/onegov/fsi/templates/macros.pt
@@ -62,9 +62,9 @@
     </tal:b>
 </metal:email_recipients>
 
-<metal:confirmation_slider define-macro="confirmation_slider">
-    <div tal:condition="not: reservation.is_placeholder" class="switch round tiny confirmation-switch">
-        <input id="${switch_id}" type="checkbox" tal:attributes="disabled python:not reservation.course_event.is_past or not request.is_admin; checked python:reservation.event_completed; ic-post-to url|nothing">
+<metal:confirmation_slider define-macro="confirmation_slider" tal:define="completed reservation.event_completed">
+    <div tal:condition="not: reservation.is_placeholder" tal:attributes="class python: 'switch round tiny confirmation-switch' + (' print-checked' if completed else ' print-unchecked')">
+        <input id="${switch_id}" type="checkbox" tal:attributes="disabled python:not reservation.course_event.is_past or not request.is_admin; checked completed; ic-post-to url|nothing">
         <label for="${switch_id}"></label>
     </div>
 </metal:confirmation_slider>

--- a/src/onegov/fsi/templates/mail_layout.pt
+++ b/src/onegov/fsi/templates/mail_layout.pt
@@ -97,11 +97,6 @@
         padding: 10px 0;
     }
 
-    .ticket-number {
-        font-family: Consolas, "Liberation Mono", Courier, monospace;
-        font-weight: bold;
-    }
-
     table {
         width: 100% !important;
     }
@@ -163,16 +158,6 @@
         font-weight: bold;
     }
 
-    .fieldset {
-        font-size: 14px;
-        font-weight: normal;
-        Margin-bottom: 10px;
-    }
-
-    .descreet {
-        color: #555;
-    }
-
     ul li, ol li {
         Margin-left: 5px;
         list-style-position: inside;
@@ -199,27 +184,6 @@
         Margin-top: 20px;
     }
 
-    .reservation {
-        border: 1px solid #eee;
-        color: #222;
-        Margin-bottom: 10px;
-        padding: 0;
-    }
-
-    .header {
-        background-color: #eee;
-        padding: 5px 10px;
-    }
-
-    .body {
-        padding: 0 10px;
-    }
-
-    .inline-message {
-        padding: 10px 10px 5px;
-        background-color: #f5f5f5;
-        border-left: 4px solid #ddd;
-    }
 
     .inline-message + br {
         content: "";
@@ -227,25 +191,6 @@
         display: block;
     }
 
-    .message-owner, .message-owner a {
-        font-size: .8rem;
-        color: #666;
-    }
-
-    .message-owner {
-        display: block;
-        position: relative;
-        top: -5px;
-    }
-
-    .previous-message {
-        border-left: 4px solid #ddd;
-    }
-
-    .current-message {
-        Margin-bottom: 10px;
-        border-left: 4px solid <tal:b replace="primary_color" />;
-    }
 
     .inline-message p:last-child {
         Margin-bottom: 5px;
@@ -275,6 +220,11 @@
     .content table {
         width: 100%;
     }
+
+    .text-left {
+        text-align: left;
+    }
+
     </style>
 </head>
 <body bgcolor="#f6f6f6">

--- a/src/onegov/fsi/templates/mail_macros.pt
+++ b/src/onegov/fsi/templates/mail_macros.pt
@@ -50,7 +50,7 @@
         </tal:b>
         <tal:b tal:case="'invitation'">
             <p i18n:translate="">We would like to invite you to subscribe for one of the events for the course ${layout.model.name}.</p>
-            <p i18n:translate="">You can find the list of future events below.</p><br>
+            <p i18n:translate="">You can find the list of future events below.</p>
             <tal:b metal:use-macro="layout.default_macros['course_details']" tal:define="model layout.model"/>
             <h3 i18n:translate="">Events</h3>
             <tal:b metal:use-macro="layout.default_macros['course_event_listing']" tal:define="events layout.model.future_events; for_email True"/>
@@ -68,7 +68,6 @@
         </tal:b>
     </tal:b>
     <br>
-    <p i18n:translate="">Your course management team.</p>
 </metal:email_footer>
 
 

--- a/src/onegov/fsi/templates/reservations.pt
+++ b/src/onegov/fsi/templates/reservations.pt
@@ -6,7 +6,7 @@
         <div class="row">
             <div class="columns small-12">
                 <div class="row">
-                    <div class="columns small-12">
+                    <div class="columns small-12" tal:define="has_course layout.model.course_event_id">
 
                         <p tal:condition="not: reservations"><strong i18n:translate="">No entries found</strong></p>
                         <p tal:condition="request.is_editor" i18n:translate="">You can only see subscriptions from attendees fitting your permissions.</p>
@@ -14,20 +14,26 @@
                         <tal:b tal:condition="reservations|nothing">
                                 <table class="subscription-table fullwidth">
                                     <thead>
-                                        <th i18n:translate="">Attendee</th>
-                                        <th i18n:translate="" tal:condition="not: layout.model.course_event_id">Course Name</th>
-                                        <th i18n:translate="">Date</th>
-                                        <th i18n:translate="">Course Status</th>
-                                        <th i18n:translate="">Course attended</th>
-                                        <th i18n:translate="">Last info mail</th>
+                                        <th i18n:translate>Attendee</th>
+                                        <th i18n:translate>Shortcode</th>
+                                        <th i18n:translate tal:condition="not: has_course">Course Name</th>
+                                        <th i18n:translate tal:condition="not: has_course">Date</th>
+                                        <th i18n:translate>Course Status</th>
+                                        <th i18n:translate>Course attended</th>
+                                        <th i18n:translate>Last info mail</th>
                                         <th tal:condition="request.is_admin" i18n:translate="" class="no-print">Manage</th>
                                     </thead>
                                     <tbody>
                                         <tal:b tal:repeat="reservation reservations">
                                             <tr>
                                                 <td><a href="${layout.link(reservation)}">${str(reservation)}</a></td>
-                                                <td tal:condition="not: layout.model.course_event_id"><a href="${request.link(reservation.course_event)}">${reservation.course_event.name}</a></td>
-                                                <td>${layout.format_date(reservation.course_event.start, 'date')}</td>
+                                                <td>
+                                                    <tal:b tal:condition="reservation.attendee and reservation.attendee.user">
+                                                        ${reservation.attendee.user.source_id}
+                                                    </tal:b>
+                                                </td>
+                                                <td tal:condition="not: has_course"><a href="${request.link(reservation.course_event)}">${reservation.course_event.name}</a></td>
+                                                <td tal:condition="not: has_course">${layout.format_date(reservation.course_event.start, 'date')}</td>
                                                 <td>${layout.format_status(reservation.course_event.status)}</td>
 
                                                 <td>

--- a/src/onegov/fsi/theme/styles/fsi.scss
+++ b/src/onegov/fsi/theme/styles/fsi.scss
@@ -97,6 +97,10 @@ dd.accordion-navigation + dd.accordion-navigation {
 */
 @media print {
 
+    .print-checked::before { @include icon('\f046'); }
+
+    .print-unchecked::before { @include icon('\f096'); }
+
     .breadcrumbs {
         display: none;
     }

--- a/src/onegov/fsi/views/course.py
+++ b/src/onegov/fsi/views/course.py
@@ -148,6 +148,15 @@ def view_course_event(self, request):
     }
 
 
+@FsiApp.json(
+    model=Course,
+    permission=Personal,
+    name='content-json'
+)
+def view_course_event(self, request):
+    return self.description_html
+
+
 @FsiApp.form(
     model=Course,
     template='form.pt',

--- a/src/onegov/fsi/views/reservation.py
+++ b/src/onegov/fsi/views/reservation.py
@@ -139,7 +139,7 @@ def view_delete_reservation(self, request):
     request.success(_('Subscription successfully deleted'))
 
 
-@FsiApp.html(
+@FsiApp.json(
     model=CourseReservation,
     request_method='POST',
     permission=Secret,
@@ -148,3 +148,4 @@ def view_delete_reservation(self, request):
 def view_toggle_confirm_reservation(self, request):
     request.assert_valid_csrf_token()
     self.event_completed = not self.event_completed
+    return self.event_completed

--- a/tests/onegov/fsi/test_views_course.py
+++ b/tests/onegov/fsi/test_views_course.py
@@ -87,14 +87,7 @@ def test_delete_course_1(client_with_db):
 
     page = client.get(view)
     assert "Dieser Kurs besitzt bereits Durchführungen " \
-           "und kann nicht gelöscht werden." in page
-    # for event in course.events:
-    #     session.delete(event)
-    # session.flush()
-    #
-    # page = client.get(view)
-    # assert "Keine Einträge gefunden" in page
-    # assert not session.query(Course).filter_by(id=course_id).first()
+           "und kann nicht gelöscht werden" in page
 
 
 def test_course_invite(client_with_db):


### PR DESCRIPTION
- auto-resizing of iframe
- Hiding cols in reservation table
- lazy-loading switch for accordions /fsi/courses (not yet working as it should)
- use fa icons when printing "course attended" column

Todo: replace the slider element/checked attribute of input DOM element in /fsi/reservations with the actual response from the view Reservation - toggle-confirm.

To check lazy loading of accordion: uncomment `src/onegov/fsi/layouts/course.py:75`
Is the encoding wrong, or the json response has to be in a different format? Any hint would be appreciated