### PR TITLE
Ais2py v2.1.0

### DIFF
--- a/src/onegov/file/sign/swisscom_ais.py
+++ b/src/onegov/file/sign/swisscom_ais.py
@@ -1,9 +1,7 @@
 import os
 
 from AIS import AIS, PDF
-from contextlib import suppress
 from onegov.file.sign.generic import SigningService
-from io import UnsupportedOperation
 
 
 class SwisscomAIS(SigningService, service_name='swisscom_ais'):
@@ -23,8 +21,9 @@ class SwisscomAIS(SigningService, service_name='swisscom_ais'):
         self.client = AIS(customer, key_static, cert_file, cert_key)
 
     def sign(self, infile, outfile):
-        with suppress(UnsupportedOperation):
-            infile.seek(0)
+        # HACK: pyHanko expects the IO interface to be implemented
+        #       and calls writeable() on the out_stream
+        setattr(outfile, 'writeable', lambda s: True)
 
         pdf = PDF(infile, out_stream=outfile)
         self.client.sign_one_pdf(pdf)

--- a/src/onegov/file/sign/swisscom_ais.py
+++ b/src/onegov/file/sign/swisscom_ais.py
@@ -1,4 +1,3 @@
-import io
 import os
 
 from AIS import AIS, PDF
@@ -27,17 +26,7 @@ class SwisscomAIS(SigningService, service_name='swisscom_ais'):
         with suppress(UnsupportedOperation):
             infile.seek(0)
 
-        in_stream = io.BytesIO()
-        for chunk in iter(lambda: infile.read(4096), b''):
-            in_stream.write(chunk)
-
-        pdf = PDF(in_stream)
+        pdf = PDF(infile, out_stream=outfile)
         self.client.sign_one_pdf(pdf)
-
-        with suppress(UnsupportedOperation):
-            pdf.out_stream.seek(0)
-
-        for chunk in iter(lambda: pdf.out_stream.read(4096), b''):
-            outfile.write(chunk)
 
         return f'swisscom_ais/{self.customer}/{self.client.last_request_id}'


### PR DESCRIPTION
Minor efficiency improvement. The old implementation would create two separate BytesIO buffers for input and output, but pyHanko can sign the document in-place, so only one temporary buffer is necessary.

Due to SpooledTemporaryFile not fully implementing BaseIO we can't pass the infile and outfile directly without some hacky workarounds. But it might be an option for the future, to get rid of the temporary buffer entirely.