### PR TITLE
ElectionDay: Modifies ElectionCompound list view

### DIFF
--- a/src/onegov/ballot/models/election/election.py
+++ b/src/onegov/ballot/models/election/election.py
@@ -286,7 +286,6 @@ class Election(Base, ContentMixin, TimestampMixin,
         if result:
             return result.district or result.name
 
-
     @property
     def votes_by_district(self):
         results = self.results.order_by(None)

--- a/src/onegov/election_day/templates/election_compound/lists.pt
+++ b/src/onegov/election_day/templates/election_compound/lists.pt
@@ -35,7 +35,7 @@
                 </div>
             </div>
 
-            <tal:block metal:use-macro="layout.macros['election-lists-table']" tal:define="election election_compound"/>
+            <tal:block metal:use-macro="layout.macros['election-compound-lists-table']" tal:define="election election_compound"/>
             <tal:block metal:use-macro="layout.macros['embedded_widget']" tal:define="embed_link layout.table_link"/>
 
         </tal:block>

--- a/src/onegov/election_day/templates/embed.pt
+++ b/src/onegov/election_day/templates/embed.pt
@@ -142,6 +142,9 @@
             <tal:b tal:condition="type == 'election-table' and scope == 'lists'">
                 <tal:b metal:use-macro="layout.macros['election-lists-table']"/>
             </tal:b>
+            <tal:b tal:condition="type == 'election-compound-table' and scope == 'lists'">
+                <tal:b metal:use-macro="layout.macros['election-compound-lists-table']"/>
+            </tal:b>
             <tal:b tal:condition="type == 'election-compound-table' and scope == 'statistics'">
                 <tal:b metal:use-macro="layout.macros['election-statistics-table']"/>
             </tal:b>

--- a/src/onegov/election_day/templates/macros.pt
+++ b/src/onegov/election_day/templates/macros.pt
@@ -295,6 +295,35 @@
     </table>
 </metal:election-lists-table>
 
+<metal:election-compound-lists-table define-macro="election-compound-lists-table" i18n:domain="onegov.election_day">
+    <table
+        class="results tablesaw sortable"
+        data-tablesaw-mode="columntoggle"
+        data-tablesaw-mode-switch="" data-tablesaw-mode-exclude="swipe"
+        data-tablesaw-minimap=""
+        >
+        <thead>
+            <tr>
+                <th data-tablesaw-priority="persist" i18n:translate="">List</th>
+                <th data-tablesaw-priority="${'0' if election.after_pukelsheim else '1'}" i18n:translate="single_votes" class="right-aligned">Votes</th>
+                <th data-tablesaw-priority="2" i18n:translate="" class="right-aligned">Mandates</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr tal:repeat="list lists">
+                <td>${list.name}</td>
+                <td class="right-aligned" data-text="${list.votes or 0}">${layout.format_number(list.votes or 0)}</td>
+                <tal:b tal:switch="python: (election.after_pukelsheim or election.completed)">
+                    <td tal:case="True" class="right-aligned">${list.number_of_mandates}</td>
+                    <td tal:case="False" class="right-aligned" i18n:translate>n.a.</td>
+
+                </tal:b>
+
+            </tr>
+        </tbody>
+    </table>
+</metal:election-compound-lists-table>
+
 <metal:embedded_widget define-macro="embedded_widget" i18n:domain="onegov.election_day">
     <div tal:condition="embed_link" class="embedded-widget"
         data-embed-link="Embed"

--- a/src/onegov/election_day/views/election_compound/lists.py
+++ b/src/onegov/election_day/views/election_compound/lists.py
@@ -61,7 +61,7 @@ def view_election_compound_lists_table(self, request):
         'election': self,
         'lists': get_list_results(self, object_session(self)),
         'layout': DefaultLayout(self, request),
-        'type': 'election-table',
+        'type': 'election-compound-table',
         'scope': 'lists',
     }
 

--- a/src/onegov/election_day/views/election_compound/lists.py
+++ b/src/onegov/election_day/views/election_compound/lists.py
@@ -18,7 +18,7 @@ def view_election_compound_lists_data(self, request):
 
     """" View the lists as JSON. Used to for the lists bar chart. """
 
-    return get_lists_data(self, request)
+    return get_lists_data(self, request, mandates_only=self.after_pukelsheim)
 
 
 @ElectionDayApp.html(

--- a/src/onegov/form/fields.py
+++ b/src/onegov/form/fields.py
@@ -1,6 +1,4 @@
 import inspect
-import re
-from datetime import timedelta
 
 import phonenumbers
 import sedate
@@ -28,6 +26,20 @@ from wtforms.fields import Field
 from wtforms.validators import DataRequired
 from wtforms.validators import InputRequired
 from wtforms.fields.html5 import DateTimeField
+from wtforms_components import TimeField as DefaultTimeField
+
+
+class TimeField(DefaultTimeField):
+    """
+    Fixes the case for MS Edge Browser that returns the 'valuelist'
+    as [08:00:000] instead of [08:00]. This is only the case of the time
+    is set with the js popup, not when switching the time
+    e.g. with the arrow keys on the form.
+    """
+
+    def process_formdata(self, valuelist):
+        valuelist = [t[:5] for t in valuelist]
+        return super().process_formdata(valuelist)
 
 
 class MultiCheckboxField(SelectMultipleField):

--- a/src/onegov/org/cli.py
+++ b/src/onegov/org/cli.py
@@ -997,8 +997,8 @@ def fix_tags(group_context, dry_run):
                 if not dry_run:
                     occurrence.tags = tags
 
-        for event in session.query(Event):
-            handle_occurrence_tags(event)
+        for event_ in session.query(Event):
+            handle_occurrence_tags(event_)
 
         for occurrence in session.query(Occurrence):
             handle_occurrence_tags(occurrence)

--- a/src/onegov/org/forms/allocation.py
+++ b/src/onegov/org/forms/allocation.py
@@ -11,7 +11,7 @@ from uuid import uuid4
 from wtforms.fields import StringField, RadioField
 from wtforms.fields.html5 import DateField, IntegerField
 from wtforms.validators import DataRequired, NumberRange, InputRequired
-from wtforms_components import TimeField
+from onegov.form.fields import TimeField
 
 
 WEEKDAYS = (

--- a/src/onegov/org/forms/event.py
+++ b/src/onegov/org/forms/event.py
@@ -15,7 +15,7 @@ from onegov.org import _
 from sedate import replace_timezone, to_timezone
 from wtforms import RadioField, StringField, TextAreaField, validators
 from wtforms.fields.html5 import DateField, EmailField
-from wtforms_components import TimeField
+from onegov.form.fields import TimeField
 
 
 TAGS = [(tag, tag) for tag in (


### PR DESCRIPTION
If the ElectionCompound is after_pukelsheim, hides by default the votes from the list table on the ElectionCompound. Also if after_pukelheim, the bar chart shows only the mandates not the sum of all ListResult.votes.

Type: Feature