### PR TITLE
Fsi locked events

### DIFF
--- a/src/onegov/fsi/collections/reservation.py
+++ b/src/onegov/fsi/collections/reservation.py
@@ -66,7 +66,7 @@ class ReservationCollection(GenericCollection, Pagination):
                 or_(CourseAttendee.organisation.in_(
                     self.auth_attendee.permissions, ),
                     CourseReservation.attendee_id == self.auth_attendee.id)
-                )
+            )
         if self.attendee_id:
             # Always set in path for members to their own
             query = query.filter(

--- a/src/onegov/fsi/collections/reservation.py
+++ b/src/onegov/fsi/collections/reservation.py
@@ -54,6 +54,10 @@ class ReservationCollection(GenericCollection, Pagination):
             auth_attendee=self.auth_attendee
         )
 
+    @property
+    def for_himself(self):
+        return str(self.auth_attendee.id) == str(self.attendee_id)
+
     def query(self):
         query = super().query()
         if self.auth_attendee and self.auth_attendee.role == 'editor':
@@ -62,7 +66,7 @@ class ReservationCollection(GenericCollection, Pagination):
                 or_(CourseAttendee.organisation.in_(
                     self.auth_attendee.permissions, ),
                     CourseReservation.attendee_id == self.auth_attendee.id)
-            )
+                )
         if self.attendee_id:
             # Always set in path for members to their own
             query = query.filter(

--- a/src/onegov/fsi/custom.py
+++ b/src/onegov/fsi/custom.py
@@ -53,8 +53,7 @@ def get_base_tools(request):
                 Link(
                     _('Attendees'),
                     request.link(CourseAttendeeCollection(
-                        request.session,
-                        auth_attendee=request.current_attendee)),
+                        request.session, auth_attendee=usr)),
                     attrs={'class': 'attendees'}
                 )
             )
@@ -62,8 +61,7 @@ def get_base_tools(request):
                 Link(
                     _('Event Subscriptions'),
                     request.link(ReservationCollection(
-                        request.session,
-                        auth_attendee=request.current_attendee)),
+                        request.session, auth_attendee=usr)),
                     attrs={'class': 'reservations'}
                 )
             )
@@ -113,7 +111,7 @@ def get_base_tools(request):
                 ReservationCollection(
                     request.session,
                     attendee_id=request.attendee_id,
-                    auth_attendee=request.current_attendee
+                    auth_attendee=usr
                 ),
             ),
             attrs={
@@ -155,11 +153,6 @@ def get_top_navigation(request):
         text=_("Courses"),
         url=request.class_link(CourseCollection)
     )
-
-    # yield Link(
-    #     text=_("Upcoming Course Events"),
-    #     url=request.link(CourseEventCollection.latest(request.app.session()))
-    # )
 
     layout = DefaultLayout(request.app.org, request)
     yield from layout.top_navigation

--- a/src/onegov/fsi/forms/course_event.py
+++ b/src/onegov/fsi/forms/course_event.py
@@ -45,6 +45,11 @@ class CourseEventForm(Form):
         default=False,
     )
 
+    locked_for_subscriptions = BooleanField(
+        label=_("Locked for Subscriptions"),
+        default=False,
+    )
+
     # Course Event info
     start = TimezoneDateTimeField(
         label=_('Course Start'),
@@ -106,6 +111,7 @@ class CourseEventForm(Form):
         self.presenter_company.data = model.presenter_company
         self.presenter_email.data = model.presenter_email
         self.hidden_from_public.data = model.hidden_from_public
+        self.locked_for_subscriptions = model.locked_for_subscriptions
 
         self.start.data = model.start
         self.end.data = model.end
@@ -119,6 +125,7 @@ class CourseEventForm(Form):
         model.presenter_company = self.presenter_company.data
         model.presenter_email = self.presenter_email.data
         model.hidden_from_public = self.hidden_from_public.data
+        model.locked_for_subscriptions = self.locked_for_subscriptions.data
 
         model.start = self.start.data
         model.end = self.end.data

--- a/src/onegov/fsi/layout.py
+++ b/src/onegov/fsi/layout.py
@@ -4,6 +4,7 @@ from onegov.fsi.models.course_event import (
 from onegov.fsi.models.course_notification_template import \
     NOTIFICATION_TYPE_TRANSLATIONS, NOTIFICATION_TYPES
 from onegov.org.layout import DefaultLayout as BaseLayout
+from onegov.fsi import _
 
 
 class FormatMixin:
@@ -19,6 +20,10 @@ class FormatMixin:
         return NOTIFICATION_TYPE_TRANSLATIONS[
             NOTIFICATION_TYPES.index(notification_type)
         ]
+
+    def format_boolean(self, val):
+        assert isinstance(val, bool)
+        return self.request.translate((_('Yes') if val else _('No')))
 
 
 class DefaultLayout(BaseLayout, FormatMixin):

--- a/src/onegov/fsi/layouts/course_attendee.py
+++ b/src/onegov/fsi/layouts/course_attendee.py
@@ -39,18 +39,36 @@ class CourseAttendeeCollectionLayout(DefaultLayout):
         return links
 
     @cached_property
+    def collection(self):
+        return CourseAttendeeCollection(
+            self.request.session, auth_attendee=self.request.current_attendee
+        )
+
+    @cached_property
+    def collection_externals(self):
+        return CourseAttendeeCollection(
+            self.request.session, auth_attendee=self.request.current_attendee,
+            external_only=True
+        )
+
+    @cached_property
+    def collection_editors(self):
+        return CourseAttendeeCollection(
+            self.request.session, auth_attendee=self.request.current_attendee,
+            editors_only=True
+        )
+
+    @cached_property
     def menu(self):
         if not self.request.is_admin:
             # Hide menu for editor since filtered by permissions
             return []
         return [
-            (_('All'), self.request.class_link(CourseAttendeeCollection),
+            (_('All'), self.request.link(self.collection),
              self.model.unfiltered),
-            (_('External'), self.request.link(CourseAttendeeCollection(
-                self.request.session, external_only=True)),
+            (_('External'), self.request.link(self.collection_externals),
              self.model.external_only),
-            (_('Editors'), self.request.link(CourseAttendeeCollection(
-                self.request.session, editors_only=True)),
+            (_('Editors'), self.request.link(self.collection_editors),
              self.model.editors_only)
         ]
 
@@ -64,13 +82,18 @@ class CourseAttendeeLayout(DefaultLayout):
         return _('Profile Details')
 
     @cached_property
+    def collection(self):
+        return CourseAttendeeCollection(
+            self.request.session, auth_attendee=self.request.current_attendee)
+
+    @cached_property
     def breadcrumbs(self):
         links = super().breadcrumbs
         if self.request.is_manager:
             links.append(
                 Link(
                     _('Manage Course Attendees'),
-                    self.request.class_link(CourseAttendeeCollection)
+                    self.request.link(self.collection)
                 )
             )
         links.append(
@@ -89,7 +112,8 @@ class CourseAttendeeLayout(DefaultLayout):
                 Link(
                     _('Add Subscription'),
                     self.request.link(ReservationCollection(
-                        self.request.session, attendee_id=self.model.id),
+                        self.request.session, attendee_id=self.model.id,
+                        auth_attendee=self.request.current_attendee),
                         name='add'),
                     attrs={'class': 'add-icon'}
                 )
@@ -98,15 +122,14 @@ class CourseAttendeeLayout(DefaultLayout):
             links.append(
                 Link(
                     _('Edit Profile'),
-                    url=self.request.link(self.model, name='edit'),
+                    self.request.link(self.model, name='edit'),
                     attrs={'class': 'edit-link'}
                 )
             )
             links.append(
                 Link(
                     _('Add External Attendee'),
-                    url=self.request.class_link(
-                        CourseAttendeeCollection, name='add-external'),
+                    self.request.link(self.collection, name='add-external'),
                     attrs={'class': 'add-external'}
                 )
             )

--- a/src/onegov/fsi/layouts/course_event.py
+++ b/src/onegov/fsi/layouts/course_event.py
@@ -6,7 +6,7 @@ from onegov.fsi.collections.course_event import CourseEventCollection
 from onegov.fsi.collections.notification_template import \
     CourseNotificationTemplateCollection
 from onegov.fsi.collections.reservation import ReservationCollection
-from onegov.fsi.layout import DefaultLayout
+from onegov.fsi.layout import DefaultLayout, FormatMixin
 from onegov.fsi import _
 
 
@@ -62,7 +62,7 @@ class CourseEventCollectionLayout(DefaultLayout):
         return links
 
 
-class CourseEventLayout(DefaultLayout):
+class CourseEventLayout(DefaultLayout, FormatMixin):
 
     @cached_property
     def title(self):

--- a/src/onegov/fsi/layouts/course_event.py
+++ b/src/onegov/fsi/layouts/course_event.py
@@ -139,6 +139,9 @@ class CourseEventLayout(DefaultLayout, FormatMixin):
         if self.request.is_member:
             return []
 
+        if self.request.is_editor and self.model.locked:
+            return []
+
         attendee_link = Link(
             _('Attendees'),
             self.request.link(self.reservation_collection),

--- a/src/onegov/fsi/layouts/course_event.py
+++ b/src/onegov/fsi/layouts/course_event.py
@@ -87,7 +87,8 @@ class CourseEventLayout(DefaultLayout):
     def reservation_collection(self):
         return ReservationCollection(
             self.request.session,
-            course_event_id=self.model.id
+            course_event_id=self.model.id,
+            auth_attendee=self.request.current_attendee
         )
 
     @cached_property
@@ -155,6 +156,7 @@ class CourseEventLayout(DefaultLayout):
                 self.request.link(
                     ReservationCollection(
                         self.request.session,
+                        auth_attendee=self.request.current_attendee,
                         course_event_id=self.model.id,
                         external_only=True),
                     name='add'
@@ -247,6 +249,7 @@ class CourseEventLayout(DefaultLayout):
                 self.request.link(
                     ReservationCollection(
                         self.request.session,
+                        auth_attendee=self.request.current_attendee,
                         course_event_id=self.model.id,
                         attendee_id=self.request.attendee_id
                     ),

--- a/src/onegov/fsi/layouts/reservation.py
+++ b/src/onegov/fsi/layouts/reservation.py
@@ -141,6 +141,7 @@ class ReservationLayout(DefaultLayout):
     def collection(self):
         return ReservationCollection(
             self.request.session,
+            auth_attendee=self.request.current_attendee,
             attendee_id=None,
             course_event_id=self.model.course_event_id
         )

--- a/src/onegov/fsi/layouts/reservation.py
+++ b/src/onegov/fsi/layouts/reservation.py
@@ -22,6 +22,11 @@ class ReservationCollectionLayout(DefaultLayout):
             self.request.link(reservation, name='toggle-confirm'))
 
     @cached_property
+    def course_event(self):
+        event_id = self.model.course_event_id
+        return self.model.by_id(event_id) if event_id else None
+
+    @cached_property
     def title(self):
         if self.request.view_name == 'add':
             return _('Add Attendee')

--- a/src/onegov/fsi/locale/de_CH/LC_MESSAGES/onegov.fsi.po
+++ b/src/onegov/fsi/locale/de_CH/LC_MESSAGES/onegov.fsi.po
@@ -1,8 +1,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE 1.0\n"
-"POT-Creation-Date: 2020-01-15 11:05+0100\n"
-"PO-Revision-Date: 2020-01-15 11:05+0100\n"
+"POT-Creation-Date: 2020-01-16 08:19+0100\n"
+"PO-Revision-Date: 2020-01-16 08:19+0100\n"
 "Last-Translator: Denis Krienbühl <denis.krienbuehl@seantis.ch>\n"
 "Language-Team: German\n"
 "Language: de_CH\n"
@@ -106,6 +106,9 @@ msgstr "Referent Email"
 
 msgid "Hidden"
 msgstr "Versteckt"
+
+msgid "Locked for Subscriptions"
+msgstr "Für Anmeldungen gesperrt"
 
 msgid "Course Start"
 msgstr "Kurs-Start"
@@ -412,8 +415,8 @@ msgstr "Details"
 msgid "Registered"
 msgstr "Angemeldet"
 
-msgid "This course event can't be booked anymore."
-msgstr "Dieser Kurs kann nicht mehr gebucht werden."
+msgid "This course event can't be booked (anymore)."
+msgstr "Diese Durchführung kann (nicht) mehr gebucht werden."
 
 msgid "No entries found."
 msgstr "Keine Einträge gefunden."
@@ -459,6 +462,9 @@ msgstr "Verbleibende Plätze"
 
 msgid "Description:"
 msgstr "Beschreibung:"
+
+msgid "Locked"
+msgstr "Gesperrt"
 
 msgid "Yes"
 msgstr "Ja"
@@ -635,6 +641,9 @@ msgstr "Neue Anmeldungen erfasst"
 
 msgid "Subscription successfully deleted"
 msgstr "Anmeldung erfolgreich gelöscht"
+
+#~ msgid "This course event can't be booked anymore."
+#~ msgstr "Dieser Kurs kann nicht mehr gebucht werden."
 
 #~ msgid "Time"
 #~ msgstr "Uhrzeit"

--- a/src/onegov/fsi/models/course_event.py
+++ b/src/onegov/fsi/models/course_event.py
@@ -140,6 +140,9 @@ class CourseEvent(Base, TimestampMixin, ORMSearchable):
     # hides from member roles
     hidden_from_public = Column(Boolean, nullable=False, default=False)
 
+    # to a locked event, only admin can place subscriptions
+    locked_for_subscriptions = Column(Boolean, default=False)
+
     # when before course start schedule reminder email
     schedule_reminder_before = Column(
         Interval,
@@ -194,6 +197,11 @@ class CourseEvent(Base, TimestampMixin, ORMSearchable):
     @property
     def is_past(self):
         return self.start < utcnow()
+
+    @property
+    def locked(self):
+        # Basically locked for non-admins
+        return self.locked_for_subscriptions or not self.bookable
 
     @property
     def duplicate_dict(self):

--- a/src/onegov/fsi/templates/course_event.pt
+++ b/src/onegov/fsi/templates/course_event.pt
@@ -15,10 +15,10 @@
                             <tal:b tal:define="registered model.has_reservation(request.attendee_id)">
                                 <tal:b tal:switch="registered">
                                     <button tal:case="True" class="button success disabled"><i class="fa fa-check" aria-hidden="true"></i> <tal:b i18n:translate>Registered</tal:b></button>
-                                    <metal:b tal:case="False" tal:condition="model.bookable" use-macro="layout.macros['intercooler_btn']"/>
+                                    <metal:b tal:case="False" tal:condition="not: model.locked" use-macro="layout.macros['intercooler_btn']"/>
                                 </tal:b>
 
-                                <p><strong tal:condition="not: model.bookable" i18n:translate="">This course event can't be booked anymore.</strong></p>
+                                <p><strong tal:condition="model.locked and not request.is_admin" i18n:translate="">This course event can't be booked (anymore).</strong></p>
                             </tal:b>
 
                             <tal:b tal:condition="request.is_manager">

--- a/src/onegov/fsi/templates/course_event.pt
+++ b/src/onegov/fsi/templates/course_event.pt
@@ -23,10 +23,10 @@
 
                             <tal:b tal:condition="request.is_admin">
                                 <h3 i18n:translate="">Attendees</h3>
-                                    <tal:b tal:switch="model.reservations.count() == 0">
-                                        <p tal:case="True" i18n:translate>No entries found.</p>
-                                        <ul tal:case="False">
-                                            <tal:b tal:repeat="reservation model.reservations">
+                                    <tal:b tal:switch="layout.reservation_collection.query().first() and True or False">
+                                        <p tal:case="False" i18n:translate>No entries found.</p>
+                                        <ul tal:case="True">
+                                            <tal:b tal:repeat="reservation layout.reservation_collection.query()">
                                                 <li tal:attributes="class python: 'grayed-out' if reservation.is_placeholder else ''">${str(reservation)}</li>
                                             </tal:b>
                                         </ul>

--- a/src/onegov/fsi/templates/course_event.pt
+++ b/src/onegov/fsi/templates/course_event.pt
@@ -21,7 +21,7 @@
                                 <p><strong tal:condition="not: model.bookable" i18n:translate="">This course event can't be booked anymore.</strong></p>
                             </tal:b>
 
-                            <tal:b tal:condition="request.is_admin">
+                            <tal:b tal:condition="request.is_manager">
                                 <h3 i18n:translate="">Attendees</h3>
                                     <tal:b tal:switch="layout.reservation_collection.query().first() and True or False">
                                         <p tal:case="False" i18n:translate>No entries found.</p>

--- a/src/onegov/fsi/templates/macros.pt
+++ b/src/onegov/fsi/templates/macros.pt
@@ -125,7 +125,12 @@
         <dt i18n:translate="">Status</dt>
         <dd>${layout.format_status(model.status)}</dd>
         <div class="clearfix"></div>
-    </dl>
+      </dl>
+      <dl class="field-display" tal:condition="not: for_email|False and request.is_manager">
+        <dt i18n:translate="">Locked for Subscriptions</dt>
+        <dd>${layout.format_boolean(model.locked_for_subscriptions)}</dd>
+        <div class="clearfix"></div>
+      </dl>
 </metal:course_event>
 
 <metal:course define-macro="course_details">

--- a/src/onegov/fsi/templates/macros.pt
+++ b/src/onegov/fsi/templates/macros.pt
@@ -149,12 +149,13 @@
                         <th i18n:translate class='text-left' tal:condition="not for_email">Presenter Company</th>
                         <th i18n:translate class='text-left'>Free Space</th>
                         <th tal:condition="not for_email and request.is_manager" i18n:translate>Hidden</th>
+                        <th tal:condition="not for_email and request.is_manager" i18n:translate>Locked</th>
                     </thead>
                     <tbody>
                         <tal:b tal:repeat="event events">
                             <tr>
                                 <td>
-                                    <a href="${request.link(event)}">
+                                    <a href="${request.link(event)}" class="${'grayed-out' if event.locked else ''}">
                                         <strong>${layout.format_date(event.start, 'date_long')}</strong>
                                     </a>
                                 </td>
@@ -166,6 +167,10 @@
                                 <td tal:condition="not for_email">${event.presenter_company}</td>
                                 <td class='text-right'>${event.available_seats}</td>
                                 <tal:b tal:condition="request.is_manager and not for_email" tal:switch="event.hidden_from_public">
+                                    <td tal:case="True" i18n:translate>Yes</td>
+                                    <td tal:case="False" i18n:translate>No</td>
+                                </tal:b>
+                                <tal:b tal:condition="not for_email and request.is_manager" tal:switch="event.locked_for_subscriptions">
                                     <td tal:case="True" i18n:translate>Yes</td>
                                     <td tal:case="False" i18n:translate>No</td>
                                 </tal:b>

--- a/src/onegov/fsi/theme/styles/fsi.scss
+++ b/src/onegov/fsi/theme/styles/fsi.scss
@@ -66,6 +66,17 @@ dd.accordion-navigation + dd.accordion-navigation {
 }
 
 /*
+    Links
+*/
+
+a.grayed-out {
+    color: darkgray;
+    &:hover {
+        color: gray;
+    }
+}
+
+/*
     Navigation
 */
 

--- a/src/onegov/fsi/upgrade.py
+++ b/src/onegov/fsi/upgrade.py
@@ -2,7 +2,7 @@
 upgraded on the server. See :class:`onegov.core.upgrade.upgrade_task`.
 
 """
-from sqlalchemy import Column, ARRAY, Text
+from sqlalchemy import Column, ARRAY, Text, Boolean
 
 from onegov.core.orm.types import UTCDateTime
 from onegov.core.upgrade import upgrade_task
@@ -84,3 +84,13 @@ def remove_course_event_uc(context):
     if context.has_table('fsi_course_events'):
         context.operations.drop_constraint(
             '_start_end_uc', 'fsi_course_events')
+
+
+@upgrade_task('Adds locked_for_subscriptions property')
+def add_event_property_locked(context):
+    if not context.has_column('fsi_course_events', 'locked_for_subscriptions'):
+        context.add_column_with_defaults(
+            'fsi_course_events',
+            Column('locked_for_subscriptions', Boolean,
+                   nullable=False, default=True),
+            default=lambda x: True)

--- a/src/onegov/fsi/upgrade.py
+++ b/src/onegov/fsi/upgrade.py
@@ -93,4 +93,4 @@ def add_event_property_locked(context):
             'fsi_course_events',
             Column('locked_for_subscriptions', Boolean,
                    nullable=False, default=True),
-            default=lambda x: True)
+            default=lambda x: False)

--- a/src/onegov/fsi/views/reservation.py
+++ b/src/onegov/fsi/views/reservation.py
@@ -83,6 +83,7 @@ def view_edit_reservation(self, request, form):
             request.success(_("Subscription was updated"))
             return request.redirect(request.link(ReservationCollection(
                 request.session,
+                auth_attendee=request.current_attendee,
                 course_event_id=self.course_event_id,
                 attendee_id=self.attendee_id
             )))
@@ -119,6 +120,7 @@ def view_edit_placeholder_reservation(self, request, form):
         return request.redirect(request.link(ReservationCollection(
             request.session,
             course_event_id=self.course_event_id,
+            auth_attendee=request.current_attendee
         )))
 
     if not form.errors:
@@ -189,7 +191,8 @@ def view_add_from_course_event(self, request):
 )
 def view_delete_reservation(self, request):
     request.assert_valid_csrf_token()
-    ReservationCollection(request.session).delete(self)
+    ReservationCollection(
+        request.session, auth_attendee=request.current_attendee).delete(self)
     request.success(_('Subscription successfully deleted'))
 
 

--- a/src/onegov/fsi/views/reservation.py
+++ b/src/onegov/fsi/views/reservation.py
@@ -6,7 +6,7 @@ from onegov.fsi.forms.reservation import AddFsiReservationForm, \
     AddFsiPlaceholderReservationForm
 from onegov.fsi.layouts.reservation import ReservationLayout, \
     ReservationCollectionLayout
-from onegov.fsi.models import CourseReservation
+from onegov.fsi.models import CourseReservation, CourseEvent
 from onegov.fsi import _
 from onegov.fsi.views.notifcations import handle_send_email
 
@@ -36,16 +36,23 @@ def view_add_reservation(self, request, form):
 
     if form.submitted(request):
         data = form.get_useful_data()
-        course_id = data['course_event_id']
+        event_id = data['course_event_id']
         attendee_id = data['attendee_id']
         existing = request.session.query(CourseReservation).filter_by(
-            course_event_id=course_id,
+            course_event_id=event_id,
             attendee_id=attendee_id
         ).first()
 
         if not existing:
-            self.add(**data)
-            request.success(_("Added a new subscription"))
+            course_event = request.session.query(CourseEvent).filter_by(
+                id=event_id).first()
+            if course_event.locked and not request.is_admin:
+                request.warning(
+                    _("This course event can't be booked (anymore)."))
+                return request.redirect(request.link(self))
+            else:
+                self.add(**data)
+                request.success(_("Added a new subscription"))
         else:
             request.warning(_('Subscription already exists'))
         return request.redirect(request.link(self))
@@ -71,14 +78,22 @@ def view_edit_reservation(self, request, form):
 
     if form.submitted(request):
         data = form.get_useful_data()
+        event_id = data['course_event_id']
         coll = ReservationCollection(
             request.session,
             attendee_id=data['attendee_id'],
-            course_event_id=data['course_event_id'],
+            course_event_id=event_id,
             auth_attendee=request.current_attendee
         )
         res_existing = coll.query().first()
         if not res_existing:
+            course_event = request.session.query(CourseEvent).filter_by(
+                id=event_id).first()
+            if course_event.locked and not request.is_admin:
+                request.warning(
+                    _("This course event can't be booked (anymore)."))
+                return request.redirect(request.link(self))
+
             form.update_model(self)
             request.success(_("Subscription was updated"))
             return request.redirect(request.link(ReservationCollection(
@@ -147,6 +162,14 @@ def view_add_reservation_placeholder(self, request, form):
 
     if form.submitted(request):
         data = form.get_useful_data()
+        event_id = data['course_event_id']
+        course_event = request.session.query(CourseEvent).filter_by(
+            id=event_id).first()
+        if course_event.locked and not request.is_admin:
+            request.warning(
+                _("This course event can't be booked (anymore)."))
+            return request.redirect(request.link(self))
+
         default_desc = request.translate(_('Placeholder Reservation'))
         if not data.get('dummy_desc'):
             data['dummy_desc'] = default_desc

--- a/tests/onegov/fsi/test_views_course_event.py
+++ b/tests/onegov/fsi/test_views_course_event.py
@@ -45,6 +45,7 @@ def test_edit_course_event(client_with_db):
     new.form['min_attendees'] = 2
     new.form['max_attendees'] = 3
     new.form['hidden_from_public'] = True
+    new.form['locked_for_subscriptions'] = True
     page = new.form.submit().follow()
 
     assert 'New Loc' in page

--- a/tests/onegov/fsi/test_views_reservation.py
+++ b/tests/onegov/fsi/test_views_reservation.py
@@ -1,6 +1,33 @@
+import pytest
 from onegov.fsi.collections.course_event import CourseEventCollection
-from onegov.fsi.models import CourseReservation, CourseAttendee, CourseEvent
+from onegov.fsi.models import CourseReservation, CourseAttendee, CourseEvent, \
+    Course
 from onegov.user import User
+
+
+@pytest.mark.skip('Webstest ES configuration issue')
+def test_locked_course_event_reservations(client_with_db):
+    client = client_with_db
+    client.login_admin()
+    session = client.app.session()
+    course = session.query(Course).first()
+
+    # Add a new course event
+    page = client.get(f'/fsi/events/add?course_id={course.id}')
+    page.form['presenter_name'] = 'Presenter'
+    page.form['presenter_company'] = 'Presenter'
+    page.form['presenter_email'] = 'presenter@example.org'
+    page.form['locked_for_subscriptions'] = True
+    page.form['start'] = '2050-10-04 10:00:00'
+    page.form['end'] = '2050-10-04 12:00:00'
+    page.form['location'] = 'location'
+    page.form['max_attendees'] = 20
+    # goes to the event created
+    new = page.form.submit().follow()
+
+    # Hinzufügen - Teilnehmer
+    add_subscription = new.click('Teilnehmer', href='attendees')
+    page = add_subscription.form.submit()
 
 
 def test_reservation_collection_view(client_with_db):


### PR DESCRIPTION
Only admins should be able add subscriptions for locked course events.
Adds property `locked_for_subscriptions` to `CourseEvent` and adapts form.
Introduces checks for reservation adding/editing in views.