### PR TITLE
Mapbox leaflet update

### DIFF
--- a/src/onegov/gis/assets/js/leaflet-integration.js
+++ b/src/onegov/gis/assets/js/leaflet-integration.js
@@ -298,12 +298,14 @@ function addGeocoder(map) {
 }
 
 function getMapboxTiles() {
-    var url = 'https://api.mapbox.com/v4/mapbox.streets/{z}/{x}/{y}';
-    url += (L.Browser.retina ? '@2x.png' : '.png');
-    url += '?access_token=' + getMapboxToken();
+    var url = 'https://api.mapbox.com/styles/v1/{id}/tiles/{z}/{x}/{y}?access_token={accessToken}';
 
     return L.tileLayer(url, {
-        attribution: '<ul><li><a href="https://www.mapbox.com/map-feedback/">© Mapbox</a></li><li><a href="http://www.openstreetmap.org/copyright">© OpenStreetMap</a></li></ul>'
+        attribution: '<ul><li><a href="https://www.mapbox.com/map-feedback/">© Mapbox</a></li><li><a href="http://www.openstreetmap.org/copyright">© OpenStreetMap</a></li></ul>',
+        tileSize: 512,
+        zoomOffset: -1,
+        id: 'mapbox/streets-v11',
+        accessToken: getMapboxToken()
     });
 }
 

--- a/src/onegov/swissvotes/external_sources.py
+++ b/src/onegov/swissvotes/external_sources.py
@@ -47,6 +47,11 @@ def fetch_changed(poster_urls, image_urls, api_key):
             continue
         try:
             img_url = parse_xml(resp)
+
+            if not img_url:
+                failed += 1
+                continue
+
             # eMuseum should deliver urls as https when they redirect anyway
             img_url = img_url.replace('http:', 'https:')
         except ElementTree.ParseError:


### PR DESCRIPTION
Updates the leaflet integration for the streets api of mapbox, see https://docs.mapbox.com/help/troubleshooting/migrate-legacy-static-tiles-api/?/=blog&utm_source=mapbox-blog&utm_campaign=blog%7Cmapbox-blog%7Cdoc-migrate-static%7Cdeprecating-studio-classic-styles-d8892ac38cb4-20-03&utm_term=doc-migrate-static&utm_content=deprecating-studio-classic-styles-d8892ac38cb4#leaflet-implementations