### PR TITLE
Remove tile-images

### DIFF
--- a/src/onegov/org/forms/settings.py
+++ b/src/onegov/org/forms/settings.py
@@ -477,30 +477,6 @@ class HeaderSettingsForm(Form):
 
 class HomepageSettingsForm(Form):
 
-    homepage_image_1 = StringField(
-        label=_("Homepage Image #1"),
-        render_kw={'class_': 'image-url'})
-
-    homepage_image_2 = StringField(
-        label=_("Homepage Image #2"),
-        render_kw={'class_': 'image-url'})
-
-    homepage_image_3 = StringField(
-        label=_("Homepage Image #3"),
-        render_kw={'class_': 'image-url'})
-
-    homepage_image_4 = StringField(
-        label=_("Homepage Image #4"),
-        render_kw={'class_': 'image-url'})
-
-    homepage_image_5 = StringField(
-        label=_("Homepage Image #5"),
-        render_kw={'class_': 'image-url'})
-
-    homepage_image_6 = StringField(
-        label=_("Homepage Image #6"),
-        render_kw={'class_': 'image-url'})
-
     homepage_cover = HtmlField(
         label=_("Homepage Cover"),
         render_kw={'rows': 10})
@@ -556,43 +532,6 @@ class HomepageSettingsForm(Form):
                 field.render_kw['data-highlight-line'] = correct_line
 
                 raise ValidationError(correct_msg)
-
-    @property
-    def theme_options(self):
-        options = self.model.theme_options
-
-        # set the images only if provided
-        for i in range(1, 7):
-            image = getattr(self, 'homepage_image_{}'.format(i)).data
-
-            if not image:
-                options.pop(f'tile-image-{i}', None)
-            else:
-                options[f'tile-image-{i}'] = '"{}"'.format(image)
-
-        # override the options using the default values if no value was given
-        for key in options:
-            if not options[key]:
-                options[key] = user_options[key]
-
-        return options
-
-    @theme_options.setter
-    def theme_options(self, options):
-        self.homepage_image_1.data = options.get('tile-image-1', '').strip('"')
-        self.homepage_image_2.data = options.get('tile-image-2', '').strip('"')
-        self.homepage_image_3.data = options.get('tile-image-3', '').strip('"')
-        self.homepage_image_4.data = options.get('tile-image-4', '').strip('"')
-        self.homepage_image_5.data = options.get('tile-image-5', '').strip('"')
-        self.homepage_image_6.data = options.get('tile-image-6', '').strip('"')
-
-    def populate_obj(self, model):
-        super().populate_obj(model)
-        model.theme_options = self.theme_options
-
-    def process_obj(self, model):
-        super().process_obj(model)
-        self.theme_options = model.theme_options
 
 
 class ModuleSettingsForm(Form):

--- a/src/onegov/org/homepage_widgets.py
+++ b/src/onegov/org/homepage_widgets.py
@@ -384,19 +384,10 @@ class SliderWidget:
                 'src': layout.request.link(image)
             }
 
-    def get_images_from_theme(self, layout):
-        for key, value in layout.org.theme_options.items():
-            if key.startswith('tile-image'):
-                yield {
-                    'note': None,
-                    'src': value.strip('"\'')
-                }
-
     def get_variables(self, layout):
         # if we don't have an album used for images, we use the images
         # shown on the homepage anyway to avoid having to show nothing
-        images = tuple(self.get_images_from_sets(layout)) \
-            or tuple(self.get_images_from_theme(layout))
+        images = tuple(self.get_images_from_sets(layout))
 
         return {
             'images': images

--- a/src/onegov/org/templates/macros.pt
+++ b/src/onegov/org/templates/macros.pt
@@ -351,7 +351,6 @@
         <div class="homepage-tiles">
             <div tal:repeat="tile tiles" class="homepage-tile" id="homepage-tile-${tile.number}">
                 <a href="${tile.page.url}" class="tile-link">
-                    <div class="tile-image"></div>
                     <h3>${tile.page.text}</h3>
                 </a>
                 <div class="child-links">

--- a/src/onegov/org/theme/org_theme.py
+++ b/src/onegov/org/theme/org_theme.py
@@ -1,5 +1,4 @@
 import os
-from collections import OrderedDict
 
 from onegov.foundation import BaseTheme
 from onegov.core.utils import module_path
@@ -30,18 +29,7 @@ class OrgTheme(BaseTheme):
 
     @property
     def default_options(self):
-        options = OrderedDict((
-            # tile images
-            ('tile-image-1', '"../static/homepage-images/tile-1-small.jpg"'),
-            ('tile-image-2', '"../static/homepage-images/tile-2-small.jpg"'),
-            ('tile-image-3', '"../static/homepage-images/tile-3-small.jpg"'),
-            ('tile-image-4', '"../static/homepage-images/tile-4-small.jpg"'),
-            ('tile-image-5', '"../static/homepage-images/tile-5-small.jpg"'),
-            ('tile-image-6', '"../static/homepage-images/tile-6-small.jpg"'),
-        ))
-        options.update(user_options)
-
-        return options
+        return user_options
 
     @property
     def foundation_components(self):

--- a/src/onegov/org/theme/styles/org.scss
+++ b/src/onegov/org/theme/styles/org.scss
@@ -1041,17 +1041,6 @@ form {
 }
 
 /*
-    homepage tiles images
-*/
-
-#homepage-tile-1 .tile-image { background-image: url(#{$tile-image-1});}
-#homepage-tile-2 .tile-image { background-image: url(#{$tile-image-2});}
-#homepage-tile-3 .tile-image { background-image: url(#{$tile-image-3});}
-#homepage-tile-4 .tile-image { background-image: url(#{$tile-image-4});}
-#homepage-tile-5 .tile-image { background-image: url(#{$tile-image-5});}
-#homepage-tile-6 .tile-image { background-image: url(#{$tile-image-6});}
-
-/*
     Hide the spam bot honeypot field
 */
 .field-roboter_falle {
@@ -1309,21 +1298,10 @@ input[type='color'] {
         content: '';
     }
 
-    .tile-image {
-        background-position: center center;
-        background-size: cover;
-        display: block;
-        height: 7rem;
-        width: 100%;
-    }
-
     .tile-link:hover h3 {
         color: $anchor-font-color-hover;
     }
 
-    .tile-link:hover .tile-image {
-        @include grayscale;
-    }
 }
 
 /*

--- a/src/onegov/town6/theme/styles/homepage-tiles.scss
+++ b/src/onegov/town6/theme/styles/homepage-tiles.scss
@@ -1,15 +1,3 @@
-/*
-    homepage tiles images
-*/
-
-#homepage-tile-1 .tile-image { background-image: url(#{$tile-image-1});}
-#homepage-tile-2 .tile-image { background-image: url(#{$tile-image-2});}
-#homepage-tile-3 .tile-image { background-image: url(#{$tile-image-3});}
-#homepage-tile-4 .tile-image { background-image: url(#{$tile-image-4});}
-#homepage-tile-5 .tile-image { background-image: url(#{$tile-image-5});}
-#homepage-tile-6 .tile-image { background-image: url(#{$tile-image-6});}
-
-
 .homepage-tile {
     .card-section {
         padding-bottom: .5rem;

--- a/src/onegov/town6/theme/town_theme.py
+++ b/src/onegov/town6/theme/town_theme.py
@@ -1,5 +1,4 @@
 import os
-from collections import OrderedDict
 
 from onegov.foundation6 import BaseTheme
 from onegov.core.utils import module_path
@@ -37,18 +36,7 @@ class TownTheme(BaseTheme):
 
     @property
     def default_options(self):
-        options = OrderedDict((
-            # tile images
-            ('tile-image-1', '"../static/homepage-images/tile-1-small.jpg"'),
-            ('tile-image-2', '"../static/homepage-images/tile-2-small.jpg"'),
-            ('tile-image-3', '"../static/homepage-images/tile-3-small.jpg"'),
-            ('tile-image-4', '"../static/homepage-images/tile-4-small.jpg"'),
-            ('tile-image-5', '"../static/homepage-images/tile-5-small.jpg"'),
-            ('tile-image-6', '"../static/homepage-images/tile-6-small.jpg"'),
-        ))
-        options.update(user_options)
-
-        return options
+        return user_options
 
     @property
     def foundation_styles(self):

--- a/src/onegov/town6/views/settings.py
+++ b/src/onegov/town6/views/settings.py
@@ -100,7 +100,7 @@ def get_custom_settings_form(model, request, homepage_settings_form=None):
             'event_limit_homepage',
             'news_limit_homepage',
         ),
-        after='homepage_image_6'
+        after='homepage_cover'
     )
 
 

--- a/tests/onegov/org/test_views_settings.py
+++ b/tests/onegov/org/test_views_settings.py
@@ -43,16 +43,6 @@ def test_settings(client):
     assert '<img src="https://seantis.ch/logo.img"' in settings.text
     assert '<style>h1 { text-decoration: underline; }</style>' in settings.text
 
-    # homepage settings
-    settings = client.get('/homepage-settings')
-    settings.form['homepage_image_1'] = "http://images/one"
-    settings.form['homepage_image_2'] = "http://images/two"
-    settings.form.submit()
-
-    settings = client.get('/homepage-settings')
-    assert 'http://images/one' in settings
-    assert 'http://images/two' in settings
-
     # analytics settings
     settings = client.get('/analytics-settings')
     settings.form['analytics_code'] = '<script>alert("Hi!");</script>'


### PR DESCRIPTION
Please fill in the commit message below and work through the checklist. You can delete parts that are not needed, e.g. the optional description, the link to a ticket or irrelevant options of the checklist.

## Commit message

Town6: Remove unused tile image option in settings

TYPE: Bugfix
LINK: OGC-592

## Checklist

- [X] I made changes/features for both org and town6
- [X] I have performed a self-review of my code
- [X] I considered adding a reviewer
- [X] I have tested my code thoroughly by hand
    - [X] I have tested styling changes/features on different browsers
