### PR TITLE
Fsi minor updates

### DIFF
--- a/src/onegov/fsi/collections/course.py
+++ b/src/onegov/fsi/collections/course.py
@@ -13,7 +13,8 @@ class CourseCollection(GenericCollection):
 
     def query(self):
         query = super().query()
-        return query.filter_by(hidden_from_public=False)
+        query = query.filter_by(hidden_from_public=False)
+        return query.order_by(Course.name)
 
     def by_id(self, id):
         return super().query().filter(self.primary_key == id).first()

--- a/src/onegov/fsi/collections/course.py
+++ b/src/onegov/fsi/collections/course.py
@@ -3,8 +3,9 @@ from onegov.fsi.models.course import Course
 
 
 class CourseCollection(GenericCollection):
-    def __init__(self, session):
+    def __init__(self, session, auth_attendee=None):
         super().__init__(session)
+        self.auth_attendee = auth_attendee
 
     @property
     def model_class(self):
@@ -12,4 +13,7 @@ class CourseCollection(GenericCollection):
 
     def query(self):
         query = super().query()
-        return query
+        return query.filter_by(hidden_from_public=False)
+
+    def by_id(self, id):
+        return super().query().filter(self.primary_key == id).first()

--- a/src/onegov/fsi/forms/course.py
+++ b/src/onegov/fsi/forms/course.py
@@ -123,6 +123,11 @@ class CourseForm(Form):
         default=12,
     )
 
+    hidden_from_public = BooleanField(
+        label=_("Hidden"),
+        default=False,
+    )
+
     def get_useful_data(self, exclude={'csrf_token'}):
         result = super().get_useful_data(exclude)
         if self.description.data:
@@ -141,11 +146,13 @@ class CourseForm(Form):
         self.mandatory_refresh.data = model.mandatory_refresh
         self.refresh_interval.data = months_from_timedelta(
             model.refresh_interval)
+        self.hidden_from_public.data = model.hidden_from_public
 
     def update_model(self, model):
         model.name = self.name.data
         model.description = linkify(self.description.data, escape=False)
         model.mandatory_refresh = self.mandatory_refresh.data
+        model.hidden_from_public = self.hidden_from_public.data
         if not model.mandatory_refresh:
             model.refresh_interval = None
         else:

--- a/src/onegov/fsi/forms/course_event.py
+++ b/src/onegov/fsi/forms/course_event.py
@@ -111,7 +111,7 @@ class CourseEventForm(Form):
         self.presenter_company.data = model.presenter_company
         self.presenter_email.data = model.presenter_email
         self.hidden_from_public.data = model.hidden_from_public
-        self.locked_for_subscriptions = model.locked_for_subscriptions
+        self.locked_for_subscriptions.data = model.locked_for_subscriptions
 
         self.start.data = model.start
         self.end.data = model.end

--- a/src/onegov/fsi/forms/reservation.py
+++ b/src/onegov/fsi/forms/reservation.py
@@ -92,7 +92,7 @@ class AddFsiReservationForm(Form, ReservationFormMixin):
             return self.attendee_choice(self.attendee),
 
         if self.model.course_event_id:
-            attendees = self.event.possible_bookers(
+            attendees = self.event.possible_subscribers(
                 external_only=self.model.external_only
             )
             att = self.request.current_attendee
@@ -194,7 +194,7 @@ class EditFsiReservationForm(Form, ReservationFormMixin):
         return [self.event_choice(self.model.course_event)]
 
     def get_attendee_choices(self):
-        attendees = self.model.course_event.possible_bookers(
+        attendees = self.model.course_event.possible_subscribers(
             external_only=False
         )
         att = self.request.current_attendee

--- a/src/onegov/fsi/layouts/course.py
+++ b/src/onegov/fsi/layouts/course.py
@@ -30,6 +30,17 @@ class CourseInviteMailLayout(OrgDefaultMailLayout, FormatMixin):
     def course_url(self):
         return self.request.link(self.model)
 
+    @cached_property
+    def upcoming_events_collection(self):
+        return CourseEventCollection(
+            self.request.session,
+            course_id=self.model.id,
+            upcoming_only=True)
+
+    @cached_property
+    def open_events_url(self):
+        return self.request.link(self.upcoming_events_collection)
+
     @property
     def notification_type(self):
         return 'invitation'

--- a/src/onegov/fsi/locale/de_CH/LC_MESSAGES/onegov.fsi.po
+++ b/src/onegov/fsi/locale/de_CH/LC_MESSAGES/onegov.fsi.po
@@ -1,8 +1,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE 1.0\n"
-"POT-Creation-Date: 2020-01-27 09:21+0100\n"
-"PO-Revision-Date: 2020-01-16 08:19+0100\n"
+"POT-Creation-Date: 2020-01-28 09:53+0100\n"
+"PO-Revision-Date: 2020-01-28 09:54+0100\n"
 "Last-Translator: Denis Krienbühl <denis.krienbuehl@seantis.ch>\n"
 "Language-Team: German\n"
 "Language: de_CH\n"
@@ -74,6 +74,9 @@ msgstr "Wiederholungsintervall (in Monaten)"
 msgid "Number of months"
 msgstr "Anzahl Monate"
 
+msgid "Hidden"
+msgstr "Versteckt"
+
 msgid "Paste a list of email addresses."
 msgstr "Fügen Sie eine Liste von Email-Addressen ein."
 
@@ -103,9 +106,6 @@ msgstr "Firma"
 
 msgid "Presenter Email"
 msgstr "Referent Email"
-
-msgid "Hidden"
-msgstr "Versteckt"
 
 msgid "Locked for Subscriptions"
 msgstr "Für Anmeldungen gesperrt"
@@ -448,9 +448,6 @@ msgstr "Freie Plätze"
 msgid "Email Preview"
 msgstr "Email Vorschau"
 
-msgid "Details / Registration"
-msgstr "Details / Anmeldung"
-
 msgid "Subject:"
 msgstr "Betreff:"
 
@@ -469,8 +466,8 @@ msgstr "Verbleibende Plätze"
 msgid "Description:"
 msgstr "Beschreibung:"
 
-msgid "Locked"
-msgstr "Gesperrt"
+msgid "Hidden / Locked"
+msgstr "Versteckt / Gesperrt"
 
 msgid "No events found."
 msgstr "Keine Durchführungen gefunden."
@@ -487,11 +484,16 @@ msgstr "Sehr geehrte(r) [first_name] [last_name],"
 msgid "Please take notice about the information below."
 msgstr "Bitte beachten sie die untenstehenden Informationen."
 
-msgid "We hereby confirm your subscription for:"
-msgstr "Wir bestätigen hiermit ihre Anmeldung für:"
+msgid "You have successfully subscribed to the following course event:"
+msgstr ""
 
-msgid "You will receive a reminder email prior to the course."
-msgstr "Sie werden eine Erinnerungs-Email vor dem Kurs-Start erhalten."
+msgid ""
+"Thank you for your course subscription. Please add the course event to your "
+"outlook calender."
+msgstr ""
+
+msgid "You will receive a reminder email 2 weeks prior to the start"
+msgstr ""
 
 msgid "Further information can be found on the"
 msgstr "Weitere Informationen finden Sie auf der"
@@ -609,14 +611,17 @@ msgstr "E-Mail / Benutzername / Kürzel"
 msgid "Send E-Mail Now"
 msgstr "Email jetzt senden"
 
+msgid "There are other subscriptions for the same course in this year"
+msgstr "Für dieses Jahr gibt es bereits andere Anmeldungen für diesen Kurs"
+
 msgid "Added a new subscription"
 msgstr "Neue Anmeldung wurde hinzugefügt"
 
-msgid "Subscription already exists"
-msgstr "Anmeldung existiert bereits"
-
 msgid "Subscription was updated"
 msgstr "Anmeldung wurde aktualisert"
+
+msgid "Subscription already exists"
+msgstr "Anmeldung existiert bereits"
 
 msgid "Edit Subscription"
 msgstr "Anmeldung bearbeiten"
@@ -638,6 +643,21 @@ msgstr "Neue Anmeldungen erfasst"
 
 msgid "Subscription successfully deleted"
 msgstr "Anmeldung erfolgreich gelöscht"
+
+msgid "Placeholder successfully deleted"
+msgstr ""
+
+#~ msgid "Details / Registration"
+#~ msgstr "Details / Anmeldung"
+
+#~ msgid "Locked"
+#~ msgstr "Gesperrt"
+
+#~ msgid "We hereby confirm your subscription for:"
+#~ msgstr "Wir bestätigen hiermit ihre Anmeldung für:"
+
+#~ msgid "You will receive a reminder email prior to the course."
+#~ msgstr "Sie werden eine Erinnerungs-Email vor dem Kurs-Start erhalten."
 
 #~ msgid "Add Reservation"
 #~ msgstr "Reservation hinzufügen"

--- a/src/onegov/fsi/locale/de_CH/LC_MESSAGES/onegov.fsi.po
+++ b/src/onegov/fsi/locale/de_CH/LC_MESSAGES/onegov.fsi.po
@@ -1,8 +1,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE 1.0\n"
-"POT-Creation-Date: 2020-01-28 09:53+0100\n"
-"PO-Revision-Date: 2020-01-28 09:54+0100\n"
+"POT-Creation-Date: 2020-01-28 11:37+0100\n"
+"PO-Revision-Date: 2020-01-28 11:39+0100\n"
 "Last-Translator: Denis Krienbühl <denis.krienbuehl@seantis.ch>\n"
 "Language-Team: German\n"
 "Language: de_CH\n"
@@ -430,21 +430,6 @@ msgstr "Keine Einträge gefunden."
 msgid "No entries found"
 msgstr "Keine Einträge gefunden"
 
-msgid "Date"
-msgstr "Datum"
-
-msgid "Start"
-msgstr "Start"
-
-msgid "End"
-msgstr "Ende"
-
-msgid "Presenter Company"
-msgstr "Referent Firma"
-
-msgid "Free Space"
-msgstr "Freie Plätze"
-
 msgid "Email Preview"
 msgstr "Email Vorschau"
 
@@ -460,11 +445,26 @@ msgstr "Empfänger:"
 msgid "Name"
 msgstr "Name"
 
+msgid "Date"
+msgstr "Datum"
+
 msgid "Remaining seats"
 msgstr "Verbleibende Plätze"
 
 msgid "Description:"
 msgstr "Beschreibung:"
+
+msgid "Start"
+msgstr "Start"
+
+msgid "End"
+msgstr "Ende"
+
+msgid "Presenter Company"
+msgstr "Referent Firma"
+
+msgid "Free Space"
+msgstr "Freie Plätze"
 
 msgid "Hidden / Locked"
 msgstr "Versteckt / Gesperrt"
@@ -485,33 +485,43 @@ msgid "Please take notice about the information below."
 msgstr "Bitte beachten sie die untenstehenden Informationen."
 
 msgid "You have successfully subscribed to the following course event:"
-msgstr ""
+msgstr "Sie haben sich erfolgreich für folgenden Kurs angemeldet:"
+
+msgid "Details:"
+msgstr "Details:"
 
 msgid ""
 "Thank you for your course subscription. Please add the course event to your "
 "outlook calender."
 msgstr ""
+"Besten Dank für Ihre Kursanmeldung. Bitte tragen Sie sich den Kurstermin in "
+"den Outlook-Kalender ein."
 
-msgid "You will receive a reminder email 2 weeks prior to the start"
+msgid "You will receive a reminder email 2 weeks prior to the start."
+msgstr "Sie erhalten 2 Wochen vor Kursbeginn eine Erinnerungsmail."
+
+msgid ""
+"The event will take place as planned. We kindly request to arrive on time at "
+"the event location. Please take note of the course description at"
 msgstr ""
+"Der Kurs wird wie geplant durchgeführt. Wir bitten um pünktliches Eintreffen "
+"im Kurslokal. Bitte beachten Sie auch den Kursbeschrieb im"
 
-msgid "Further information can be found on the"
-msgstr "Weitere Informationen finden Sie auf der"
+msgid "iZug/Fachstelle Sicherheit"
+msgstr "iZug/Fachstelle Sicherheit"
 
-msgid "course website."
-msgstr "Kurswebseite."
+msgid ""
+"Unfortuntely, we have to inform you, that the following course event will "
+"not take place:"
+msgstr ""
+"Leider müssen wir Ihnen mitteilen, dass folgender Kurs nicht wie geplant "
+"stattfindet:"
 
-msgid "We would like to remind you of your subscription for:"
-msgstr "Wir würden Sie gerne an ihre Anmeldung erinnern für:"
+msgid "Available event dates can be found at:"
+msgstr "Verfügbare Kurstermine finden Sie unter:"
 
-msgid "We hereby confirm your cancellation for subscription:"
-msgstr "Hiermit bestätigen wir die Annulierung für die Anmeldung:"
-
-msgid "If you still like to visit this course, have a look at the"
-msgstr "Falls sie diesen Kurs noch besuchen möchten, schauen sie unter"
-
-msgid "open events."
-msgstr "zukünfigte Durchführungen."
+msgid "We kindly ask for understanding and acknowledgement."
+msgstr "Wir bitten um Verständnis und Ihre Kenntnisnahme."
 
 msgid ""
 "We would like to invite you to subscribe for one of the events for the "
@@ -520,11 +530,17 @@ msgstr ""
 "Wir würden Sie gerne einladen, sich für eine zukünftige Kursveranstaltung "
 "des Kurses ${course_name} anzumelden."
 
-msgid "You can find the list of future events below."
-msgstr "Untenstehend finden Sie eine Liste der zukünftigen Durchführungen."
+msgid "Your subscription for the following event has been deleted:"
+msgstr "Ihre Anmeldung für den folgenden Kurs wurde gelöscht:"
 
 msgid "Event Details"
 msgstr "Details Durchführung"
+
+msgid "Your's sincerily"
+msgstr "Mit freundlichen Grüssen"
+
+msgid "Fachstelle Sicherheit"
+msgstr "Fachstelle Sicherheit"
 
 msgid ""
 "Clicking \"Send\" will send the e-mail below to all selected recipients. You "
@@ -645,7 +661,31 @@ msgid "Subscription successfully deleted"
 msgstr "Anmeldung erfolgreich gelöscht"
 
 msgid "Placeholder successfully deleted"
-msgstr ""
+msgstr "Platzhalter erfolgreich gelöscht"
+
+#~ msgid "Your subscription for the following event has beeen deleted:"
+#~ msgstr "Ihre Anmeldung für den folgenden Kurs wurde gelöscht:"
+
+#~ msgid "Further information can be found on the"
+#~ msgstr "Weitere Informationen finden Sie auf der"
+
+#~ msgid "course website."
+#~ msgstr "Kurswebseite."
+
+#~ msgid "We would like to remind you of your subscription for:"
+#~ msgstr "Wir würden Sie gerne an ihre Anmeldung erinnern für:"
+
+#~ msgid "We hereby confirm your cancellation for subscription:"
+#~ msgstr "Hiermit bestätigen wir die Annulierung für die Anmeldung:"
+
+#~ msgid "If you still like to visit this course, have a look at the"
+#~ msgstr "Falls sie diesen Kurs noch besuchen möchten, schauen sie unter"
+
+#~ msgid "open events."
+#~ msgstr "zukünfigte Durchführungen."
+
+#~ msgid "You can find the list of future events below."
+#~ msgstr "Untenstehend finden Sie eine Liste der zukünftigen Durchführungen."
 
 #~ msgid "Details / Registration"
 #~ msgstr "Details / Anmeldung"

--- a/src/onegov/fsi/locale/de_CH/LC_MESSAGES/onegov.fsi.po
+++ b/src/onegov/fsi/locale/de_CH/LC_MESSAGES/onegov.fsi.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE 1.0\n"
-"POT-Creation-Date: 2020-01-16 08:19+0100\n"
+"POT-Creation-Date: 2020-01-27 09:21+0100\n"
 "PO-Revision-Date: 2020-01-16 08:19+0100\n"
 "Last-Translator: Denis Krienbühl <denis.krienbuehl@seantis.ch>\n"
 "Language-Team: German\n"
@@ -154,6 +154,12 @@ msgstr "Platzhalter-Beschreibung (optional)"
 
 msgid "Placeholder Reservation"
 msgstr "Platzhalter-Reservation"
+
+msgid "Yes"
+msgstr "Ja"
+
+msgid "No"
+msgstr "Nein"
 
 msgid "New Course"
 msgstr "Neuer Kurs"
@@ -466,12 +472,6 @@ msgstr "Beschreibung:"
 msgid "Locked"
 msgstr "Gesperrt"
 
-msgid "Yes"
-msgstr "Ja"
-
-msgid "No"
-msgstr "Nein"
-
 msgid "No events found."
 msgstr "Keine Durchführungen gefunden."
 
@@ -615,9 +615,6 @@ msgstr "Neue Anmeldung wurde hinzugefügt"
 msgid "Subscription already exists"
 msgstr "Anmeldung existiert bereits"
 
-msgid "Add Reservation"
-msgstr "Reservation hinzufügen"
-
 msgid "Subscription was updated"
 msgstr "Anmeldung wurde aktualisert"
 
@@ -641,6 +638,9 @@ msgstr "Neue Anmeldungen erfasst"
 
 msgid "Subscription successfully deleted"
 msgstr "Anmeldung erfolgreich gelöscht"
+
+#~ msgid "Add Reservation"
+#~ msgstr "Reservation hinzufügen"
 
 #~ msgid "This course event can't be booked anymore."
 #~ msgstr "Dieser Kurs kann nicht mehr gebucht werden."

--- a/src/onegov/fsi/models/course.py
+++ b/src/onegov/fsi/models/course.py
@@ -28,6 +28,9 @@ class Course(Base, ORMSearchable):
     # If the course has to be refreshed after some interval
     mandatory_refresh = Column(Boolean, nullable=False, default=False)
 
+    # hides the course in the collection for non-admins
+    hidden_from_public = Column(Boolean, nullable=False, default=False)
+
     @property
     def title(self):
         return self.name

--- a/src/onegov/fsi/models/course_event.py
+++ b/src/onegov/fsi/models/course_event.py
@@ -223,7 +223,7 @@ class CourseEvent(Base, TimestampMixin, ORMSearchable):
 
     def has_reservation(self, attendee_id):
         return self.reservations.filter_by(
-            attendee_id=attendee_id).count() != 0
+            attendee_id=attendee_id).first() is not None
 
     def possible_bookers(self, external_only=False):
         session = object_session(self)

--- a/src/onegov/fsi/models/course_event.py
+++ b/src/onegov/fsi/models/course_event.py
@@ -280,6 +280,4 @@ class CourseEvent(Base, TimestampMixin, ORMSearchable):
 
     def can_book(self, attendee, year=None):
         assert isinstance(attendee, CourseAttendee)
-        if self.locked:
-            return False
         return attendee.id not in self.excluded_subscribers(year=year)

--- a/src/onegov/fsi/templates/course_event.pt
+++ b/src/onegov/fsi/templates/course_event.pt
@@ -15,7 +15,7 @@
                             <tal:b tal:define="registered model.has_reservation(request.attendee_id)">
                                 <tal:b tal:switch="registered">
                                     <button tal:case="True" class="button success disabled"><i class="fa fa-check" aria-hidden="true"></i> <tal:b i18n:translate>Registered</tal:b></button>
-                                    <metal:b tal:case="False" tal:condition="model.can_book(request.current_attendee)" use-macro="layout.macros['intercooler_btn']"/>
+                                    <metal:b tal:case="False" tal:condition="model.can_book(request.current_attendee) and not model.locked" use-macro="layout.macros['intercooler_btn']"/>
                                 </tal:b>
 
                                 <p><strong tal:condition="model.locked and not request.is_admin" i18n:translate="">This course event can't be booked (anymore).</strong></p>

--- a/src/onegov/fsi/templates/course_event.pt
+++ b/src/onegov/fsi/templates/course_event.pt
@@ -15,7 +15,7 @@
                             <tal:b tal:define="registered model.has_reservation(request.attendee_id)">
                                 <tal:b tal:switch="registered">
                                     <button tal:case="True" class="button success disabled"><i class="fa fa-check" aria-hidden="true"></i> <tal:b i18n:translate>Registered</tal:b></button>
-                                    <metal:b tal:case="False" tal:condition="not: model.locked" use-macro="layout.macros['intercooler_btn']"/>
+                                    <metal:b tal:case="False" tal:condition="model.can_book(request.current_attendee)" use-macro="layout.macros['intercooler_btn']"/>
                                 </tal:b>
 
                                 <p><strong tal:condition="model.locked and not request.is_admin" i18n:translate="">This course event can't be booked (anymore).</strong></p>

--- a/src/onegov/fsi/templates/course_events.pt
+++ b/src/onegov/fsi/templates/course_events.pt
@@ -10,41 +10,8 @@
                         <strong tal:condition="not: events" i18n:translate="">No entries found</strong>
                         <tal:b tal:condition="events">
                             <h4 tal:condition="layout.course">${layout.course.name}</h4>
-                            <table class="tablesaw hover">
-                                <thead>
-                                    <th i18n:translate="" tal:condition="not: layout.model.course_id">Course</th>
-                                    <th i18n:translate="">Date</th>
-                                    <th i18n:translate="">Start</th>
-                                    <th i18n:translate="">End</th>
-                                    <th i18n:translate="">Presenter</th>
-                                    <th i18n:translate="">Presenter Company</th>
-<!--?                                    <th i18n:translate="">Refresh</th>-->
-<!--?                                    <th i18n:translate="">Status</th>-->
-                                    <th i18n:translate="">Free Space</th>
-                                    <th tal:condition="request.is_manager" i18n:translate>Hidden</th>
-                                </thead>
-                                <tbody>
-                                    <tal:b tal:repeat="event events">
-                                        <tr>
-                                            <td class="" tal:condition="not: layout.model.course_id"><a href="${layout.instance_link(event)}">${event.name}</a></td>
-                                            <td class="">${layout.format_date(event.start, 'date')}</td>
-                                            <td class="">${layout.format_date(event.start, 'time')}</td>
-                                            <td class="">${layout.format_date(event.end, 'time')}</td>
-                                            <td class="">${event.presenter_name}</td>
-                                            <td class="">${event.presenter_company}</td>
-<!--?                                            <td class="" tal:condition="event.mandatory_refresh" i18n:translate="">Yes</td>-->
-<!--?                                            <td class="" tal:condition="not event.mandatory_refresh" i18n:translate="">No</td>-->
-<!--?                                            <td class="">${layout.format_status(event.status)}</td>-->
-                                            <td class="">${event.available_seats}</td>
-                                            <tal:b tal:condition="request.is_manager" tal:switch="event.hidden_from_public">
-                                                <td tal:case="True">Yes</td>
-                                                <td tal:case="False">No</td>
-                                            </tal:b>
-                                        </tr>
-                                    </tal:b>
-                                </tbody>
-
-                            </table>
+                            <br>
+                            <tal:b metal:use-macro="layout.macros['course_event_listing']"/>
                         </tal:b>
 
                     </div>

--- a/src/onegov/fsi/templates/macros.pt
+++ b/src/onegov/fsi/templates/macros.pt
@@ -146,20 +146,20 @@
             <tal:b tal:condition="events">
                 <table class="tablesaw hover events-table fullwidth">
                     <thead>
-                        <th i18n:translate class='text-left'>Date</th>
-                        <th i18n:translate class='text-left'>Start</th>
-                        <th i18n:translate class='text-left'>End</th>
-                        <th i18n:translate class='text-left'>Status</th>
-                        <th i18n:translate class='text-left'>Presenter</th>
-                        <th i18n:translate class='text-left' tal:condition="not for_email">Presenter Company</th>
-                        <th i18n:translate class='text-left'>Free Space</th>
+                        <th i18n:translate class="text-left">Date</th>
+                        <th i18n:translate class="text-left">Start</th>
+                        <th i18n:translate class="text-left">End</th>
+                        <th i18n:translate class="text-left">Status</th>
+                        <th i18n:translate class="text-left">Presenter</th>
+                        <th i18n:translate class="text-left" tal:condition="not for_email">Presenter Company</th>
+                        <th i18n:translate class='text-right'>Free Space</th>
                         <th tal:condition="not for_email and request.is_manager" i18n:translate>Hidden</th>
                         <th tal:condition="not for_email and request.is_manager" i18n:translate>Locked</th>
                     </thead>
                     <tbody>
                         <tal:b tal:repeat="event events">
                             <tr>
-                                <td>
+                                <td class="no-wrap">
                                     <a href="${request.link(event)}" class="${'grayed-out' if event.locked else ''}">
                                         <strong>${layout.format_date(event.start, 'date_long')}</strong>
                                     </a>

--- a/src/onegov/fsi/templates/macros.pt
+++ b/src/onegov/fsi/templates/macros.pt
@@ -121,16 +121,21 @@
         <div class="clearfix"></div>
     </dl>
 
-      <dl class="field-display" tal:condition="not: for_email|False">
+    <dl class="field-display" tal:condition="not: for_email|False">
         <dt i18n:translate="">Status</dt>
         <dd>${layout.format_status(model.status)}</dd>
         <div class="clearfix"></div>
       </dl>
-      <dl class="field-display" tal:condition="not: for_email|False and request.is_manager">
+    <dl class="field-display" tal:condition="not: for_email|False and request.is_manager">
         <dt i18n:translate="">Locked for Subscriptions</dt>
         <dd>${layout.format_boolean(model.locked_for_subscriptions)}</dd>
         <div class="clearfix"></div>
-      </dl>
+    </dl>
+    <dl class="field-display" tal:condition="not: for_email|False and request.is_admin">
+        <dt i18n:translate="">Hidden</dt>
+        <dd>${layout.format_boolean(model.hidden_from_public)}</dd>
+        <div class="clearfix"></div>
+    </dl>
 </metal:course_event>
 
 <metal:course define-macro="course_details">
@@ -146,15 +151,14 @@
             <tal:b tal:condition="events">
                 <table class="tablesaw hover events-table fullwidth">
                     <thead>
-                        <th i18n:translate class="text-left">Date</th>
+                        <th i18n:translate>Date</th>
                         <th i18n:translate class="text-left">Start</th>
                         <th i18n:translate class="text-left">End</th>
                         <th i18n:translate class="text-left">Status</th>
                         <th i18n:translate class="text-left">Presenter</th>
                         <th i18n:translate class="text-left" tal:condition="not for_email">Presenter Company</th>
-                        <th i18n:translate class='text-right'>Free Space</th>
-                        <th tal:condition="not for_email and request.is_manager" i18n:translate>Hidden</th>
-                        <th tal:condition="not for_email and request.is_manager" i18n:translate>Locked</th>
+                        <th i18n:translate class='text-left'>Free Space</th>
+                        <th tal:condition="not for_email and request.is_manager" i18n:translate>Hidden / Locked</th>
                     </thead>
                     <tbody>
                         <tal:b tal:repeat="event events">
@@ -170,15 +174,11 @@
                                 <td>${layout.format_status(event.status)}</td>
                                 <td>${event.presenter_name}</td>
                                 <td tal:condition="not for_email">${event.presenter_company}</td>
-                                <td class='text-right'>${event.available_seats}</td>
-                                <tal:b tal:condition="request.is_manager and not for_email" tal:switch="event.hidden_from_public">
-                                    <td tal:case="True" i18n:translate>Yes</td>
-                                    <td tal:case="False" i18n:translate>No</td>
-                                </tal:b>
-                                <tal:b tal:condition="not for_email and request.is_manager" tal:switch="event.locked_for_subscriptions">
-                                    <td tal:case="True" i18n:translate>Yes</td>
-                                    <td tal:case="False" i18n:translate>No</td>
-                                </tal:b>
+                                <td class='text-left'>${event.available_seats}</td>
+                                <td tal:condition="request.is_manager and not for_email">
+                                    <span class="${'hidden-icon ' if event.hidden_from_public else ''}"></span>
+                                    <span class="${'locked-icon' if event.locked_for_subscriptions else ''}"></span>
+                                </td>
                             </tr>
                         </tal:b>
                     </tbody>

--- a/src/onegov/fsi/templates/macros.pt
+++ b/src/onegov/fsi/templates/macros.pt
@@ -135,7 +135,7 @@
 
 <metal:course define-macro="course_details">
     <h3 i18n:translate="">Description:</h3>
-    <div class="page-text">
+    <div class="page-text course-page-text">
         <p tal:content="structure model.description_html"></p>
     </div>
 </metal:course>

--- a/src/onegov/fsi/templates/macros.pt
+++ b/src/onegov/fsi/templates/macros.pt
@@ -32,7 +32,7 @@
                             <div tal:case="True" id="${accordion_id + 'content'}"></div>
                         </tal:b>
 
-                        <span tal:condition="item['url']|nothing"><a href="${item['url']}" class="button hollow" i18n:translate>Details / Registration</a></span>
+                        <span tal:condition="item['url']|nothing and request.is_admin"><a href="${item['url']}" class="button hollow" i18n:translate>Details</a></span>
                     </div>
                 </dd>
             </tal:b>

--- a/src/onegov/fsi/templates/mail_macros.pt
+++ b/src/onegov/fsi/templates/mail_macros.pt
@@ -17,11 +17,12 @@
             <br>
         </tal:b>
         <tal:b tal:case="'reservation'">
-            <p i18n:translate="">We hereby confirm your subscription for:</p>
+            <p i18n:translate="">You have successfully subscribed to the following course event: </p>
+            <metal:b use-macro="layout.default_macros['course_details']" tal:define="model layout.model.course_event.course"/>
+            <metal:b use-macro="layout.default_macros['course_event_details']" tal:define="model layout.model.course_event; for_email True"/>
             <br>
-            <tal:b metal:use-macro="layout.default_macros['course_event_details']" tal:define="model layout.model.course_event; for_email True"/>
-            <br>
-            <p i18n:translate="">You will receive a reminder email prior to the course.</p>
+            <p i18n:translate="">Thank you for your course subscription. Please add the course event to your outlook calender.</p>
+            <p i18n:translate="">You will receive a reminder email 2 weeks prior to the start</p>
             <p>
                 <span i18n:translate="">Further information can be found on the </span>
                 <a href="${layout.event_url}" i18n:translate="">course website.</a>

--- a/src/onegov/fsi/templates/mail_macros.pt
+++ b/src/onegov/fsi/templates/mail_macros.pt
@@ -35,6 +35,7 @@
         </tal:b>
         <tal:b tal:case="'cancellation'">
             <p i18n:translate="">Unfortuntely, we have to inform you, that the following course event will not take place:</p>
+            <br>
             <tal:b metal:use-macro="layout.default_macros['course_event_details']" tal:define="model layout.model.course_event; for_email True"/>
             <br>
             <p>

--- a/src/onegov/fsi/templates/mail_macros.pt
+++ b/src/onegov/fsi/templates/mail_macros.pt
@@ -14,49 +14,47 @@
     <tal:b tal:switch="layout.notification_type">
         <tal:b tal:case="'info'">
             <p i18n:translate="">Please take notice about the information below.</p>
-            <br>
         </tal:b>
         <tal:b tal:case="'reservation'">
-            <p i18n:translate="">You have successfully subscribed to the following course event: </p>
+            <p i18n:translate="">You have successfully subscribed to the following course event:</p>
             <metal:b use-macro="layout.default_macros['course_details']" tal:define="model layout.model.course_event.course"/>
+            <h3 i18n:translate="">Details:</h3>
             <metal:b use-macro="layout.default_macros['course_event_details']" tal:define="model layout.model.course_event; for_email True"/>
             <br>
             <p i18n:translate="">Thank you for your course subscription. Please add the course event to your outlook calender.</p>
-            <p i18n:translate="">You will receive a reminder email 2 weeks prior to the start</p>
-            <p>
-                <span i18n:translate="">Further information can be found on the </span>
-                <a href="${layout.event_url}" i18n:translate="">course website.</a>
-            </p>
+            <p i18n:translate="">You will receive a reminder email 2 weeks prior to the start.</p>
         </tal:b>
         <tal:b tal:case="'reminder'">
-            <p i18n:translate="">We would like to remind you of your subscription for: </p>
-            <br>
+            <p i18n:translate="">You have successfully subscribed to the following course event:</p>
+            <metal:b use-macro="layout.default_macros['course_details']" tal:define="model layout.model.course_event.course"/>
+            <h3 i18n:translate="">Details:</h3>
             <tal:b metal:use-macro="layout.default_macros['course_event_details']" tal:define="model layout.model.course_event; for_email True"/>
-            <br>
-            <p>
-                <span i18n:translate="">Further information can be found on the </span>
-                <a href="${layout.event_url}" i18n:translate="">course website.</a>
+            <p><span i18n:translate="">The event will take place as planned. We kindly request to arrive on time at the event location.
+                Please take note of the course description at </span><a href="${layout.event_url}" i18n:translate="">iZug/Fachstelle Sicherheit</a>.
             </p>
-
         </tal:b>
         <tal:b tal:case="'cancellation'">
-            <p i18n:translate="">We hereby confirm your cancellation for subscription:</p>
-            <br>
+            <p i18n:translate="">Unfortuntely, we have to inform you, that the following course event will not take place:</p>
             <tal:b metal:use-macro="layout.default_macros['course_event_details']" tal:define="model layout.model.course_event; for_email True"/>
             <br>
             <p>
-                <span i18n:translate="">If you still like to visit this course, have a look at the </span>
-                <a href="${layout.open_events_url}" i18n:translate="">open events.</a>
+                <span i18n:translate="">Available event dates can be found at: </span>
+                <a href="${layout.open_events_url}" i18n:translate="">iZug/Fachstelle Sicherheit</a>.
             </p>
+            <p i18n:translate="">We kindly ask for understanding and acknowledgement.</p>
         </tal:b>
         <tal:b tal:case="'invitation'">
             <p i18n:translate="">We would like to invite you to subscribe for one of the events for the course <span tal:replace="layout.model.name" i18n:name="course_name" />.</p>
-            <p i18n:translate="">You can find the list of future events below.</p><br>
-            <tal:b metal:use-macro="layout.default_macros['course_details']" tal:define="model layout.model"/>
-            <h3 i18n:translate="">Events</h3>
-            <tal:b metal:use-macro="layout.default_macros['course_event_listing']" tal:define="events layout.model.future_events; for_email True"/>
+            <p>
+                <span i18n:translate="">Available event dates can be found at: </span>
+                <a href="${layout.open_events_url}" i18n:translate="">iZug/Fachstelle Sicherheit</a>.
+            </p>
+            <br>
 
-
+        </tal:b>
+        <tal:b tal:case="'unsubscribe'">
+            <p i18n:translate="">Your subscription for the following event has been deleted:</p>
+            <metal:b use-macro="layout.default_macros['course_event_details']" tal:define="model layout.model.course_event; for_email True"/>
         </tal:b>
     </tal:b>
 </metal:email_header>
@@ -72,9 +70,15 @@
 </metal:email_footer>
 
 
-<metal:sender define-macro="sender" i18n:domain="onegov.org">
+<metal:sender define-macro="sender">
     <p>${layout.org.name}</p>
 </metal:sender>
+
+
+<metal:email_signature define-macro="email_signature">
+    <p i18n:translate="">Your's sincerily</p>
+    <p i18n:translate="" class="last">Fachstelle Sicherheit</p>
+</metal:email_signature>
 
 </body>
 </html>

--- a/src/onegov/fsi/theme/styles/fsi.scss
+++ b/src/onegov/fsi/theme/styles/fsi.scss
@@ -1,3 +1,16 @@
+/*
+    The maximum width of a line relative to the font. This limits textblocks
+    to a readable length.
+*/
+
+$course-description-line-width: 87ex;
+
+.course-page-text {
+    p {
+        max-width: $course-description-line-width;
+    }
+}
+
 // Removes margin for button inside a table td
 td {
     a.button,

--- a/src/onegov/fsi/theme/styles/fsi.scss
+++ b/src/onegov/fsi/theme/styles/fsi.scss
@@ -77,11 +77,23 @@ dd.accordion-navigation + dd.accordion-navigation {
 .events-table {
     border: 1px solid $gray-light;
     border-width: 1px 1px 0;
+
+    td > span {
+        padding-right: 1em;;
+    }
 }
 
 .fullwidth {
     width: 100%
 }
+
+// Table icons
+
+.locked-icon::before { @include icon('\f023'); }
+.locked-icon-after::after { @include icon('\f023'); }
+.unlocked-icon::before { @include icon('\f09c'); }
+.visible-icon::before { @include icon('\f06e'); }
+.hidden-icon::before { @include icon('\f070'); }
 
 /*
     Links

--- a/src/onegov/fsi/theme/styles/fsi.scss
+++ b/src/onegov/fsi/theme/styles/fsi.scss
@@ -69,6 +69,11 @@ dd.accordion-navigation + dd.accordion-navigation {
 /*
     Tables
 */
+
+.no-wrap {
+    white-space: nowrap;
+}
+
 .events-table {
     border: 1px solid $gray-light;
     border-width: 1px 1px 0;

--- a/src/onegov/fsi/upgrade.py
+++ b/src/onegov/fsi/upgrade.py
@@ -94,3 +94,13 @@ def add_event_property_locked(context):
             Column('locked_for_subscriptions', Boolean,
                    nullable=False, default=True),
             default=lambda x: False)
+
+
+@upgrade_task('Adds hidden_from_public to course')
+def add_hidden_from_public_in_course(context):
+    if not context.has_column('fsi_courses', 'hidden_from_public'):
+        context.add_column_with_defaults(
+            'fsi_courses',
+            Column('hidden_from_public', Boolean, nullable=False,
+                   default=False),
+            default=lambda x: False)

--- a/src/onegov/fsi/views/reservation.py
+++ b/src/onegov/fsi/views/reservation.py
@@ -231,14 +231,17 @@ def view_delete_reservation(self, request):
     request.assert_valid_csrf_token()
     ReservationCollection(
         request.session, auth_attendee=request.current_attendee).delete(self)
-    request = handle_send_email(
-            self.course_event.cancellation_template,
-            request,
-            (self.attendee_id, ),
-            cc_to_sender=False,
-            show_sent_count=True
-        )
-    request.success(_('Subscription successfully deleted'))
+    if not self.is_placeholder:
+        request = handle_send_email(
+                self.course_event.cancellation_template,
+                request,
+                (self.attendee_id, ),
+                cc_to_sender=False,
+                show_sent_count=True
+            )
+        request.success(_('Subscription successfully deleted'))
+    else:
+        request.success(_('Placeholder successfully deleted'))
 
 
 @FsiApp.json(

--- a/src/onegov/fsi/views/reservation.py
+++ b/src/onegov/fsi/views/reservation.py
@@ -66,7 +66,7 @@ def view_add_reservation(self, request, form):
         return request.redirect(request.link(self))
 
     return {
-        'title': _('Add Reservation'),
+        'title': _('Add Subscription'),
         'model': self,
         'layout': layout,
         'form': form

--- a/src/onegov/fsi/views/reservation.py
+++ b/src/onegov/fsi/views/reservation.py
@@ -7,7 +7,7 @@ from onegov.fsi.forms.reservation import AddFsiReservationForm, \
     AddFsiPlaceholderReservationForm
 from onegov.fsi.layouts.reservation import ReservationLayout, \
     ReservationCollectionLayout
-from onegov.fsi.models import CourseReservation, CourseEvent
+from onegov.fsi.models import CourseReservation, CourseEvent, CourseAttendee
 from onegov.fsi import _
 from onegov.fsi.views.notifcations import handle_send_email
 
@@ -39,30 +39,33 @@ def view_add_reservation(self, request, form):
         data = form.get_useful_data()
         event_id = data['course_event_id']
         attendee_id = data['attendee_id']
-        existing = request.session.query(CourseReservation).filter_by(
-            course_event_id=event_id,
-            attendee_id=attendee_id
+        course_event = request.session.query(CourseEvent).filter_by(
+            id=event_id).first()
+
+        if course_event.locked and not request.is_admin:
+            request.warning(
+                _("This course event can't be booked (anymore)."))
+            return request.redirect(request.link(self))
+
+        attendee = request.session.query(CourseAttendee).filter_by(
+            id=attendee_id
         ).first()
 
-        if not existing:
-            course_event = request.session.query(CourseEvent).filter_by(
-                id=event_id).first()
-            if course_event.locked and not request.is_admin:
-                request.warning(
-                    _("This course event can't be booked (anymore)."))
-                return request.redirect(request.link(self))
-            else:
-                self.add(**data)
-                request.success(_("Added a new subscription"))
-                request = handle_send_email(
-                    course_event.reservation_template,
-                    request,
-                    (attendee_id, ),
-                    cc_to_sender=False,
-                    show_sent_count=False
-                )
-        else:
-            request.warning(_('Subscription already exists'))
+        if not course_event.can_book(attendee):
+            request.warning(
+                _("There are other subscriptions for "
+                  "the same course in this year"))
+            return request.redirect(request.link(self))
+
+        self.add(**data)
+        request.success(_("Added a new subscription"))
+        request = handle_send_email(
+            course_event.reservation_template,
+            request,
+            (attendee_id, ),
+            cc_to_sender=False,
+            show_sent_count=False
+        )
         return request.redirect(request.link(self))
 
     return {

--- a/src/onegov/fsi/views/reservation.py
+++ b/src/onegov/fsi/views/reservation.py
@@ -231,6 +231,13 @@ def view_delete_reservation(self, request):
     request.assert_valid_csrf_token()
     ReservationCollection(
         request.session, auth_attendee=request.current_attendee).delete(self)
+    request = handle_send_email(
+            self.course_event.cancellation_template,
+            request,
+            (self.attendee_id, ),
+            cc_to_sender=False,
+            show_sent_count=True
+        )
     request.success(_('Subscription successfully deleted'))
 
 

--- a/tests/onegov/fsi/test_collections.py
+++ b/tests/onegov/fsi/test_collections.py
@@ -4,6 +4,7 @@ from uuid import uuid4
 from sedate import utcnow
 
 from onegov.fsi.collections.attendee import CourseAttendeeCollection
+from onegov.fsi.collections.course import CourseCollection
 from onegov.fsi.collections.course_event import CourseEventCollection
 from onegov.fsi.collections.reservation import ReservationCollection
 
@@ -17,6 +18,16 @@ class authAttendee:
         self.role = role or 'admin'
         self.id = id or uuid4()
         self.permissions = permissions or []
+
+
+def test_course_collection_1(session, course):
+    course(session, hidden_from_public=True, name='Hidden')
+    course1, data = course(session)
+    coll = CourseCollection(session)
+    assert coll.query().count() == 1
+    course1.hidden_from_public = True
+    session.flush()
+    assert coll.by_id(course1.id) is not None
 
 
 def test_course_event_collection(session, course):

--- a/tests/onegov/fsi/test_models.py
+++ b/tests/onegov/fsi/test_models.py
@@ -93,6 +93,7 @@ def test_course_event_1(session, course, course_event, attendee):
     # Subscription in for event2 has impact on possible bookers in event
     assert event.start.year == event2.start.year
     assert event.possible_bookers(year=event.start.year).first() is None
+    assert event.can_book(attendee) is False
 
     # Test course behind the event
     assert event.name == event.course.name

--- a/tests/onegov/fsi/test_models.py
+++ b/tests/onegov/fsi/test_models.py
@@ -74,12 +74,12 @@ def test_course_event_1(session, course, course_event, attendee):
     assert event.reservations.count() == 2
     assert event.attendees.count() == 1
     assert event.available_seats == 20 - 2
-    assert event.possible_bookers().count() == 0
+    assert event.possible_subscribers().count() == 0
 
     attendee_2, data = attendee(session, first_name='2')
-    assert event.possible_bookers().first() == attendee_2
-    assert event2.possible_bookers().first() == attendee_2
-    assert event.possible_bookers(external_only=True).count() == 0
+    assert event.possible_subscribers().first() == attendee_2
+    assert event2.possible_subscribers().first() == attendee_2
+    assert event.possible_subscribers(external_only=True).count() == 0
 
     # Add attendee2 also to event2, so that can not book event
     session.add(
@@ -92,7 +92,7 @@ def test_course_event_1(session, course, course_event, attendee):
 
     # Subscription in for event2 has impact on possible bookers in event
     assert event.start.year == event2.start.year
-    assert event.possible_bookers(year=event.start.year).first() is None
+    assert event.possible_subscribers(year=event.start.year).first() is None
     assert event.can_book(attendee) is False
 
     # Test course behind the event

--- a/tests/onegov/fsi/test_views_course.py
+++ b/tests/onegov/fsi/test_views_course.py
@@ -36,7 +36,7 @@ def test_add_course_and_invite(client):
     assert message['subject'] == '=?utf-8?q?Einladung_f=C3=BCr_Kursanmeldung?='
     text = message['text']
     assert 'New Course' in text
-    assert 'Desc' in text
+    assert 'Verfügbare Kurstermine finden Sie unter' in text
 
 
 def test_course_details(client_with_db):

--- a/tests/onegov/fsi/test_views_course_event.py
+++ b/tests/onegov/fsi/test_views_course_event.py
@@ -157,6 +157,15 @@ def test_register_for_course_event_member(client_with_db):
     assert message['to'] == 'member@example.org'
     assert message['subject'] == '=?utf-8?q?Anmeldungsbest=C3=A4tigung?='
 
+    # Test cancellation emails upon unsubscribing
+    client.login_admin()
+    view = f'/fsi/reservations?course_event_id={event.id}'
+    page = client.get(view)
+    page = page.click('Löschen')
+    assert len(client.app.smtp.outbox) == 2
+    message = get_mail(client.app.smtp.outbox, 1)
+    assert message['subject'] == 'Absage Kursveranstaltung'
+
 
 def test_register_for_course_event_editor(client_with_db):
     client = client_with_db

--- a/tests/onegov/fsi/test_views_reservation.py
+++ b/tests/onegov/fsi/test_views_reservation.py
@@ -186,8 +186,9 @@ def test_create_delete_reservation(client_with_db):
     assert '01.01.2060' in page
 
     page = client.get(view).form.submit().follow()
-    assert 'Anmeldung existiert bereits' in page
-
+    print(page)
+    msg = 'Für dieses Jahr gibt es bereits andere Anmeldungen für diesen Kurs'
+    assert msg in page
     # Settings the attendee id should filter down to events the attendee
     # hasn't any subscription
     page = client.get(f'/fsi/reservations/add?attendee_id={attendee.id}')

--- a/tests/onegov/fsi/test_views_reservation.py
+++ b/tests/onegov/fsi/test_views_reservation.py
@@ -104,7 +104,7 @@ def test_edit_reservation(client_with_db):
         reservation.course_event_id)
     assert edit.form['attendee_id'].value == str(reservation.attendee_id)
     options = [opt[2] for opt in edit.form['attendee_id'].options]
-    # Returns event.possible_bookers, tested elsewhere
+    # Returns event.possible_subscribers, tested elsewhere
     # Planner (admin) and attendee have reservation, not planner_editor (PE)
     # L, F is the normal attendee
     assert options == ['L, F', 'PE, PE']


### PR DESCRIPTION
- Adds hiding a course
- Adapted Email Template texts and translations
- order courses by name
- hides Course "Details" button for non-admins
- disables "Subscribe Button" based on other events of the selected year
- prevents selecting attendees that have already other subscriptions of same course in the same year
- adds icons for locked and hidden_from_public
- sends cancellation email when subscription is deleted
- fixes table wrapping even listing macro