### PR TITLE
Feriennet: Avoid throwing an error when displaying QR bills with inva…

### DIFF
--- a/src/onegov/feriennet/qrbill.py
+++ b/src/onegov/feriennet/qrbill.py
@@ -76,6 +76,8 @@ def generate_qr_bill(schema, request, user, invoice):
         return None
     if debtor['street'] and len(debtor['street']) > 70:
         debtor['street'] = debtor['street'][:70]
+    if debtor['pcode'] and len(debtor['pcode']) > 16:
+        debtor['pcode'] = debtor['pcode'][:16]
 
     # Language
     language = {'de_CH': 'de', 'fr_CH': 'fr', 'it_CH': 'it'}.get(


### PR DESCRIPTION
## Commit message

Feriennet: Avoid throwing an error when displaying QR bills with invalid zip codes.

TYPE: Feature
LINK: PRO-1083

## Checklist

- [x] I have performed a self-review of my code
- [x] I have tested my code thoroughly by hand