### PR TITLE
Directory change request uploads fix

### DIFF
--- a/src/onegov/form/submissions.py
+++ b/src/onegov/form/submissions.py
@@ -1,0 +1,56 @@
+from inspect import getmembers
+
+from wtforms.validators import DataRequired
+
+from onegov.form.fields import UploadField
+from onegov.form.validators import StrictOptional
+
+
+def prepare_for_submission(
+        form_class,
+        for_change_request=False,
+        force_simple=True,
+):
+    # force all upload fields to be simple, we do not support the more
+    # complex add/keep/replace widget, which is hard to properly support
+    # and is not super useful in submissions
+    def is_upload(attribute):
+        if not hasattr(attribute, 'field_class'):
+            return None
+
+        return issubclass(attribute.field_class, UploadField)
+
+    for name, field in getmembers(form_class, predicate=is_upload):
+
+        if force_simple:
+            if 'render_kw' not in field.kwargs:
+                field.kwargs['render_kw'] = {}
+
+            field.kwargs['render_kw']['force_simple'] = True
+
+        # Otherwise the user gets stuck when in form validation not
+        # changing the file
+        if for_change_request:
+            validators = [StrictOptional()] + [
+                v for v in field.kwargs['validators'] or []
+                if not isinstance(v, DataRequired)
+            ]
+            field.kwargs['validators'] = validators
+
+    return form_class
+
+
+def get_fields(form_class, names_only=False, exclude=None):
+    """ Takes an unbound form and returns the name of the fields """
+    def is_field(attribute):
+        if not hasattr(attribute, 'field_class'):
+            return None
+        return True
+
+    for name, field in getmembers(form_class, predicate=is_field):
+        if exclude and name in exclude:
+            continue
+        if names_only:
+            yield name
+        else:
+            yield name, field

--- a/src/onegov/org/forms/extensions.py
+++ b/src/onegov/org/forms/extensions.py
@@ -2,6 +2,7 @@ from cached_property import cached_property
 from onegov.core.html_diff import render_html_diff
 from onegov.form.extensions import FormExtension
 from onegov.form.fields import UploadField
+from onegov.form.submissions import prepare_for_submission
 from onegov.gis import CoordinatesField
 from onegov.org import _
 from wtforms.fields import TextAreaField
@@ -57,6 +58,7 @@ class ChangeRequestFormExtension(FormExtension, name='change-request'):
 
         # XXX circular import
         from onegov.org.models.directory import ExtendedDirectoryEntry
+        prepare_for_submission(self.form_class, for_change_request=True)
 
         class ChangeRequestForm(self.form_class):
 

--- a/src/onegov/org/forms/extensions.py
+++ b/src/onegov/org/forms/extensions.py
@@ -94,8 +94,9 @@ class ChangeRequestFormExtension(FormExtension, name='change-request'):
                 # upload fields differ if they are not empty
                 if isinstance(field, UploadField):
                     return field.data and True or False
-
-                return self.target.values.get(field.id) != field.data
+                stored = self.target.values.get(field.id) or None
+                field_data = field.data or None
+                return stored != field_data
 
             def render_original(self, field):
                 prev = field.data

--- a/src/onegov/org/models/directory.py
+++ b/src/onegov/org/models/directory.py
@@ -1,4 +1,3 @@
-import inspect
 import sedate
 
 from cached_property import cached_property
@@ -10,7 +9,6 @@ from onegov.directory import Directory, DirectoryEntry
 from onegov.directory.errors import DuplicateEntryError, ValidationError
 from onegov.directory.migration import DirectoryMigration
 from onegov.form import as_internal_id, Extendable, FormSubmission
-from onegov.form.fields import UploadField
 from onegov.form.submissions import prepare_for_submission
 from onegov.org import _
 from onegov.org.models.extensions import CoordinatesExtension

--- a/src/onegov/org/views/directory.py
+++ b/src/onegov/org/views/directory.py
@@ -47,11 +47,11 @@ def get_directory_entry_form_class(model, request):
 
 
 def get_submission_form_class(model, request):
-    return model.directory.form_class_for_submissions(include_private=True)
+    return model.directory.form_class_for_submissions(change_request=False)
 
 
 def get_change_request_form_class(model, request):
-    return model.directory.form_class_for_submissions(include_private=False)
+    return model.directory.form_class_for_submissions(change_request=True)
 
 
 @OrgApp.html(

--- a/src/onegov/org/views/form_submission.py
+++ b/src/onegov/org/views/form_submission.py
@@ -134,7 +134,7 @@ def handle_pending_submission(self, request):
     user to turn the submission into a complete submission, once all data
     is valid.
 
-    This view has two states, a completeable state where the form values
+    This view has two states, a completable state where the form values
     are displayed without a form and an edit state, where a form is rendered
     to change the values.
 

--- a/tests/onegov/org/test_views.py
+++ b/tests/onegov/org/test_views.py
@@ -1,3 +1,4 @@
+
 import babel.dates
 import onegov.core
 import onegov.org
@@ -4330,21 +4331,22 @@ def test_directory_change_requests(client):
     page.form['title'] = "Playgrounds"
     page.form['structure'] = """
         Name *= ___
+        Pic *= *.jpg|*.png|*.gif
     """
     page.form['enable_change_requests'] = True
     page.form['title_format'] = '[Name]'
+    page.form['content_fields'] = 'Name\nPic'
     page = page.form.submit().follow()
 
     # create an entry
     page = page.click('Eintrag')
     page.form['name'] = 'Central Park'
+    page.form['pic'] = Upload('test.jpg', utils.create_image().read())
     page = page.form.submit().follow()
 
-    # ask for a change
+    # ask for a change, completely empty
     page = page.click("Änderung vorschlagen")
-    page.form['name'] = 'Diana Ross Playground'
     page.form['submitter'] = 'user@example.org'
-    page.form['comment'] = 'This is better'
     assert len(client.app.smtp.outbox) == 0
     form_preview = page.form.submit().follow()
     assert 'Bitte geben Sie mindestens eine Änderung ein' in form_preview

--- a/tests/onegov/org/test_views.py
+++ b/tests/onegov/org/test_views.py
@@ -4346,7 +4346,11 @@ def test_directory_change_requests(client):
     page.form['submitter'] = 'user@example.org'
     page.form['comment'] = 'This is better'
     assert len(client.app.smtp.outbox) == 0
-    page.form.submit().follow().form.submit().follow()
+    form_preview = page.form.submit().follow()
+    assert 'Bitte geben Sie mindestens eine Änderung ein' in form_preview
+    form_preview.form['comment'] = 'This is better'
+    form_preview.form['name'] = 'Diana Ross Playground'
+    page = form_preview.form.submit().form.submit().follow()
 
     # check the ticket
     assert len(client.app.smtp.outbox) == 1

--- a/tests/onegov/org/test_views.py
+++ b/tests/onegov/org/test_views.py
@@ -4343,6 +4343,7 @@ def test_directory_change_requests(client):
     page.form['name'] = 'Central Park'
     page.form['pic'] = Upload('test.jpg', utils.create_image().read())
     page = page.form.submit().follow()
+    img_url = page.pyquery('.field-display img').attr('href')
 
     # ask for a change, completely empty
     page = page.click("Änderung vorschlagen")
@@ -4374,8 +4375,10 @@ def test_directory_change_requests(client):
     assert 'This is better' in page
 
     # check if they were applied (the id won't have changed)
-    assert 'Diana Ross Playground' in \
-        client.get('/directories/playgrounds/central-park')
+    page = client.get('/directories/playgrounds/central-park')
+    assert 'Diana Ross Playground' in page
+    # ensure the picture was not deleted
+    assert page.pyquery('.field-display img').attr('href') == img_url
 
 
 def test_dependent_number_form(client):


### PR DESCRIPTION
Up change requests, users had to submit uploaded files again (required or not by the directory). For new submissions, required files are required, for change requests they are never required. Also fixes a bug in the ChangeRequestFormExtension in `is_different` where empty string and None would have been different not triggering the validation.