### PR TITLE
Town6: Listing of people displayed is shown without empty entry

### DIFF
--- a/src/onegov/town6/templates/macros.pt
+++ b/src/onegov/town6/templates/macros.pt
@@ -373,7 +373,7 @@
         <tal:b condition="button_text|nothing">
             <input type="submit" value="${button_text}" class="button" role="button">
         </tal:b>
-        <a class="cancel-link" href="#" onclick="if(document.referrer) {window.open(document.referrer,'_self');} else {history.go(-1);} return false;"> <span i18n:translate="">Cancel</span><a/>
+        <a class="cancel-link" href="#" onclick="if(document.referrer) {window.open(document.referrer,'_self');} else {history.go(-1);} return false;"> <span i18n:translate="">Cancel</span></a>
     </form>
 </metal:form>
 


### PR DESCRIPTION
Please fill in the commit message below and work through the checklist. You can delete parts that are not needed, e.g. the optional description, the link to a ticket or irrelevant options of the checklist.

## Commit message

Town6: Fix small typo in html tag of person sidebar

Person sidebar is now displayed correctly, without this empty entry. 

TYPE: Bugfix
LINK: OGC-750

## Checklist

- [x] I have performed a self-review of my code
- [x] I have tested my code thoroughly by hand
