### PR TITLE
Org tickets and emails 2

### DIFF
--- a/src/onegov/org/cli.py
+++ b/src/onegov/org/cli.py
@@ -1021,6 +1021,23 @@ def fix_tags(group_context, dry_run):
     return fixes_german_tags_in_db
 
 
+def close_ticket(ticket, user, request):
+    if ticket.state == 'open':
+        ticket.accept_ticket(user)
+        TicketMessage.create(
+            ticket,
+            request,
+            'opened'
+        )
+
+    TicketMessage.create(
+        ticket,
+        request,
+        'closed'
+    )
+    ticket.close_ticket()
+
+
 @cli.command('fetch')
 @pass_group_context
 @click.option('--source', multiple=True)
@@ -1184,22 +1201,6 @@ def fetch(group_context, source, tag, location, create_tickets,
                 def ticket_for_event(event_id):
                     return TicketCollection(local_session).by_handler_id(
                         event_id.hex)
-
-                def close_ticket(ticket, user, request):
-                    if ticket.state == 'open':
-                        ticket.accept_ticket(user)
-                        TicketMessage.create(
-                            ticket,
-                            request,
-                            'opened'
-                        )
-
-                    TicketMessage.create(
-                        ticket,
-                        request,
-                        'closed'
-                    )
-                    ticket.close_ticket()
 
                 helper_request = Bunch(
                     current_username=local_admin.username,

--- a/src/onegov/org/forms/settings.py
+++ b/src/onegov/org/forms/settings.py
@@ -553,16 +553,16 @@ class HolidaySettingsForm(Form):
 
 class OrgTicketSettingsForm(Form):
     ticket_auto_accepts = MultiCheckboxField(
-            label=_("Accept request and close ticket automatically "
-                    "for these ticket categories"),
-            choices=[],
-        )
+        label=_("Accept request and close ticket automatically "
+                "for these ticket categories"),
+        choices=[],
+    )
 
     tickets_skip_opening_email = MultiCheckboxField(
-            label=_("Block email confirmation when "
-                    "this ticket category is opened"),
-            choices=[],
-        )
+        label=_("Block email confirmation when "
+                "this ticket category is opened"),
+        choices=[],
+    )
 
     tickets_skip_changed_email = MultiCheckboxField(
         label=_("Block email confirmation on ticket change"),

--- a/src/onegov/org/forms/settings.py
+++ b/src/onegov/org/forms/settings.py
@@ -564,10 +564,6 @@ class OrgTicketSettingsForm(Form):
         choices=[],
     )
 
-    tickets_skip_changed_email = MultiCheckboxField(
-        label=_("Block email confirmation on ticket change"),
-        choices=[],
-    )
 
     mute_all_tickets = BooleanField(
         label=_("Mute all tickets")
@@ -577,4 +573,3 @@ class OrgTicketSettingsForm(Form):
         choices = tuple((key, key) for key in handlers.registry.keys())
         self.ticket_auto_accepts.choices = choices
         self.tickets_skip_opening_email.choices = choices
-        self.tickets_skip_changed_email.choices = choices

--- a/src/onegov/org/forms/settings.py
+++ b/src/onegov/org/forms/settings.py
@@ -19,6 +19,7 @@ from wtforms import validators
 from wtforms.fields.html5 import EmailField, URLField
 from wtforms_components import ColorField
 
+from onegov.ticket import handlers
 
 ERROR_LINE_RE = re.compile(r'line ([0-9]+)')
 
@@ -548,3 +549,32 @@ class HolidaySettingsForm(Form):
     def process_obj(self, model):
         super().process_obj(model)
         self.holiday_settings = model.holiday_settings
+
+
+class OrgTicketSettingsForm(Form):
+    ticket_auto_accepts = MultiCheckboxField(
+            label=_("Accept request and close ticket automatically "
+                    "for these ticket categories"),
+            choices=[],
+        )
+
+    tickets_skip_opening_email = MultiCheckboxField(
+            label=_("Block email confirmation when "
+                    "this ticket category is opened"),
+            choices=[],
+        )
+
+    tickets_skip_changed_email = MultiCheckboxField(
+        label=_("Block email confirmation on ticket change"),
+        choices=[],
+    )
+
+    mute_all_tickets = BooleanField(
+        label=_("Mute all tickets")
+    )
+
+    def on_request(self):
+        choices = tuple((key, key) for key in handlers.registry.keys())
+        self.ticket_auto_accepts.choices = choices
+        self.tickets_skip_opening_email.choices = choices
+        self.tickets_skip_changed_email.choices = choices

--- a/src/onegov/org/forms/settings.py
+++ b/src/onegov/org/forms/settings.py
@@ -564,7 +564,6 @@ class OrgTicketSettingsForm(Form):
         choices=[],
     )
 
-
     mute_all_tickets = BooleanField(
         label=_("Mute all tickets")
     )

--- a/src/onegov/org/locale/de_CH/LC_MESSAGES/onegov.org.po
+++ b/src/onegov/org/locale/de_CH/LC_MESSAGES/onegov.org.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE 1.0\n"
-"POT-Creation-Date: 2020-05-06 04:22+0200\n"
+"POT-Creation-Date: 2020-05-06 11:00+0200\n"
 "PO-Revision-Date: 2020-04-09 05:55+0200\n"
 "Last-Translator: Marc Sommerhalder <marc.sommerhalder@seantis.ch>\n"
 "Language-Team: German\n"
@@ -3302,6 +3302,10 @@ msgstr "Ungültige Adresse oder abgelaufener Link."
 
 msgid "A link was added to the clipboard"
 msgstr "Ein Verweis wurde in die Zwischenablage kopiert"
+
+#, python-format
+msgid "The entry ${name} exists twice"
+msgstr "Der Eintrag ${name} existiert zweimal"
 
 msgid "Added a new directory"
 msgstr "Ein neues Verzeichnis wurde hinzugefügt"

--- a/src/onegov/org/locale/de_CH/LC_MESSAGES/onegov.org.po
+++ b/src/onegov/org/locale/de_CH/LC_MESSAGES/onegov.org.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE 1.0\n"
-"POT-Creation-Date: 2020-05-06 14:06+0200\n"
+"POT-Creation-Date: 2020-05-06 17:22+0200\n"
 "PO-Revision-Date: 2020-04-09 05:55+0200\n"
 "Last-Translator: Marc Sommerhalder <marc.sommerhalder@seantis.ch>\n"
 "Language-Team: German\n"
@@ -1081,6 +1081,9 @@ msgstr "Akteptiere und schliesse Ticket automatisch für diese Kategorien"
 
 msgid "Block email confirmation when this ticket category is opened"
 msgstr "Keine Email-Benachrichtung nach Eröffnung dieser Ticket-Kategorie"
+
+msgid "Mute all tickets"
+msgstr "Email-Benachrichtigungen für alle Tickets deaktivieren"
 
 msgid "E-Mail Address"
 msgstr "E-Mail Adresse"
@@ -3422,6 +3425,9 @@ msgstr ""
 "Veranstaltungen. Es besteht kein Publikationsrecht und bereits publizierte "
 "Veranstaltungen können jederzeit und ohne Angabe von Gründen gelöscht werden."
 
+msgid "Your request could not be accepted automatically!"
+msgstr "Ihre Anfrage konnte nicht automatisch verarbeitet werden!"
+
 msgid "Your ticket has been opened"
 msgstr "Ihr Ticket wurde eröffnet"
 
@@ -3868,6 +3874,14 @@ msgstr "Feiertage"
 msgid "Ticket Settings"
 msgstr "Ticket-Einstellungen"
 
+#, python-format
+msgid ""
+"The feature to automatically close tickets and accept their items is "
+"experimental. It works for ${handler_codes}."
+msgstr ""
+"Die Funktion für das automatische Schliessen der Tickets und das "
+"Akzeptieren ihrer Objekte ist experimentall. Es funktioniert für "
+"${handler_codes}."
 msgid "No holidays defined"
 msgstr "Keine Feiertage definiert"
 
@@ -4025,6 +4039,9 @@ msgstr "Der Benutzer wurde erfolgreich erstellt"
 
 msgid "You have been successfully unsubscribed from all regular emails."
 msgstr "Sie wurden erfolgreich von allen regelmässigen E-Mails abgemeldet."
+
+#~ msgid "Block email confirmation on ticket change"
+#~ msgstr "Keine Email-Benachrichtigung bei Änderung (aus"
 
 #~ msgid "Messages cannot be sent for imported tickets"
 #~ msgstr "Zu importierten Events können keine Nachrichten gesendet werden"

--- a/src/onegov/org/locale/de_CH/LC_MESSAGES/onegov.org.po
+++ b/src/onegov/org/locale/de_CH/LC_MESSAGES/onegov.org.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE 1.0\n"
-"POT-Creation-Date: 2020-04-29 14:29+0200\n"
+"POT-Creation-Date: 2020-04-30 12:29+0200\n"
 "PO-Revision-Date: 2020-04-09 05:55+0200\n"
 "Last-Translator: Marc Sommerhalder <marc.sommerhalder@seantis.ch>\n"
 "Language-Team: German\n"
@@ -3271,6 +3271,10 @@ msgstr "Ungültige Adresse oder abgelaufener Link."
 msgid "A link was added to the clipboard"
 msgstr "Ein Verweis wurde in die Zwischenablage kopiert"
 
+#, python-format
+msgid "The entry ${name} exists twice"
+msgstr "Der Eintrag ${name} existiert zweimal"
+
 msgid "Added a new directory"
 msgstr "Ein neues Verzeichnis wurde hinzugefügt"
 
@@ -3326,10 +3330,6 @@ msgstr "Die Spalte ${name} fehlt"
 #, python-format
 msgid "The file ${name} is missing"
 msgstr "Die Datei ${name} fehlt"
-
-#, python-format
-msgid "The entry ${name} exists twice"
-msgstr "Der Eintrag ${name} existiert zweimal"
 
 msgid ""
 "The given file is invalid, does it include a metadata.json with a data.xlsx, "
@@ -3904,6 +3904,9 @@ msgstr "Sie haben das Ticket ${number} abgeschlossen"
 
 msgid "Your ticket has been closed"
 msgstr "Ihr Ticket wurde geschlossen"
+
+msgid "The submitter email is not available"
+msgstr "Die Email des Antragstellers fehlt"
 
 msgid "The ticket cannot be re-opened because it's not closed"
 msgstr ""

--- a/src/onegov/org/locale/de_CH/LC_MESSAGES/onegov.org.po
+++ b/src/onegov/org/locale/de_CH/LC_MESSAGES/onegov.org.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE 1.0\n"
-"POT-Creation-Date: 2020-05-06 11:00+0200\n"
+"POT-Creation-Date: 2020-05-06 14:06+0200\n"
 "PO-Revision-Date: 2020-04-09 05:55+0200\n"
 "Last-Translator: Marc Sommerhalder <marc.sommerhalder@seantis.ch>\n"
 "Language-Team: German\n"
@@ -1074,6 +1074,13 @@ msgstr "Bitte geben Sie ein Datum pro Zeile ein"
 
 msgid "Please enter only day and month"
 msgstr "Bitte geben Sie nur Tag und Monat ein"
+
+msgid ""
+"Accept request and close ticket automatically for these ticket categories"
+msgstr "Akteptiere und schliesse Ticket automatisch für diese Kategorien"
+
+msgid "Block email confirmation when this ticket category is opened"
+msgstr "Keine Email-Benachrichtung nach Eröffnung dieser Ticket-Kategorie"
 
 msgid "E-Mail Address"
 msgstr "E-Mail Adresse"
@@ -2209,6 +2216,13 @@ msgstr ""
 "Ihre Anfrage wird in Kürze bearbeitet. Sie können jederzeit zu dieser Seite "
 "zurückkehren um den Status Ihrer Anfrage abzufragen. Alle Informationen auf "
 "dieser Seite wurde an Ihre E-Mail Adresse gesendet."
+
+msgid ""
+"Your request will be processed shortly. To see the state of your process "
+"your may return to this page at any time."
+msgstr ""
+"Ihre Anfrage wird in Kürze bearbeitet. Sie können jederzeit zu dieser Seite "
+"zurückkehren um den Status Ihrer Anfrage abzufragen."
 
 msgid ""
 "Your request has been completed. If you asked for documents to be sent to "
@@ -3850,6 +3864,9 @@ msgstr "Web-Statistik"
 
 msgid "Holidays"
 msgstr "Feiertage"
+
+msgid "Ticket Settings"
+msgstr "Ticket-Einstellungen"
 
 msgid "No holidays defined"
 msgstr "Keine Feiertage definiert"

--- a/src/onegov/org/locale/fr_CH/LC_MESSAGES/onegov.org.po
+++ b/src/onegov/org/locale/fr_CH/LC_MESSAGES/onegov.org.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE 1.0\n"
-"POT-Creation-Date: 2020-04-29 14:29+0200\n"
+"POT-Creation-Date: 2020-04-30 12:29+0200\n"
 "PO-Revision-Date: 2020-03-17 11:04+0100\n"
 "Last-Translator: Marc Sommerhalder <marc.sommerhalder@seantis.ch>\n"
 "Language-Team: French\n"
@@ -3289,6 +3289,10 @@ msgstr ""
 msgid "A link was added to the clipboard"
 msgstr "Un lien a été ajouté au presse-papiers"
 
+#, python-format
+msgid "The entry ${name} exists twice"
+msgstr "L'entrée ${name} existe deux fois"
+
 msgid "Added a new directory"
 msgstr "Ajout d'un nouveau dossier"
 
@@ -3344,10 +3348,6 @@ msgstr "La colonne ${name} est manquante"
 #, python-format
 msgid "The file ${name} is missing"
 msgstr "Le fichier ${name} est manquante"
-
-#, python-format
-msgid "The entry ${name} exists twice"
-msgstr "L'entrée ${name} existe deux fois"
 
 msgid ""
 "The given file is invalid, does it include a metadata.json with a data.xlsx, "
@@ -3923,6 +3923,9 @@ msgstr "Vous avez clôturé ${number} ticket(s)"
 
 msgid "Your ticket has been closed"
 msgstr "Votre ticket a été fermé"
+
+msgid "The submitter email is not available"
+msgstr "L'adresse e-mail de l'expéditeur n'est pas disponible"
 
 msgid "The ticket cannot be re-opened because it's not closed"
 msgstr "Le ticket ne peut pas être réouvert car il n'est pas clôturé"

--- a/src/onegov/org/locale/fr_CH/LC_MESSAGES/onegov.org.po
+++ b/src/onegov/org/locale/fr_CH/LC_MESSAGES/onegov.org.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE 1.0\n"
-"POT-Creation-Date: 2020-05-06 14:06+0200\n"
+"POT-Creation-Date: 2020-05-06 17:22+0200\n"
 "PO-Revision-Date: 2020-03-17 11:04+0100\n"
 "Last-Translator: Marc Sommerhalder <marc.sommerhalder@seantis.ch>\n"
 "Language-Team: French\n"
@@ -1087,8 +1087,10 @@ msgstr ""
 "Accepter la demande et fermer le ticket automatiquement pour ces catégories"
 
 msgid "Block email confirmation when this ticket category is opened"
-msgstr ""
-"N'envoyez pas d'e-mail lorsque cette catégorie de billets est ouverte"
+msgstr "N'envoyez pas d'e-mail lorsque cette catégorie de billets est ouverte"
+
+msgid "Mute all tickets"
+msgstr "Désactiver tous les emails de statut pour les tickets"
 
 msgid "E-Mail Address"
 msgstr "Adresse e-mail"
@@ -3441,6 +3443,9 @@ msgstr ""
 "ne sont pas publiés. Il n'ont aucuns droits à être publiés et les événements "
 "déjà publiés peuvent être supprimés de la page sans notification ni motif."
 
+msgid "Your request could not be accepted automatically!"
+msgstr "Votre demande n'a pas pu être traitée automatiquement."
+
 msgid "Your ticket has been opened"
 msgstr "Votre ticket a été ouvert"
 
@@ -3889,6 +3894,14 @@ msgstr "Jours fériés"
 
 msgid "Ticket Settings"
 msgstr "Paramètres tickets"
+
+#, python-format
+msgid ""
+"The feature to automatically close tickets and accept their items is "
+"experimental. It works for ${handler_codes}."
+msgstr ""
+"La fonction permettant de fermer automatiquement les tickets et "
+"d'accepter leurs articles est expérimentale. Il fonctionne pour ${handler_codes}."
 
 msgid "No holidays defined"
 msgstr "Aucun jour férié défini"

--- a/src/onegov/org/locale/fr_CH/LC_MESSAGES/onegov.org.po
+++ b/src/onegov/org/locale/fr_CH/LC_MESSAGES/onegov.org.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE 1.0\n"
-"POT-Creation-Date: 2020-05-06 11:00+0200\n"
+"POT-Creation-Date: 2020-05-06 14:06+0200\n"
 "PO-Revision-Date: 2020-03-17 11:04+0100\n"
 "Last-Translator: Marc Sommerhalder <marc.sommerhalder@seantis.ch>\n"
 "Language-Team: French\n"
@@ -1080,6 +1080,15 @@ msgstr "Veuillez renseigner une date par ligne"
 
 msgid "Please enter only day and month"
 msgstr "Veuillez ne renseigner que des jours et des mois"
+
+msgid ""
+"Accept request and close ticket automatically for these ticket categories"
+msgstr ""
+"Accepter la demande et fermer le ticket automatiquement pour ces catégories"
+
+msgid "Block email confirmation when this ticket category is opened"
+msgstr ""
+"N'envoyez pas d'e-mail lorsque cette catégorie de billets est ouverte"
 
 msgid "E-Mail Address"
 msgstr "Adresse e-mail"
@@ -2215,6 +2224,11 @@ msgstr ""
 "Votre demande va être traitée sous peu. Pour suivre l'état d'avancement, "
 "vous pouvez revenir sur cette page à tout moment. Toutes les informations "
 "présentes sur cette page ont été envoyées à votre adresse e-mail."
+
+msgid ""
+"Your request will be processed shortly. To see the state of your process "
+"your may return to this page at any time."
+msgstr ""
 
 msgid ""
 "Your request has been completed. If you asked for documents to be sent to "
@@ -3872,6 +3886,9 @@ msgstr "Analytics"
 
 msgid "Holidays"
 msgstr "Jours fériés"
+
+msgid "Ticket Settings"
+msgstr "Paramètres tickets"
 
 msgid "No holidays defined"
 msgstr "Aucun jour férié défini"

--- a/src/onegov/org/locale/fr_CH/LC_MESSAGES/onegov.org.po
+++ b/src/onegov/org/locale/fr_CH/LC_MESSAGES/onegov.org.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE 1.0\n"
-"POT-Creation-Date: 2020-05-06 04:22+0200\n"
+"POT-Creation-Date: 2020-05-06 11:00+0200\n"
 "PO-Revision-Date: 2020-03-17 11:04+0100\n"
 "Last-Translator: Marc Sommerhalder <marc.sommerhalder@seantis.ch>\n"
 "Language-Team: French\n"
@@ -1723,6 +1723,7 @@ msgstr "Refuser la réservation"
 
 #. Used in sentence: "${event} published."
 #. Used in sentence: "${event} deleted."
+#. Used in sentence: "${event} withdrawn."
 #.
 msgid "Event"
 msgstr "Événement"
@@ -2973,7 +2974,8 @@ msgid "Enable E-Mails"
 msgstr "Activer les e-mails"
 
 msgid "E-Mails can not be sent for tickets of imported events"
-msgstr "E-Mails ne peuvent pas être envoyés pour les tickets d'événements importés"
+msgstr ""
+"E-Mails ne peuvent pas être envoyés pour les tickets d'événements importés"
 
 msgid "Send Message"
 msgstr "Envoyer le message"
@@ -2985,7 +2987,8 @@ msgid "Please reopen the ticket to send a message"
 msgstr "Veuillez rouvrir le ticket pour envoyer un message."
 
 msgid "Messages cannot be sent for imported events"
-msgstr "Messages ne peuvent pas être envoyés pour les tickets d'événements importés"
+msgstr ""
+"Messages ne peuvent pas être envoyés pour les tickets d'événements importés"
 
 msgid "${count} received"
 msgstr "${count} reçu(s)"

--- a/src/onegov/org/mail.py
+++ b/src/onegov/org/mail.py
@@ -58,11 +58,6 @@ def send_ticket_mail(request, template, subject, receivers, ticket,
         if opened and ticket.handler_code in skip_handler_codes:
             return
 
-        skip_handler_codes = org.tickets_skip_changed_email or []
-        changed = ticket.state == 'pending'
-        if changed and ticket.handler_code in skip_handler_codes:
-            return
-
         if request.current_username in receivers:
             if len(receivers) == 1:
                 return

--- a/src/onegov/org/mail.py
+++ b/src/onegov/org/mail.py
@@ -44,10 +44,23 @@ def send_marketing_html_mail(*args, **kwargs):
 
 def send_ticket_mail(request, template, subject, receivers, ticket,
                      content=None, force=False, **kwargs):
-
+    org = request.app.org
     if not force:
 
+        if request.app.org.mute_all_tickets:
+            return
+
         if ticket.muted:
+            return
+
+        skip_handler_codes = org.tickets_mute_mails_for_states or []
+        opened = ticket.state == 'open'
+        if opened and ticket.handler_code in skip_handler_codes:
+            return
+
+        skip_handler_codes = org.tickets_skip_changed_email or []
+        changed = ticket.state == 'pending'
+        if changed and ticket.handler_code in skip_handler_codes:
             return
 
         if request.current_username in receivers:

--- a/src/onegov/org/mail.py
+++ b/src/onegov/org/mail.py
@@ -47,13 +47,13 @@ def send_ticket_mail(request, template, subject, receivers, ticket,
     org = request.app.org
     if not force:
 
-        if request.app.org.mute_all_tickets:
+        if org.mute_all_tickets:
             return
 
         if ticket.muted:
             return
 
-        skip_handler_codes = org.tickets_mute_mails_for_states or []
+        skip_handler_codes = org.tickets_skip_opening_email or []
         opened = ticket.state == 'open'
         if opened and ticket.handler_code in skip_handler_codes:
             return

--- a/src/onegov/org/models/organisation.py
+++ b/src/onegov/org/models/organisation.py
@@ -96,7 +96,6 @@ class Organisation(Base, TimestampMixin):
     # Ticket options
     ticket_auto_accepts = meta_property()
     tickets_skip_opening_email = meta_property()
-    tickets_skip_changed_email = meta_property()
     mute_all_tickets = meta_property()
 
     @property

--- a/src/onegov/org/models/organisation.py
+++ b/src/onegov/org/models/organisation.py
@@ -93,6 +93,12 @@ class Organisation(Base, TimestampMixin):
     partner_4_url = meta_property()
     partner_4_name = meta_property()
 
+    # Ticket options
+    ticket_auto_accepts = meta_property()
+    tickets_skip_opening_email = meta_property()
+    tickets_skip_changed_email = meta_property()
+    mute_all_tickets = meta_property()
+
     @property
     def public_identity(self):
         """ The public identity is a globally unique SHA 256 hash of the

--- a/src/onegov/org/models/ticket.py
+++ b/src/onegov/org/models/ticket.py
@@ -280,6 +280,8 @@ class ReservationHandler(Handler):
 
     @cached_property
     def resource(self):
+        if self.deleted:
+            return None
         query = self.session.query(Resource)
         query = query.filter(Resource.id == self.reservations[0].resource)
 
@@ -318,6 +320,8 @@ class ReservationHandler(Handler):
     @property
     def email(self):
         # the e-mail is the same over all reservations
+        if self.deleted:
+            return self.ticket.snapshot.get('email')
         return self.reservations[0].email
 
     @property

--- a/src/onegov/org/request.py
+++ b/src/onegov/org/request.py
@@ -46,4 +46,4 @@ class OrgRequest(CoreRequest):
             User.created).first()
 
     def auto_accept(self, ticket):
-        return ticket.handler_code in self.app.org.ticket_auto_accepts
+        return ticket.handler_code in (self.app.org.ticket_auto_accepts or [])

--- a/src/onegov/org/request.py
+++ b/src/onegov/org/request.py
@@ -39,3 +39,11 @@ class OrgRequest(CoreRequest):
         if self.identity:
             return self.session.query(User) \
                 .filter_by(username=self.identity.userid).first()
+
+    @cached_property
+    def first_admin_available(self):
+        return self.session.query(User).filter_by(role='admin').order_by(
+            User.created).first()
+
+    def auto_accept(self, ticket):
+        return ticket.handler_code in self.app.org.ticket_auto_accepts

--- a/src/onegov/org/templates/form.pt
+++ b/src/onegov/org/templates/form.pt
@@ -22,6 +22,12 @@
             }[econtext.get('form_width', 'normal')]
         ?>
 
+        <tal:b tal:condition="warning_msg|nothing">
+            <div class="panel callout">
+                <tal:block replace="structure warning_msg" />
+            </div>
+        </tal:b>
+
         <tal:b tal:define="item definition|nothing" tal:condition="item">
             <div class="resource-group blank-label" tal:condition="item.group|nothing">
                 ${item.group}

--- a/src/onegov/org/templates/macros.pt
+++ b/src/onegov/org/templates/macros.pt
@@ -1223,9 +1223,9 @@
 </metal:search_result_default>
 
 
-<metal:ticket_status_page_message define-macro="ticket_status_page_message" i18n:domain="onegov.org">
+<metal:ticket_status_page_message define-macro="ticket_status_page_message" i18n:domain="onegov.org" tal:define="mute_all request.app.org.mute_all_tickets; skip request.app.org.tickets_skip_opening_email or []">
     <tal:b tal:condition="ticket.state == 'open'">
-        <tal:b tal:switch="python: not request.app.org.mute_all_tickets and ticket.handler_code in request.app.org.tickets_skip_opening_email or []">
+        <tal:b tal:switch="not mute_all and ticket.handler_code in skip">
             <p tal:case="False" i18n:translate>
                 Your request will be processed shortly. To see the state of
                 your process your may return to this page at any time.

--- a/src/onegov/org/templates/macros.pt
+++ b/src/onegov/org/templates/macros.pt
@@ -1224,12 +1224,21 @@
 
 
 <metal:ticket_status_page_message define-macro="ticket_status_page_message" i18n:domain="onegov.org">
-    <p i18n:translate tal:condition="ticket.state == 'open'">
-        Your request will be processed shortly. To see the state of
-        your process your may return to this page at any time.
+    <tal:b tal:condition="ticket.state == 'open'">
+        <tal:b tal:switch="python: not request.app.org.mute_all_tickets and ticket.handler_code in request.app.org.tickets_skip_opening_email or []">
+            <p tal:case="False" i18n:translate>
+                Your request will be processed shortly. To see the state of
+                your process your may return to this page at any time.
 
-        All information on this page has been sent to your e-mail address.
-    </p>
+                All information on this page has been sent to your e-mail address.
+            </p>
+            <p tal:case="True" i18n:translate>
+                Your request will be processed shortly. To see the state of
+                your process your may return to this page at any time.
+            </p>
+        </tal:b>
+    </tal:b>
+
     <p i18n:translate tal:condition="ticket.state == 'closed'">
         Your request has been completed. If you asked for documents to be
         sent to your address, they should arrive shortly. If you asked to

--- a/src/onegov/org/views/event.py
+++ b/src/onegov/org/views/event.py
@@ -5,6 +5,7 @@ from morepath.request import Response
 from onegov.core.security import Private, Public
 from onegov.event import Event, EventCollection, OccurrenceCollection
 from onegov.org import _, OrgApp
+from onegov.org.cli import close_ticket
 from onegov.org.elements import Link
 from onegov.org.forms import EventForm
 from onegov.org.layout import EventLayout
@@ -179,6 +180,14 @@ def view_event(self, request):
                 handler_code='EVN', handler_id=self.id.hex
             )
             TicketMessage.create(ticket, request, 'opened')
+
+        if request.auto_accept(ticket):
+            try:
+                close_ticket(ticket, request.first_admin_available, request)
+                request.view(self, name='publish')
+            except Exception:
+                request.warning(_("Your event could not be "
+                                  "accepted automatically!"))
 
         send_ticket_mail(
             request=request,

--- a/src/onegov/org/views/event.py
+++ b/src/onegov/org/views/event.py
@@ -186,7 +186,7 @@ def view_event(self, request):
                 close_ticket(ticket, request.first_admin_available, request)
                 request.view(self, name='publish')
             except Exception:
-                request.warning(_("Your event could not be "
+                request.warning(_("Your request could not be "
                                   "accepted automatically!"))
 
         send_ticket_mail(

--- a/src/onegov/org/views/reservation.py
+++ b/src/onegov/org/views/reservation.py
@@ -83,7 +83,7 @@ def reserve_allocation(self, request):
 
     Does not actually reserve anything, just keeps a list of things to
     reserve later. Though it will still check if the reservation is
-    feasable.
+    feasible.
 
     """
 
@@ -171,8 +171,12 @@ def delete_reservation(self, request):
 
     # this view is public, but only for a limited time
     assert_anonymous_access_only_temporary(resource, self, request)
+    tickets = TicketCollection(request.session)
+    ticket = tickets.by_handler_id(self.token.hex)
 
     try:
+        if ticket:
+            ticket.create_snapshot(request)
         resource.scheduler.remove_reservation(self.token, self.id)
     except LibresError as e:
         message = {

--- a/src/onegov/org/views/reservation.py
+++ b/src/onegov/org/views/reservation.py
@@ -442,7 +442,7 @@ def finalize_reservation(self, request):
                 close_ticket(ticket, request.first_admin_available, request)
                 request.view(reservations[0], name='accept')
             except Exception:
-                request.warning(_("Your reservation could not be "
+                request.warning(_("Your request could not be "
                                   "accepted automatically!"))
         send_ticket_mail(
             request=request,

--- a/src/onegov/org/views/settings.py
+++ b/src/onegov/org/views/settings.py
@@ -131,7 +131,8 @@ def handle_ticket_settings(self, request, form):
     resp = handle_generic_settings(self, request, form, _("Ticket Settings"))
     resp['warning_msg'] = _(
         "The feature to automatically close tickets and accept their items "
-        "is experimental. It works for reservations (RSV) tickets for now."
+        "is experimental. It works for ${handler_codes}.",
+        mapping={'handler_codes': ", ".join(('RSV', 'EVN'))}
     )
     return resp
 

--- a/src/onegov/org/views/settings.py
+++ b/src/onegov/org/views/settings.py
@@ -128,7 +128,12 @@ def handle_holiday_settings(self, request, form):
     setting=_("Ticket Settings"), order=-950, icon='fa-ticket'
 )
 def handle_ticket_settings(self, request, form):
-    return handle_generic_settings(self, request, form, _("Ticket Settings"))
+    resp = handle_generic_settings(self, request, form, _("Ticket Settings"))
+    resp['warning_msg'] = _(
+        "The feature to automatically close tickets and accept their items "
+        "is experimental. It works for reservations (RSV) tickets for now."
+    )
+    return resp
 
 
 @OrgApp.form(model=Organisation, name='holiday-settings-preview',

--- a/src/onegov/org/views/settings.py
+++ b/src/onegov/org/views/settings.py
@@ -13,6 +13,7 @@ from onegov.org.forms import HolidaySettingsForm
 from onegov.org.forms import HomepageSettingsForm
 from onegov.org.forms import MapSettingsForm
 from onegov.org.forms import ModuleSettingsForm
+from onegov.org.forms.settings import OrgTicketSettingsForm
 from onegov.org.layout import DefaultLayout
 from onegov.org.layout import SettingsLayout
 from onegov.org.models import Organisation
@@ -119,6 +120,15 @@ def handle_analytics_settings(self, request, form):
     icon='fa-calendar-o', order=-500)
 def handle_holiday_settings(self, request, form):
     return handle_generic_settings(self, request, form, _("Holidays"))
+
+
+@OrgApp.form(
+    model=Organisation, name='ticket-settings', template='form.pt',
+    permission=Secret, form=OrgTicketSettingsForm,
+    setting=_("Ticket Settings"), order=-950, icon='fa-ticket'
+)
+def handle_ticket_settings(self, request, form):
+    return handle_generic_settings(self, request, form, _("Ticket Settings"))
 
 
 @OrgApp.form(model=Organisation, name='holiday-settings-preview',


### PR DESCRIPTION
Originates from a branch that included fixes for missing reservation snapshots. Adds Ticket Settings for sending tickets. For example the confirmation email when a ticket has been opened was not considered useful by clients. Emails can also be muted globally for all tickets. As experimental feature, in the ticket creation process for reservations of a resource and events, a global setting can intervene and before the email sending, changing the status of the ticket to closed and accepting the corresponding reservations (all of them) or the event. Then the user can get his confirmation email and directly see the ticket status as closed (same view routine e.g. for a resource). For any other type of ticket than RSV and EVN, the small code snippet to close the ticket and trigger the accept view, can be implemented later, if wished.