### PR TITLE
Adds turnout to summaries and archived results

### DIFF
--- a/src/onegov/election_day/collections/archived_results.py
+++ b/src/onegov/election_day/collections/archived_results.py
@@ -181,6 +181,7 @@ class ArchivedResultCollection(object):
 
         if isinstance(item, Election):
             result.type = 'election'
+            result.turnout = item.turnout
             result.elected_candidates = item.elected_candidates
             for association in item.associations:
                 self.update(association.election_compound, request)
@@ -193,6 +194,7 @@ class ArchivedResultCollection(object):
 
         if isinstance(item, Vote):
             result.type = 'vote'
+            result.turnout = item.turnout
             result.answer = item.answer
             result.nays_percentage = item.nays_percentage
             result.yeas_percentage = item.yeas_percentage

--- a/src/onegov/election_day/models/archived_result.py
+++ b/src/onegov/election_day/models/archived_result.py
@@ -125,6 +125,9 @@ class ArchivedResult(Base, ContentMixin, TimestampMixin,
     #: True, if the vote or election has been completed.
     completed = meta_property('completed', default=False)
 
+    #: Turnout (vote/elections)
+    turnout = meta_property('turnout')
+
     #: The local results (municipal results if fetched from cantonal instance)
     local = meta_property('local')
 

--- a/src/onegov/election_day/utils/summaries.py
+++ b/src/onegov/election_day/utils/summaries.py
@@ -23,6 +23,7 @@ def get_election_summary(election, request, url=None):
             'total': election.progress[1] or 0
         },
         'title': election.title_translations,
+        'turnout': election.turnout,
         'type': 'election',
         'url': url or request.link(election),
     }
@@ -82,6 +83,7 @@ def get_vote_summary(vote, request, url=None):
             'total': (vote.progress[1] or 0) / divider
         },
         'title': vote.title_translations,
+        'turnout': vote.turnout,
         'type': 'vote',
         'url': url or request.link(vote),
         'yeas_percentage': yeas_percentage,

--- a/tests/onegov/election_day/models/test_archived_result.py
+++ b/tests/onegov/election_day/models/test_archived_result.py
@@ -25,6 +25,7 @@ def test_archived_result(session):
     result.yeas_percentage = 79.5
     result.counted = True
     result.completed = True
+    result.turnout = 50
 
     session.add(result)
     session.flush()
@@ -63,7 +64,8 @@ def test_archived_result(session):
         'counted': True,
         'completed': True,
         'elected_candidates': [('Joe', 'Quimby')],
-        'elections': ['https://localhost/1', 'https://localhost/1']
+        'elections': ['https://localhost/1', 'https://localhost/1'],
+        'turnout': 50
     }
 
     # Test progress
@@ -126,7 +128,8 @@ def test_archived_result(session):
         'counted': True,
         'completed': True,
         'elected_candidates': [('Joe', 'Quimby')],
-        'elections': ['https://localhost/1', 'https://localhost/1']
+        'elections': ['https://localhost/1', 'https://localhost/1'],
+        'turnout': 50
     }
     assert copied.shortcode == 'shortcode'
 

--- a/tests/onegov/election_day/models/test_notification.py
+++ b/tests/onegov/election_day/models/test_notification.py
@@ -146,7 +146,8 @@ def test_webhook_notification(session):
                 'progress': {'counted': 0, 'total': 0},
                 'title': {'de_CH': 'Election'},
                 'type': 'election',
-                'url': 'Election/election'
+                'url': 'Election/election',
+                'turnout': 0
             }
 
             notification.trigger(request, vote)
@@ -169,7 +170,8 @@ def test_webhook_notification(session):
                 'title': {'de_CH': 'Vote'},
                 'type': 'vote',
                 'url': 'Vote/vote',
-                'yeas_percentage': None
+                'yeas_percentage': None,
+                'turnout': 0
             }
 
 

--- a/tests/onegov/election_day/utils/test_summaries.py
+++ b/tests/onegov/election_day/utils/test_summaries.py
@@ -37,6 +37,7 @@ def test_get_election_summary(session):
             'title': {'de_CH': 'Election'},
             'type': 'election',
             'url': 'Election/election',
+            'turnout': 0
         }
         assert expected == get_election_summary(election, request)
         assert expected == get_election_summary(result, None,
@@ -117,6 +118,7 @@ def test_get_vote_summary(session):
             'type': 'vote',
             'url': 'Vote/vote',
             'yeas_percentage': None,
+            'turnout': 0
         }
         assert expected == get_vote_summary(vote, request)
         assert expected == get_vote_summary(result, None, request.link(vote))

--- a/tests/onegov/election_day/views/test_views_election.py
+++ b/tests/onegov/election_day/views/test_views_election.py
@@ -568,6 +568,7 @@ def test_view_election_summary(election_day_app_gr):
             'title': {'de_CH': 'Majorz Election'},
             'type': 'election',
             'url': 'http://localhost/election/majorz-election',
+            'turnout': 44.642857142857146
         }
 
         response = client.get('/election/proporz-election/summary')
@@ -582,6 +583,7 @@ def test_view_election_summary(election_day_app_gr):
             'title': {'de_CH': 'Proporz Election'},
             'type': 'election',
             'url': 'http://localhost/election/proporz-election',
+            'turnout': 57.14285714285714
         }
 
 

--- a/tests/onegov/election_day/views/test_views_vote.py
+++ b/tests/onegov/election_day/views/test_views_vote.py
@@ -116,6 +116,7 @@ def test_view_vote_summary(election_day_app):
             'type': 'vote',
             'url': 'http://localhost/vote/vote',
             'yeas_percentage': 37.21191933741448,
+            'turnout': 61.34161218251847
         }
 
 


### PR DESCRIPTION
- Update all items calling url /update-results
- no need for a migration (we would need the request object anyway)