### PR TITLE
Wab sz

### DIFF
--- a/src/onegov/ballot/models/election/election.py
+++ b/src/onegov/ballot/models/election/election.py
@@ -283,22 +283,6 @@ class Election(Base, ContentMixin, TimestampMixin,
         if result:
             return result.district or result.name
 
-    # @property
-    # def votes_by_entity(self):
-    #     results = self.results.order_by(None)
-    #     results = results.with_entities(
-    #         self.__class__.id.label('election_id'),
-    #         ElectionResult.entity_id,
-    #         ElectionResult.counted,
-    #         func.coalesce(
-    #             func.sum(ElectionResult.accounted_ballots), 0).label('votes')
-    #     )
-    #     results = results.group_by(
-    #         ElectionResult.entity_id,
-    #         ElectionResult.counted,
-    #         self.__class__.id.label('election_id')
-    #     )
-    #     return results
 
     @property
     def votes_by_district(self):

--- a/src/onegov/election_day/formats/election/wabstic_proporz.py
+++ b/src/onegov/election_day/formats/election/wabstic_proporz.py
@@ -8,6 +8,7 @@ from onegov.ballot import ListConnection
 from onegov.ballot import ListResult
 from onegov.ballot.models.election.election_compound import \
     ElectionCompoundAssociation
+from onegov.core.utils import normalize_for_url
 from onegov.election_day import _
 from onegov.election_day.formats.common import EXPATS, line_is_relevant, \
     validate_integer
@@ -100,7 +101,7 @@ def create_election_wabstic_proporz(
                 line, 'mandate', treat_none_as_default=False)
 
             election = dict(
-                id=uuid4(),
+                id=normalize_for_url(line.gebezoffiziell),
                 type='proporz',
                 title_translations={request.locale: line.gebezoffiziell},
                 shortcode=line.gebezkurz,
@@ -158,7 +159,7 @@ def create_election_wabstic_proporz(
     )
 
     compound = dict(
-        id=uuid4(),
+        id=normalize_for_url(compound_title),
         title_translations={request.locale: compound_title},
         shortcode=compound_shortcode,
         date=elections[0]['date'],

--- a/src/onegov/election_day/layouts/election.py
+++ b/src/onegov/election_day/layouts/election.py
@@ -142,7 +142,7 @@ class ElectionLayout(DetailLayout):
     @cached_property
     def district_are_entities(self):
         entities = self.request.app.principal.entities[self.model.date.year]
-        return all(d['name'] == d['district'] for d in entities.values())
+        return all(d['name'] == d.get('district') for d in entities.values())
 
     @cached_property
     def majorz(self):

--- a/src/onegov/election_day/layouts/election.py
+++ b/src/onegov/election_day/layouts/election.py
@@ -104,6 +104,7 @@ class ElectionLayout(DetailLayout):
                 and self.show_map
                 and self.has_districts
                 and not self.tacit
+                and not self.district_are_entities
             )
         if tab == 'connections':
             return (
@@ -137,6 +138,11 @@ class ElectionLayout(DetailLayout):
     @cached_property
     def visible(self):
         return self.tab_visible(self.tab)
+
+    @cached_property
+    def district_are_entities(self):
+        entities = self.request.app.principal.entities[self.model.date.year]
+        return all(d['name'] == d['district'] for d in entities.values())
 
     @cached_property
     def majorz(self):

--- a/src/onegov/election_day/locale/de_CH/LC_MESSAGES/onegov.election_day.po
+++ b/src/onegov/election_day/locale/de_CH/LC_MESSAGES/onegov.election_day.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-10-10 10:44+0200\n"
+"POT-Creation-Date: 2020-03-10 14:56+0100\n"
 "PO-Revision-Date: 2019-10-10 10:45+0200\n"
 "Last-Translator: Marc Sommerhalder <marc.sommerhalder@seantis.ch>\n"
 "Language-Team: German\n"
@@ -137,8 +137,9 @@ msgstr "Listenverbindungen"
 msgid "Election statistics"
 msgstr "Wahlstatistik"
 
-msgid "Value of ausmittlungsstand not between 0 and 3"
-msgstr "Wert von ausmittlungsstand nicht zwischen 0 and 3"
+#, python-format
+msgid "Error in anzpendentgde: ${msg}"
+msgstr ""
 
 msgid "Invalid candidate results"
 msgstr "Ungültige Kandidierendenresultate"
@@ -151,9 +152,12 @@ msgstr "Kanidat mit id ${id} nicht in wm_kandidaten"
 msgid "Entity with id ${id} not in wmstatic_gemeinden"
 msgstr "Gemeinde mit id ${id} nicht in wmstatic_gemeinden"
 
+msgid "Ausmittlungsstand set to final but AnzPendentGde is not 0"
+msgstr ""
+
 #, python-format
-msgid "Value ${col} is not between 0 and 3"
-msgstr "Wert ${col} ist nicht zwischen 0 und 3"
+msgid "${msg}"
+msgstr ""
 
 #, python-format
 msgid "${var} is missing."
@@ -191,6 +195,10 @@ msgstr "Ungültige Abstimmungsart"
 
 msgid "Could not read the empty votes"
 msgstr "Konnte 'Leere Stimmzettel' nicht lesen"
+
+#, python-format
+msgid "Error in anzgdependent: ${msg}"
+msgstr ""
 
 msgid "Text Retrieval"
 msgstr "Suchbegriff"
@@ -479,6 +487,10 @@ msgid "district_label_sg"
 msgstr "Wahlkreis"
 
 #. Default: District
+msgid "district_label_sz_2020"
+msgstr "Gemeinde"
+
+#. Default: District
 msgid "district_label_sz"
 msgstr "Bezirk"
 
@@ -493,6 +505,10 @@ msgstr "Regionen"
 #. Default: Constituencies
 msgid "districts_label_sg"
 msgstr "Wahlkreise"
+
+#. Default: District
+msgid "districts_label_sz_2020"
+msgstr "Gemeinden"
 
 #. Default: Districts
 msgid "districts_label_sz"
@@ -1254,6 +1270,9 @@ msgstr ""
 msgid "The year ${year} is not yet supported"
 msgstr "Das Jahr ${year} wird noch nicht unterstützt"
 
+msgid "This source has already elections assigned to it"
+msgstr ""
+
 msgid "Invalid id"
 msgstr "Ungültige ID"
 
@@ -1262,6 +1281,12 @@ msgstr "Keine Proporzwahl"
 
 msgid "The data source is not configured properly"
 msgstr "Die Datenquellekonfiguration ist ungültig"
+
+#~ msgid "Value of ausmittlungsstand not between 0 and 3"
+#~ msgstr "Wert von ausmittlungsstand nicht zwischen 0 and 3"
+
+#~ msgid "Value ${col} is not between 0 and 3"
+#~ msgstr "Wert ${col} ist nicht zwischen 0 und 3"
 
 #~ msgid "Invalid list values"
 #~ msgstr "Ungültige Listendaten"

--- a/src/onegov/election_day/locale/fr_CH/LC_MESSAGES/onegov.election_day.po
+++ b/src/onegov/election_day/locale/fr_CH/LC_MESSAGES/onegov.election_day.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-10-10 10:44+0200\n"
+"POT-Creation-Date: 2020-03-10 14:56+0100\n"
 "PO-Revision-Date: 2019-10-10 10:46+0200\n"
 "Last-Translator: Marc Sommerhalder <marc.sommerhalder@seantis.ch>\n"
 "Language-Team: \n"
@@ -136,8 +136,9 @@ msgstr "Connexions de listes"
 msgid "Election statistics"
 msgstr "Statistiques des élections"
 
-msgid "Value of ausmittlungsstand not between 0 and 3"
-msgstr "Valeur de ausmittlungsstand pas entre 0 et 3"
+#, python-format
+msgid "Error in anzpendentgde: ${msg}"
+msgstr ""
 
 msgid "Invalid candidate results"
 msgstr "Résultats des candidats non valides"
@@ -150,9 +151,12 @@ msgstr "Candidate avec id ${id} pas dans wm_kandidaten"
 msgid "Entity with id ${id} not in wmstatic_gemeinden"
 msgstr "Commune avec id ${id} pas dans wmstatic_gemeinden"
 
+msgid "Ausmittlungsstand set to final but AnzPendentGde is not 0"
+msgstr ""
+
 #, python-format
-msgid "Value ${col} is not between 0 and 3"
-msgstr "Valeur ${col} n'est pas entry 0 et 3"
+msgid "${msg}"
+msgstr ""
 
 #, python-format
 msgid "${var} is missing."
@@ -190,6 +194,10 @@ msgstr "Type de scrutin invalide"
 
 msgid "Could not read the empty votes"
 msgstr "Impossible de connaître les votes blancs"
+
+#, python-format
+msgid "Error in anzgdependent: ${msg}"
+msgstr ""
 
 msgid "Text Retrieval"
 msgstr "Terme de recherche"
@@ -478,6 +486,10 @@ msgid "district_label_sg"
 msgstr "Circonscription électorale"
 
 #. Default: District
+msgid "district_label_sz_2020"
+msgstr "District électoral"
+
+#. Default: District
 msgid "district_label_sz"
 msgstr "District électoral"
 
@@ -492,6 +504,10 @@ msgstr "Régions"
 #. Default: Constituencies
 msgid "districts_label_sg"
 msgstr "Circonscriptions électorales"
+
+#. Default: District
+msgid "districts_label_sz_2020"
+msgstr "Districts électorales"
 
 #. Default: Districts
 msgid "districts_label_sz"
@@ -1259,6 +1275,9 @@ msgstr ""
 msgid "The year ${year} is not yet supported"
 msgstr "L'année ${year} n'est pas encore prise en charge"
 
+msgid "This source has already elections assigned to it"
+msgstr ""
+
 msgid "Invalid id"
 msgstr "Mauvaise référence"
 
@@ -1267,6 +1286,12 @@ msgstr "Aucune election selon le système proportionnel"
 
 msgid "The data source is not configured properly"
 msgstr "La source de données n'est pas configurée correctement"
+
+#~ msgid "Value of ausmittlungsstand not between 0 and 3"
+#~ msgstr "Valeur de ausmittlungsstand pas entre 0 et 3"
+
+#~ msgid "Value ${col} is not between 0 and 3"
+#~ msgstr "Valeur ${col} n'est pas entry 0 et 3"
 
 #~ msgid "Invalid list values"
 #~ msgstr "Valeurs de la liste non valides"

--- a/src/onegov/election_day/locale/it_CH/LC_MESSAGES/onegov.election_day.po
+++ b/src/onegov/election_day/locale/it_CH/LC_MESSAGES/onegov.election_day.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-10-10 10:44+0200\n"
+"POT-Creation-Date: 2020-03-10 14:56+0100\n"
 "PO-Revision-Date: 2019-10-10 10:47+0200\n"
 "Last-Translator: Marc Sommerhalder <marc.sommerhalder@seantis.ch>\n"
 "Language-Team: \n"
@@ -136,8 +136,9 @@ msgstr "Elenca i collegamenti"
 msgid "Election statistics"
 msgstr "Statistiche delle elezioni"
 
-msgid "Value of ausmittlungsstand not between 0 and 3"
-msgstr "Valore di ausmittlungsstand non compreso tra 0 e 3"
+#, python-format
+msgid "Error in anzpendentgde: ${msg}"
+msgstr ""
 
 msgid "Invalid candidate results"
 msgstr "Risultati del candidato non validi"
@@ -150,9 +151,12 @@ msgstr "Candidato con id ${id} non in wm_kandidaten"
 msgid "Entity with id ${id} not in wmstatic_gemeinden"
 msgstr "Commune con id ${id} non in wmstatic_gemeinden"
 
+msgid "Ausmittlungsstand set to final but AnzPendentGde is not 0"
+msgstr ""
+
 #, python-format
-msgid "Value ${col} is not between 0 and 3"
-msgstr "valore ${col} non compreso tra 0 e 3"
+msgid "${msg}"
+msgstr ""
 
 #, python-format
 msgid "${var} is missing."
@@ -190,6 +194,10 @@ msgstr "Tipo di scheda non valido"
 
 msgid "Could not read the empty votes"
 msgstr "Impossibile leggere 'Schede bianche'"
+
+#, python-format
+msgid "Error in anzgdependent: ${msg}"
+msgstr ""
 
 msgid "Text Retrieval"
 msgstr "Termine di ricerca"
@@ -478,6 +486,10 @@ msgid "district_label_sg"
 msgstr "Distretto elettorale"
 
 #. Default: District
+msgid "district_label_sz_2020"
+msgstr "Distretto elettorale"
+
+#. Default: District
 msgid "district_label_sz"
 msgstr "Distretto elettorale"
 
@@ -491,6 +503,10 @@ msgstr "Regioni"
 
 #. Default: Constituencies
 msgid "districts_label_sg"
+msgstr "Distretti elettorali"
+
+#. Default: District
+msgid "districts_label_sz_2020"
 msgstr "Distretti elettorali"
 
 #. Default: Districts
@@ -1256,6 +1272,9 @@ msgstr ""
 msgid "The year ${year} is not yet supported"
 msgstr "L'anno ${year} non viene ancora supportato"
 
+msgid "This source has already elections assigned to it"
+msgstr ""
+
 msgid "Invalid id"
 msgstr "ID non valido"
 
@@ -1264,6 +1283,12 @@ msgstr "Nessuna elezione secondo il sistema proporzionale"
 
 msgid "The data source is not configured properly"
 msgstr "L'origine dati non è configurata correttamente"
+
+#~ msgid "Value of ausmittlungsstand not between 0 and 3"
+#~ msgstr "Valore di ausmittlungsstand non compreso tra 0 e 3"
+
+#~ msgid "Value ${col} is not between 0 and 3"
+#~ msgstr "valore ${col} non compreso tra 0 e 3"
 
 #~ msgid "Invalid list values"
 #~ msgstr "Valori della lista non validi"

--- a/src/onegov/election_day/locale/rm_CH/LC_MESSAGES/onegov.election_day.po
+++ b/src/onegov/election_day/locale/rm_CH/LC_MESSAGES/onegov.election_day.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-10-10 10:44+0200\n"
+"POT-Creation-Date: 2020-03-10 14:56+0100\n"
 "PO-Revision-Date: 2019-10-15 09:19+0200\n"
 "Last-Translator: Marc Sommerhalder <marc.sommerhalder@seantis.ch>\n"
 "Language-Team: \n"
@@ -137,8 +137,9 @@ msgstr "Colliaziuns da glistas"
 msgid "Election statistics"
 msgstr "Statistica electorala"
 
-msgid "Value of ausmittlungsstand not between 0 and 3"
-msgstr "La valur da ausmittlungsstand n'è betg tranter 0 e 3"
+#, python-format
+msgid "Error in anzpendentgde: ${msg}"
+msgstr ""
 
 msgid "Invalid candidate results"
 msgstr "Resultats da candidat nunvalaivels"
@@ -151,9 +152,12 @@ msgstr "La candidata u il candidat cun id ${id} n'è betg en wm_kandidaten"
 msgid "Entity with id ${id} not in wmstatic_gemeinden"
 msgstr "La vischnanca cun id ${id} n'è betg en wmstatic_gemeinden"
 
+msgid "Ausmittlungsstand set to final but AnzPendentGde is not 0"
+msgstr ""
+
 #, python-format
-msgid "Value ${col} is not between 0 and 3"
-msgstr "La valur ${col} n'è betg tranter 0 e 3"
+msgid "${msg}"
+msgstr ""
 
 #, python-format
 msgid "${var} is missing."
@@ -192,6 +196,10 @@ msgstr "Tip da votaziun nunvalaivel"
 
 msgid "Could not read the empty votes"
 msgstr "I n'è betg stà pussaivel da leger ils cedels da votar vids"
+
+#, python-format
+msgid "Error in anzgdependent: ${msg}"
+msgstr ""
 
 msgid "Text Retrieval"
 msgstr "Noziun tschertgada"
@@ -480,6 +488,10 @@ msgid "district_label_sg"
 msgstr "Circul electoral"
 
 #. Default: District
+msgid "district_label_sz_2020"
+msgstr "Circul electoral"
+
+#. Default: District
 msgid "district_label_sz"
 msgstr "Circul electoral"
 
@@ -493,6 +505,10 @@ msgstr "Regiuns"
 
 #. Default: Constituencies
 msgid "districts_label_sg"
+msgstr "Circuls electorals"
+
+#. Default: District
+msgid "districts_label_sz_2020"
 msgstr "Circuls electorals"
 
 #. Default: Districts
@@ -1265,6 +1281,9 @@ msgstr ""
 msgid "The year ${year} is not yet supported"
 msgstr "L'onn ${year} na vegn anc betg sustegnì"
 
+msgid "This source has already elections assigned to it"
+msgstr ""
+
 msgid "Invalid id"
 msgstr "ID nunvalaivel"
 
@@ -1273,6 +1292,12 @@ msgstr "Nagina elecziun da proporz"
 
 msgid "The data source is not configured properly"
 msgstr "La configuraziun da la funtauna da datas n'è betg valaivla"
+
+#~ msgid "Value of ausmittlungsstand not between 0 and 3"
+#~ msgstr "La valur da ausmittlungsstand n'è betg tranter 0 e 3"
+
+#~ msgid "Value ${col} is not between 0 and 3"
+#~ msgstr "La valur ${col} n'è betg tranter 0 e 3"
 
 #~ msgid "Invalid list values"
 #~ msgstr "Datas da glista nunvalaivlas"

--- a/src/onegov/election_day/models/principal.py
+++ b/src/onegov/election_day/models/principal.py
@@ -180,6 +180,8 @@ class Canton(Principal):
             if self.id == 'sg':
                 return _("district_label_sg", default="Constituency")
             if self.id == 'sz':
+                if date.today().year >= 2020:
+                    return _("district_label_sz_2020", default="District")
                 return _("district_label_sz", default="District")
             return _("district_label_default", default="Constituency")
         if value == 'districts':
@@ -188,6 +190,8 @@ class Canton(Principal):
             if self.id == 'sg':
                 return _("districts_label_sg", default="Constituencies")
             if self.id == 'sz':
+                if date.today().year >= 2020:
+                    return _("districts_label_sz_2020", default="District")
                 return _("districts_label_sz", default="Districts")
             return _("districts_label_default", default="Constituencies")
         return ''

--- a/src/onegov/election_day/templates/election_compound/districts.pt
+++ b/src/onegov/election_day/templates/election_compound/districts.pt
@@ -18,7 +18,7 @@
 
             <h3 tal:content="layout.title()" />
 
-            <tal:block metal:use-macro="layout.macros['election-compound-districts-table']"></tal:block>
+            <tal:block metal:use-macro="layout.macros['election-compound-districts-table']" />
             <tal:block metal:use-macro="layout.macros['embedded_widget']" tal:define="embed_link layout.table_link" />
 
         </tal:block>

--- a/src/onegov/election_day/templates/macros.pt
+++ b/src/onegov/election_day/templates/macros.pt
@@ -132,7 +132,7 @@
             <tr tal:repeat="election election_compound.elections">
                 <td class="left-aligned"><a href="${request.link(election)}">${election.district}</a></td>
                 <td class="right-aligned"><tal:block metal:use-macro="layout.macros['progress']" tal:define="progress (election.allocated_mandates(consider_completed=True), election.number_of_mandates)" /></td>
-                <td class="right-aligned"><tal:block metal:use-macro="layout.macros['progress']" tal:define="progress election.progress" /></td>
+                <td class="right-aligned"><tal:block metal:use-macro="layout.macros['progress']" tal:define="progress election.progress; enable_y_n True" /></td>
             </tr>
         </tbody>
     </table>
@@ -320,7 +320,7 @@
 
 <metal:progress define-macro="progress" i18n:domain="onegov.election_day">
     <tal:b i18n:translate="" condition="progress[1]">
-        <tal:b tal:switch="progress[0] in (0, 1) and progress[1] == 1">
+        <tal:b tal:switch="enable_y_n|False and progress[0] in (0, 1) and progress[1] == 1">
             <tal:b tal:case="False">
                 <span tal:replace="progress[0]" i18n:name='counted' />
                 of

--- a/src/onegov/election_day/templates/macros.pt
+++ b/src/onegov/election_day/templates/macros.pt
@@ -320,9 +320,18 @@
 
 <metal:progress define-macro="progress" i18n:domain="onegov.election_day">
     <tal:b i18n:translate="" condition="progress[1]">
-        <span tal:replace="progress[0]" i18n:name='counted' />
-            of
-        <span tal:replace="progress[1]" i18n:name='total' />
+        <tal:b tal:switch="progress[0] in (0, 1) and progress[1] == 1">
+            <tal:b tal:case="False">
+                <span tal:replace="progress[0]" i18n:name='counted' />
+                of
+                <span tal:replace="progress[1]" i18n:name='total' />
+            </tal:b>
+            <tal:b tal:case="True">
+                <span tal:condition="progress[0] == 0" i18n:translate="">No</span>
+                <span tal:condition="progress[0] == 1" i18n:translate="">Yes</span>
+            </tal:b>
+        </tal:b>
+
     </tal:b>
 </metal:progress>
 

--- a/src/onegov/election_day/templates/macros.pt
+++ b/src/onegov/election_day/templates/macros.pt
@@ -144,12 +144,12 @@
     data-tablesaw-mode="columntoggle"
     data-tablesaw-mode-switch="" data-tablesaw-mode-exclude="swipe"
     data-tablesaw-minimap=""
-    tal:define="entity_name request.translate(layout.principal.label('entity')); district_name request.translate(layout.principal.label('district'))"
+    tal:define="show_district not:layout.district_are_entities"
     >
         <thead>
             <tr>
-                <th data-tablesaw-priority="persist" i18n:translate="" class="left-aligned">${entity_name}</th>
-                <th data-tablesaw-priority="3" i18n:translate="" class="left-aligned" tal:condition="layout.has_districts and district_name != entity_name">${district_name}</th>
+                <th data-tablesaw-priority="persist" i18n:translate="" class="left-aligned">${layout.principal.label('entity')}</th>
+                <th data-tablesaw-priority="3" i18n:translate="" class="left-aligned" tal:condition="show_district and layout.has_districts">${layout.principal.label('district')}</th>
                 <th data-tablesaw-priority="2" i18n:translate="" class="right-aligned">eligible Voters</th>
                 <th data-tablesaw-priority="4" i18n:translate="" class="right-aligned">Received Ballots</th>
                 <th data-tablesaw-priority="5" i18n:translate="" class="right-aligned">Accounted Ballots</th>
@@ -163,12 +163,12 @@
             <tr tal:repeat="result election.results">
                 <tal:block condition="not: result.counted">
                     <td>${layout.format_name(result)}</td>
-                    <td tal:condition="layout.has_districts and district_name != entity_name">${result.district}</td>
+                    <td tal:condition="show_district and layout.has_districts">${result.district}</td>
                     <td class="answer" colspan="7" i18n:translate="">Not yet counted</td>
                 </tal:block>
                 <tal:block condition="result.counted">
                     <td>${layout.format_name(result)}</td>
-                    <td tal:condition="layout.has_districts and district_name != entity_name">${result.district}</td>
+                    <td tal:condition="show_district and layout.has_districts">${result.district}</td>
                     <td class="right-aligned" data-text="${result.eligible_voters}">${layout.format_number(result.eligible_voters)}</td>
                     <td class="right-aligned" data-text="${result.received_ballots}">${layout.format_number(result.received_ballots)}</td>
                     <td class="right-aligned" data-text="${result.accounted_ballots}">${layout.format_number(result.accounted_ballots)}</td>
@@ -182,7 +182,7 @@
         <tfoot tal:condition="layout.summarize">
             <tr class="total">
                 <td i18n:translate="">Total</td>
-                <td tal:condition="layout.has_districts and district_name != entity_name"></td>
+                <td tal:condition="show_district and layout.has_districts"></td>
                 <td class="right-aligned">${layout.format_number(election.eligible_voters)}</td>
                 <td class="right-aligned">${layout.format_number(election.received_ballots)}</td>
                 <td class="right-aligned">${layout.format_number(election.accounted_ballots)}</td>

--- a/src/onegov/election_day/templates/macros.pt
+++ b/src/onegov/election_day/templates/macros.pt
@@ -144,11 +144,12 @@
     data-tablesaw-mode="columntoggle"
     data-tablesaw-mode-switch="" data-tablesaw-mode-exclude="swipe"
     data-tablesaw-minimap=""
+    tal:define="entity_name request.translate(layout.principal.label('entity')); district_name request.translate(layout.principal.label('district'))"
     >
         <thead>
             <tr>
-                <th data-tablesaw-priority="persist" i18n:translate="" class="left-aligned">${layout.principal.label('entity')}</th>
-                <th data-tablesaw-priority="3" i18n:translate="" class="left-aligned" tal:condition="layout.has_districts">${layout.principal.label('district')}</th>
+                <th data-tablesaw-priority="persist" i18n:translate="" class="left-aligned">${entity_name}</th>
+                <th data-tablesaw-priority="3" i18n:translate="" class="left-aligned" tal:condition="layout.has_districts and district_name != entity_name">${district_name}</th>
                 <th data-tablesaw-priority="2" i18n:translate="" class="right-aligned">eligible Voters</th>
                 <th data-tablesaw-priority="4" i18n:translate="" class="right-aligned">Received Ballots</th>
                 <th data-tablesaw-priority="5" i18n:translate="" class="right-aligned">Accounted Ballots</th>
@@ -162,12 +163,12 @@
             <tr tal:repeat="result election.results">
                 <tal:block condition="not: result.counted">
                     <td>${layout.format_name(result)}</td>
-                    <td tal:condition="layout.has_districts">${result.district}</td>
+                    <td tal:condition="layout.has_districts and district_name != entity_name">${result.district}</td>
                     <td class="answer" colspan="7" i18n:translate="">Not yet counted</td>
                 </tal:block>
                 <tal:block condition="result.counted">
                     <td>${layout.format_name(result)}</td>
-                    <td tal:condition="layout.has_districts">${result.district}</td>
+                    <td tal:condition="layout.has_districts and district_name != entity_name">${result.district}</td>
                     <td class="right-aligned" data-text="${result.eligible_voters}">${layout.format_number(result.eligible_voters)}</td>
                     <td class="right-aligned" data-text="${result.received_ballots}">${layout.format_number(result.received_ballots)}</td>
                     <td class="right-aligned" data-text="${result.accounted_ballots}">${layout.format_number(result.accounted_ballots)}</td>
@@ -181,7 +182,7 @@
         <tfoot tal:condition="layout.summarize">
             <tr class="total">
                 <td i18n:translate="">Total</td>
-                <td tal:condition="layout.has_districts"></td>
+                <td tal:condition="layout.has_districts and district_name != entity_name"></td>
                 <td class="right-aligned">${layout.format_number(election.eligible_voters)}</td>
                 <td class="right-aligned">${layout.format_number(election.received_ballots)}</td>
                 <td class="right-aligned">${layout.format_number(election.accounted_ballots)}</td>

--- a/src/onegov/election_day/templates/macros.pt
+++ b/src/onegov/election_day/templates/macros.pt
@@ -320,8 +320,8 @@
 </metal:answer>
 
 <metal:progress define-macro="progress" i18n:domain="onegov.election_day">
-    <tal:b i18n:translate="" condition="progress[1]">
-        <tal:b tal:switch="enable_y_n|False and progress[0] in (0, 1) and progress[1] == 1">
+    <tal:b i18n:translate="" condition="progress[1]" tal:define="show_y_n enable_y_n|False">
+        <tal:b tal:switch="python:show_y_n and progress[0] in (0, 1) and progress[1] == 1">
             <tal:b tal:case="False">
                 <span tal:replace="progress[0]" i18n:name='counted' />
                 of

--- a/tests/onegov/election_day/common.py
+++ b/tests/onegov/election_day/common.py
@@ -135,6 +135,13 @@ class DummyPostData(dict):
 
 class DummyPrincipal(object):
 
+    all_years = range(2000, 2030)
+
+    entities = {year: {
+        1: {'name': 'Entity', 'district': 'District'},
+        2: {'name': 'Entity2', 'district': 'District'}
+    } for year in all_years}
+
     def __init__(self):
         self.name = 'name'
         self.webhooks = []

--- a/tests/onegov/election_day/models/test_principal.py
+++ b/tests/onegov/election_day/models/test_principal.py
@@ -367,12 +367,23 @@ def test_principal_label(election_day_app):
     ):
         assert translate(principal.label(label), locale) == result
 
+    with freeze_time("2019-10-12 00:00"):
+        principal = Canton(name='sz', canton='sz')
+        for label, locale, result in (
+            ('entity', 'de_CH', 'Gemeinde'),
+            ('entities', 'de_CH', 'Gemeinden'),
+            ('district', 'de_CH', 'Bezirk'),
+            ('districts', 'de_CH', 'Bezirke'),
+        ):
+            assert translate(principal.label(label), locale) == result
+
+    # In 2020, sz have one entity per district so that the apear as the same
     principal = Canton(name='sz', canton='sz')
     for label, locale, result in (
         ('entity', 'de_CH', 'Gemeinde'),
         ('entities', 'de_CH', 'Gemeinden'),
-        ('district', 'de_CH', 'Bezirk'),
-        ('districts', 'de_CH', 'Bezirke'),
+        ('district', 'de_CH', 'Gemeinde'),
+        ('districts', 'de_CH', 'Gemeinden'),
     ):
         assert translate(principal.label(label), locale) == result
 


### PR DESCRIPTION
In SZ since 2020, entity and district are named the same. For elections of a compound (Kantonsratswahl), the UI has to be changed.

- Changes canton district label starting 2020 using translations
- Introduces property `district_are_entities` on `ElectionLayout`
- Changes `statistics_table` to remove district column if `district_are_entities`  is True
- Hides `candidate-by-district` if `district_are_entities` is True (the are the same)
- Changes progress macro to display e.g. "Yes" instead of "1 of 1" if flagged