### PR TITLE
Linkify elements

### DIFF
--- a/src/onegov/agency/models/ticket.py
+++ b/src/onegov/agency/models/ticket.py
@@ -4,6 +4,7 @@ from onegov.agency.collections import ExtendedPersonCollection
 from onegov.agency.layout import AgencyLayout
 from onegov.agency.layout import ExtendedPersonLayout
 from onegov.core.templates import render_macro
+from onegov.core.utils import linkify
 from onegov.org import _
 from onegov.org.models.ticket import OrgTicketMixin
 from onegov.ticket import Handler
@@ -62,12 +63,13 @@ class AgencyMutationHandler(Handler):
 
     def get_summary(self, request):
         layout = AgencyLayout(self.agency, request)
+        message = self.data['handler_data']['submitter_message']
         return render_macro(
             layout.macros['display_agency_mutation'],
             request,
             {
                 'agency': self.agency,
-                'message': self.data['handler_data']['submitter_message'],
+                'message': linkify(message).replace('\n', '<br>'),
                 'layout': layout
             }
         )
@@ -111,12 +113,13 @@ class PersonMutationHandler(Handler):
 
     def get_summary(self, request):
         layout = ExtendedPersonLayout(self.person, request)
+        message = self.data['handler_data']['submitter_message']
         return render_macro(
             layout.macros['display_person_mutation'],
             request,
             {
                 'person': self.person,
-                'message': self.data['handler_data']['submitter_message'],
+                'message': linkify(message).replace('\n', '<br>'),
                 'layout': layout
             }
         )

--- a/src/onegov/agency/templates/macros.pt
+++ b/src/onegov/agency/templates/macros.pt
@@ -234,7 +234,7 @@
             <dd><span tal:repeat="ancestor agency.ancestors">${ancestor.title}</span> <span>${agency.title}</span></dd>
 
             <dt i18n:translate>Message</dt>
-            <dd>${message}</dd>
+            <dd tal:content="structure message"></dd>
         </dl>
     </metal:display_agency_mutation>
 
@@ -245,7 +245,7 @@
             <dd><a href="${request.link(person)}">${person.title}</a></dd>
 
             <dt i18n:translate>Message</dt>
-            <dd>${message}</dd>
+            <dd tal:content="structure message"></dd>
         </dl>
     </metal:display_person_mutation>
 

--- a/src/onegov/feriennet/templates/activities-for-volunteers.pt
+++ b/src/onegov/feriennet/templates/activities-for-volunteers.pt
@@ -32,7 +32,7 @@
 
                             <div class="columns small-10">
                                 <h3><a href="${request.link(activity)}">${activity.title}</a></h3>
-                                <p class="page-lead">${activity.lead}</p>
+                                <span class="page-lead" tal:content="structure layout.paragraphify(layout.linkify(activity.lead))" />
 
                                 <tal:b repeat="occasion activity.occasions">
                                     <div class="call-for-volunteers" tal:define="dates exclude_filtered_dates(layout.model, occasion.dates)" tal:condition="occasion.seeking_volunteers and dates">

--- a/src/onegov/feriennet/templates/activities.pt
+++ b/src/onegov/feriennet/templates/activities.pt
@@ -22,7 +22,7 @@
 
                             <div class="columns small-10">
                                 <h3><a href="${request.link(activity)}">${activity.title}</a></h3>
-                                <p class="page-lead">${activity.lead}</p>
+                                <span class="page-lead" tal:content="structure layout.paragraphify(layout.linkify(activity.lead))"/>
 
                                 <div class="row collapse" tal:define="
                                     ages activity_ages(activity, request);

--- a/src/onegov/feriennet/templates/macros.pt
+++ b/src/onegov/feriennet/templates/macros.pt
@@ -237,7 +237,7 @@
         <h2>${activity.title}</h2>
 
         <p>
-            <span class="page-lead" tal:condition="activity.lead" tal:content="activity.lead" />
+            <span class="page-lead" tal:condition="activity.lead" tal:content="structure layout.paragraphify(layout.linkify(activity.lead))" />
             <span>${period.title}</span>
         </p>
 

--- a/src/onegov/feriennet/templates/macros.pt
+++ b/src/onegov/feriennet/templates/macros.pt
@@ -247,7 +247,7 @@
 <metal:activity_detailed define-macro="activity_detailed" i18n:domain="onegov.feriennet">
 
     <tal:b metal:use-macro="layout.macros.page_content"
-        tal:define="lead activity.lead; text activity.text; coordinates activity.coordinates; people None; contact None; show_side_panel True; highlight_contacts False; location activity.location">
+        tal:define="lead layout.paragraphify(layout.linkify(activity.lead)); text activity.text; coordinates activity.coordinates; people None; contact None; show_side_panel True; highlight_contacts False; location activity.location">
 
         <div metal:fill-slot="after-lead" tal:condition="activity.tags">
             <ul class="tags">

--- a/src/onegov/feriennet/templates/mail_activity_accepted.pt
+++ b/src/onegov/feriennet/templates/mail_activity_accepted.pt
@@ -6,7 +6,7 @@
         <p i18n:translate>Hello!</p>
         <p i18n:translate>Your activity has been published:</p>
         <p><b>${model.title}</b></p>
-        <p>${model.lead}</p>
+        <tal:b tal:content="structure layout.paragraphify(layout.linkify(model.lead))"></tal:b>
 
         <p>
             <a href="${request.link(ticket, 'status')}" i18n:translate>Check ticket status</a>

--- a/src/onegov/feriennet/templates/mail_activity_archived.pt
+++ b/src/onegov/feriennet/templates/mail_activity_archived.pt
@@ -6,7 +6,7 @@
         <p i18n:translate>Hello!</p>
         <p i18n:translate>Your activity has been archived:</p>
         <p><b>${model.title}</b></p>
-        <p>${model.lead}</p>
+        <tal:b tal:content="structure layout.paragraphify(layout.linkify(model.lead))"></tal:b>
 
         <p>
             <a href="${request.link(ticket, 'status')}" i18n:translate>Check ticket status</a>

--- a/src/onegov/org/layout.py
+++ b/src/onegov/org/layout.py
@@ -15,7 +15,7 @@ from onegov.core.elements import Link, LinkGroup
 from onegov.core.i18n import SiteLocale
 from onegov.core.layout import ChameleonLayout
 from onegov.core.static import StaticFile
-from onegov.core.utils import linkify
+from onegov.core.utils import linkify, paragraphify
 from onegov.directory import DirectoryCollection
 from onegov.event import OccurrenceCollection
 from onegov.file import File
@@ -586,6 +586,9 @@ class DefaultMailLayout(Layout):
                 salt='unsubscribe'
             )
         )
+
+    def paragraphify(self, text):
+        return paragraphify(text)
 
 
 class AdjacencyListMixin:

--- a/src/onegov/org/templates/directory_entry.pt
+++ b/src/onegov/org/templates/directory_entry.pt
@@ -5,7 +5,7 @@
     <tal:b metal:fill-slot="content">
         <tal:b metal:use-macro="layout.macros.page_content"
                    tal:define="
-                    lead entry.lead;
+                    lead layout.linkify(entry.lead);
                     text None;
                     people None;
                     contact entry.contact;

--- a/src/onegov/org/templates/imageset.pt
+++ b/src/onegov/org/templates/imageset.pt
@@ -4,7 +4,7 @@
     </tal:b>
     <tal:b metal:fill-slot="content">
         <tal:b metal:use-macro="layout.macros.page_content"
-             tal:define="lead imageset.meta.get('lead'); text None; people None; contact None; coordinates None;" />
+             tal:define="lead layout.linkify(imageset.meta.get('lead')); text None; people None; contact None; coordinates None;" />
 
         <p tal:condition="not:imageset.files" i18n:translate>
             This album does not contain any images yet.

--- a/src/onegov/org/templates/topic.pt
+++ b/src/onegov/org/templates/topic.pt
@@ -10,7 +10,7 @@
         <tal:b condition="page.trait == 'page'">
 
             <tal:b metal:use-macro="layout.macros.page_content"
-             tal:define="lead page.content.get('lead');text page.content.get('text'); people page.people; contact page.contact_html; coordinates page.coordinates">
+             tal:define="lead layout.linkify(page.content.get('lead'));text page.content.get('text'); people page.people; contact page.contact_html; coordinates page.coordinates">
                 <tal:b metal:fill-slot="after-text">
                      <div class="row" tal:condition="children">
                         <div class="small-12 columns">


### PR DESCRIPTION
Linkifies further elements on differnt applications.
On the views used in ongeov.agency in the ticket handlers.get_summary() and the templates they use.
Changes the `page_content` macro to render the lead as structure.
Changes corresponding lead fields in Feriennet and org app (directory lead) to have consistency.