### PR TITLE
Directory markdown field comments

### DIFF
--- a/src/onegov/form/core.py
+++ b/src/onegov/form/core.py
@@ -3,6 +3,8 @@ import weakref
 from collections import OrderedDict
 from decimal import Decimal
 from itertools import groupby
+
+from onegov.core.markdown import render_untrusted_markdown as render_md
 from onegov.form import utils
 from onegov.form.validators import StrictOptional
 from onegov.pay import Price
@@ -553,6 +555,15 @@ class Form(BaseForm):
 
                 if callable(member):
                     yield member
+
+    @staticmethod
+    def as_maybe_markdown(raw_text):
+        md = render_md(raw_text)
+        stripped = md.strip().replace('<p>', '').replace('</p>', '')
+        # has markdown elements
+        if stripped != raw_text:
+            return md, True
+        return raw_text, False
 
 
 class Fieldset(object):

--- a/src/onegov/org/templates/macros.pt
+++ b/src/onegov/org/templates/macros.pt
@@ -378,7 +378,7 @@
 
             See onegov.core.i18n.get_translation_bound_meta.render_field
         -->
-        <tal:b define="description request.translate(field.description or ''); long_description len(description) > 54; content field(placeholder=not long_description and description)">
+        <tal:b define="(description, is_md) form.as_maybe_markdown(form.request.translate(field.description or '')); long_description len(description) > 54 or is_md; content field(placeholder=not long_description and description)">
             <span class="label-text" tal:condition="not field.hide_label|True">${field.label.text}</span>
             <span class="label-required" tal:condition="field.flags.required|nothing">*</span>
             <div class="long-field-help" tal:condition="long_description">

--- a/src/onegov/org/theme/styles/org.scss
+++ b/src/onegov/org/theme/styles/org.scss
@@ -805,7 +805,8 @@ form {
         margin-left: 1.25rem;
     }
 
-    .long-field-help {
+    .long-field-help,
+    .long-field-help p {
         color: $steel;
         font-size: .8rem;
         margin: .25rem 0 .5rem;

--- a/tests/onegov/form/test_parser.py
+++ b/tests/onegov/form/test_parser.py
@@ -22,10 +22,14 @@ def parse(expr, text):
     return expr.parseString(text)
 
 
-def test_help_field_identifier():
+@pytest.mark.parametrize('comment,output', [
+    ('<< Some text >>', 'Some text'),
+    ('<< [Z](www.co.me) >>', '[Z](www.co.me)')
+])
+def test_help_field_identifier(comment, output):
 
-    parsed_result = parse(field_help_identifier(), '<< Some text >>')
-    assert parsed_result.message == 'Some text'
+    parsed_result = parse(field_help_identifier(), comment)
+    assert parsed_result.message == output
 
 
 def test_parse_text():

--- a/tests/onegov/org/test_macros.py
+++ b/tests/onegov/org/test_macros.py
@@ -1,0 +1,62 @@
+from webob.multidict import MultiDict
+from wtforms import StringField
+
+from onegov.core.templates import render_macro
+from onegov.core.utils import Bunch
+from onegov.form import Form
+from onegov.org.layout import DefaultLayout
+from pyquery import PyQuery as pq
+
+
+class DummyRequest:
+
+    is_manager = False
+    is_admin = False
+
+    def __init__(self, app):
+        self.app = app
+
+    def include(self, value):
+        pass
+
+    def translate(self, value, **kwargs):
+        return value
+
+    def get_translate(self, for_chameleon=None):
+        return self.translate
+
+    def link(self, *args, **kwargs):
+        return '#'
+
+    def new_csrf_token(self):
+        return ''
+
+
+def test_form_field_long_description_markdown(org_app):
+
+    model = Bunch()
+    request = DummyRequest(org_app)
+
+    layout = DefaultLayout(model, request)
+
+    class LongDescriptionForm(Form):
+        text = StringField(
+            label='Text',
+            description='Short text and md elem is enough [link](#).')
+
+    form = LongDescriptionForm(MultiDict([
+        ('text', 'Example')
+    ]))
+    form.request = DummyRequest(org_app)
+
+    html = render_macro(
+        layout.macros['form'],
+        form.request,
+        {
+            'form': form,
+            'layout': layout,
+            'year': layout.today().year,
+        }
+    )
+    assert pq(html)('.long-field-help a').attr('href') == '#'
+    assert pq(html)('.long-field-help a').text() == 'link'


### PR DESCRIPTION
Enables markdown rendering in org.macros.form. Checks if the Description has any markdown syntax. If so, render it in a seperate html element already introduced for long descriptions that will not used as a placeholder.