### PR TITLE
ElectionDay: Adds creation of proporz elections from WP_Wahl

### DIFF
--- a/docs/api/election_day/README.md
+++ b/docs/api/election_day/README.md
@@ -193,3 +193,19 @@ It is possible to set the language used for the error messages by setting the
       --form "wp_wahl=@WP_Wahl.csv" \
       --form "wpstatic_gemeinden=@WPStatic_Gemeinden.csv" \
       --form "wpstatic_kandidaten=@WPStatic_Kandidaten.csv"
+
+### Auto-creation of election and election compound using the REST-API
+
+As of the WabstiC Export version 2.4.3, a compound election with proporz elections can be created
+automatically using `WP_Wahl.csv` only using a normal wabsti data source token.
+
+    curl https://[base_url]/create-wabsti-proporz \
+      --user :[token] \
+      --header "Accept-Language: de_CH" \
+      --form "wp_wahl=@WP_Wahl.csv"
+      
+The endpoint created the following:
+
+1. All elections that are present in `WP_Wahl.csv`.
+2. The election compound
+3. A link (`DataSourceItem`) for each election to the data source (token), so that results can be uploaded.

--- a/docs/api/election_day/format_election_de.md
+++ b/docs/api/election_day/format_election_de.md
@@ -250,3 +250,19 @@ Panaschierdaten werden nur hinzugefügt, falls:
 #### Vorlagen
 
 - [election_party_results.csv](https://raw.githubusercontent.com/OneGov/onegov.election_day/master/docs/templates/election_party_results.csv)
+
+### Automatische Erstellung verbundene Wahl und Wahlen mit REST-API
+
+Mit der WabstiC Export Version 2.4.3 können verbundene Wahlen mithilfe der Datei `WP_Wahl.csv` erstellt werden. 
+Das Token wird unter **WabstiDatenquellen** erzeugt.
+
+    curl https://[base_url]/create-wabsti-proporz \
+      --user :[token] \
+      --header "Accept-Language: de_CH" \
+      --form "wp_wahl=@WP_Wahl.csv"
+      
+Diese Endpunkt ersetzt dann folgende, manuellen Schritte:
+
+1. Alle Wahlen, die in `WP_Wahl.csv` vorhanden sind.
+2. Die verbundene Wahl
+3. Je eine Zuordnung für jede Wahl zur Wabsti Datenquelle, um Resultate hochzuladen.

--- a/docs/api/election_day/format_election_fr.md
+++ b/docs/api/election_day/format_election_fr.md
@@ -252,3 +252,19 @@ Les résultats avec panachage sont uniquement ajoutés si :
 #### Modèles
 
 - [election_party_results.csv](https://raw.githubusercontent.com/OneGov/onegov.election_day/master/docs/templates/election_party_results.csv)
+
+### Création automatique des composantes des élections
+
+Avec WabstiC Export version 2.4.3, les composantes des élections peuvent être créées en utilisant le fichier 'WP_Wahl.csv'. 
+Le token est créé sous **Source de données Wabsti**.
+
+    curl https://[base_url]/create-wabsti-proporz \
+      --user :[token] \
+      --header "Accept-Language: de_CH" \
+      --form "wp_wahl=@WP_Wahl.csv"
+      
+La demande précedant effectue ensuite les étapes suivantes:
+
+1. Tous les élections présent dans le fichier `WP_Wahl.csv`.
+2. la composante des élections
+3. Une cartopgraphie pour chaque election afin de mettre a jour les résultats.

--- a/src/onegov/election_day/forms/upload/wabsti_proporz.py
+++ b/src/onegov/election_day/forms/upload/wabsti_proporz.py
@@ -88,3 +88,16 @@ class UploadWabstiProporzElectionForm(Form):
         ],
         render_kw=dict(force_simple=True)
     )
+
+
+class CreateWabstiProporzElectionForm(Form):
+
+    wp_wahl = UploadField(
+        label="WP_Wahl",
+        validators=[
+            DataRequired(),
+            WhitelistedMimeType(ALLOWED_MIME_TYPES),
+            FileSizeLimit(MAX_FILE_SIZE)
+        ],
+        render_kw=dict(force_simple=True)
+    )

--- a/src/onegov/election_day/views/upload/__init__.py
+++ b/src/onegov/election_day/views/upload/__init__.py
@@ -20,6 +20,19 @@ def set_locale(request):
 
 def translate_errors(errors, request):
     """ Translates and interpolates the given error messages. """
+    if isinstance(errors, list):
+        # List of line errors or FileImportErrors
+        for ix, value in enumerate(errors):
+            translation_string = getattr(value, 'error', value)
+            result = {
+                'message': request.translate(translation_string),
+            }
+            if hasattr(value, 'filename'):
+                result['filename'] = value.filename
+            if hasattr(value, 'line'):
+                result['line'] = value.line
+            errors[ix] = result
+        return
 
     for key, values in errors.items():
         errors[key] = []

--- a/src/onegov/election_day/views/upload/election_creation.py
+++ b/src/onegov/election_day/views/upload/election_creation.py
@@ -1,0 +1,69 @@
+"""
+Canton SZ has over 100 districts.
+
+For compound elections, the election creation view creates:
+
+- All election belonging to the one election compound
+- The election compound that registers all these election
+- The
+
+"""
+import transaction
+
+from onegov.election_day import _
+from onegov.core.security import Public
+from onegov.election_day import ElectionDayApp
+from onegov.election_day.formats.election.wabstic_proporz import \
+    create_election_wabstic_proporz
+from onegov.election_day.forms.upload.wabsti_proporz import \
+    CreateWabstiProporzElectionForm
+from onegov.election_day.models import Principal
+from onegov.election_day.views.upload import set_locale, translate_errors
+from onegov.election_day.views.upload.wabsti_exporter import \
+    authenticated_source
+
+
+@ElectionDayApp.json(
+    model=Principal,
+    name='create-wabsti-proporz',
+    request_method='POST',
+    permission=Public
+)
+def view_create_wabsti_proporz(self, request):
+    set_locale(request)
+    data_source = authenticated_source(request)
+    if data_source.items.first():
+        return {
+            'status': 'error',
+            'errors': {
+                'data_source': [request.translate(_(
+                    'This source has already elections assigned to it'
+                ))]
+            }
+        }
+    form = request.get_form(
+        CreateWabstiProporzElectionForm,
+        model=self,
+        csrf_support=False
+    )
+    if not form.validate():
+        return {
+            'status': 'error',
+            'errors': form.errors
+        }
+
+    errors = create_election_wabstic_proporz(
+        self,
+        request,
+        data_source,
+        form.wp_wahl.raw_data[0].file,
+        form.wp_wahl.data['mimetype']
+    )
+    translate_errors(errors, request)
+
+    if any(errors):
+        transaction.abort()
+        return {'status': 'error', 'errors': errors}
+    else:
+        request.app.pages_cache.invalidate()
+        return {'status': 'success', 'errors': {}}

--- a/tests/onegov/election_day/conftest.py
+++ b/tests/onegov/election_day/conftest.py
@@ -133,6 +133,19 @@ def election_day_app_sg(request):
 
 
 @pytest.fixture(scope="function")
+def election_day_app_sz(request):
+
+    app = create_election_day(
+        request,
+        "sz",
+        hide_candidates_chart=True,
+        hide_connections_chart=True
+    )
+    yield app
+    app.session_manager.dispose()
+
+
+@pytest.fixture(scope="function")
 def election_day_app_bern(request):
 
     app = create_election_day(request, "", "'351'", "true")

--- a/tests/onegov/election_day/fixtures/wabstic_243/WP_Wahl.csv
+++ b/tests/onegov/election_day/fixtures/wabstic_243/WP_Wahl.csv
@@ -1,0 +1,9 @@
+SortGeschaeft;AnzPendentGde;AnzPendentRang;GeBezKurz;GeBezOffiziell;Ausmittlungsstand;Sonntag;Kanton;Mandate;SortWahlkreis;WahlkreisBez;WahlkreisChef;BfsNrWKreisChef;EMailWKreisChef;InfoWebPublikation;GeArt;GeLfNr;GeVerbNr
+1;0;0;Kantonsratswahl (SG);Wahl der Mitglieder des Kantonsrates (Wahlkreis St.Gallen);0;28.02.2016;SG;29;1;Wahlkreis St. Gallen;St.Gallen;;;07.01.2016 16:56:49;Kant;1038501597;1038507525
+2;0;0;Kantonsratswahl (RO);Wahl der Mitglieder des Kantonsrates (Wahlkreis Rorschach);0;28.02.2016;SG;10;2;Wahlkreis Rorschach;Rorschach;;;07.01.2016 16:58:50;Kant;1038501600;1038507525
+3;0;0;Kantonsratswahl (RH);Wahl der Mitglieder des Kantonsrates (Wahlkreis Rheintal);0;28.02.2016;SG;17;3;Wahlkreis Rheintal;Rheintal;;;11.01.2016 08:30:35;Kant;1038501603;1038507525
+4;0;0;Kantonsratswahl (WE);Wahl der Mitglieder des Kantonsrates (Wahlkreis Werdenberg);0;28.02.2016;SG;9;5;Wahlkreis Werdenberg;Werdenberg;;;07.01.2016 17:06:00;Kant;1038501605;1038507525
+5;0;0;Kantonsratswahl (SA);Wahl der Mitglieder des Kantonsrates (Wahlkreis Sarganserland);0;28.02.2016;SG;10;6;Wahlkreis Sarganserland;Sarganserland;;;07.01.2016 17:06:53;Kant;1038501607;1038507525
+6;0;0;Kantonsratswahl (SE-GA);Wahl der Mitglieder des Kantonsrates (Wahlkreis See-Gaster);0;28.02.2016;SG;16;7;Wahlkreis See-Gaster;See-Gaster;;;08.01.2016 17:05:42;Kant;1038501609;1038507525
+7;0;0;Kantonsratswahl (TO);Wahl der Mitglieder des Kantonsrates (Wahlkreis Toggenburg);0;28.02.2016;SG;11;8;Wahlkreis Toggenburg;Toggenburg;;;29.01.2016 10:23:45;Kant;1038501611;1038507525
+8;0;0;Kantonsratswahl (WI);Wahl der Mitglieder des Kantonsrates (Wahlkreis Wil);0;28.02.2016;SG;18;13;Wahlkreis Wil;Wil;;;08.01.2016 16:57:48;Kant;1038501613;1038507525

--- a/tests/onegov/election_day/fixtures/wabstic_243/WP_Wahl_errors.csv
+++ b/tests/onegov/election_day/fixtures/wabstic_243/WP_Wahl_errors.csv
@@ -1,0 +1,9 @@
+SortGeschaeft;AnzPendentGde;AnzPendentRang;GeBezKurz;GeBezOffiziell;Ausmittlungsstand;Sonntag;Kanton;Mandate;SortWahlkreis;WahlkreisBez;WahlkreisChef;BfsNrWKreisChef;EMailWKreisChef;InfoWebPublikation;GeArt;GeLfNr;GeVerbNr
+1;0;0;Kantonsratswahl (SG);Wahl der Mitglieder des Kantonsrates (Wahlkreis St.Gallen);0;28.02.AA;SG;29;1;Wahlkreis St. Gallen;St.Gallen;;;07.01.2016 16:56:49;Kant;1038501597;1038507525
+2;0;0;Kantonsratswahl (RO);Wahl der Mitglieder des Kantonsrates (Wahlkreis Rorschach);0;28.02.2016;SG;;2;Wahlkreis Rorschach;Rorschach;;;07.01.2016 16:58:50;Kant;1038501600;1038507525
+3;0;0;Kantonsratswahl (RH);Wahl der Mitglieder des Kantonsrates (Wahlkreis Rheintal);0;28.02.2016;SG;17;3;Wahlkreis Rheintal;Rheintal;;;11.01.2016 08:30:35;Kant;1038501603;1038507525
+4;0;0;Kantonsratswahl (WE);Wahl der Mitglieder des Kantonsrates (Wahlkreis Werdenberg);0;28.02.2016;SG;9;5;Wahlkreis Werdenberg;Werdenberg;;;07.01.2016 17:06:00;Kant;1038501605;1038507525
+5;0;0;Kantonsratswahl (SA);Wahl der Mitglieder des Kantonsrates (Wahlkreis Sarganserland);0;28.02.2016;SG;10;6;Wahlkreis Sarganserland;Sarganserland;;;07.01.2016 17:06:53;Kant;1038501607;1038507525
+6;0;0;Kantonsratswahl (SE-GA);Wahl der Mitglieder des Kantonsrates (Wahlkreis See-Gaster);0;28.02.2016;SG;16;7;Wahlkreis See-Gaster;See-Gaster;;;08.01.2016 17:05:42;Kant;1038501609;1038507525
+7;0;0;Kantonsratswahl (TO);Wahl der Mitglieder des Kantonsrates (Wahlkreis Toggenburg);0;28.02.2016;SG;11;8;Wahlkreis Toggenburg;Toggenburg;;;29.01.2016 10:23:45;Kant;1038501611;1038507525
+8;0;0;Kantonsratswahl (WI);Wahl der Mitglieder des Kantonsrates (Wahlkreis Wil);0;28.02.2016;SG;18;13;Wahlkreis Wil;Wil;;;08.01.2016 16:57:48;Kant;1038501613;1038507525

--- a/tests/onegov/election_day/views/test_views_upload_wabstic.py
+++ b/tests/onegov/election_day/views/test_views_upload_wabstic.py
@@ -256,7 +256,9 @@ def test_create_elections_wabsti_proporz(election_day_app_sg):
     )
 
     params = [
-        ('wp_wahl', Upload(test_file, content_type='text/plain'))
+        ('wp_wahl', Upload(test_file, content_type='text/plain')),
+        ('wp_listen', Upload('wp_listen.csv', 'a'.encode('utf-8'),
+                             content_type='text/plain'))
     ]
 
     client = Client(election_day_app_sg)


### PR DESCRIPTION
Based on the data in WP_Wahl and an existing `DataSource`, the endpoint `/create-wabsti-proporz` will create all elections,
the election compound, and the all `DataSourceItems`. The same `DataSource` can then be used to upload the results.

Type: Feature