### PR TITLE
Add arrows as hover-effect for homepage-tiles

### DIFF
--- a/src/onegov/town6/templates/macros.pt
+++ b/src/onegov/town6/templates/macros.pt
@@ -1764,7 +1764,7 @@
                                 <metal:hint use-macro="layout.macros['access_hint']" tal:define="item record" />
                         </a>
                         <div class="list-lead" tal:define="lead lead_func(record)|layout.linkify(record.meta.get('lead'))"
-                            tal:content="structure lead">
+                            tal:content="structure lead" tal:condition="lead">
                         </div>
                         <div class="list-hint hints" tal:define="hint hint(record)|False"
                             tal:content="structure hint" tal:condition="hint">

--- a/src/onegov/town6/theme/styles/custom_mixins.scss
+++ b/src/onegov/town6/theme/styles/custom_mixins.scss
@@ -130,10 +130,6 @@ $morelist-default-padding: .5rem 0;
             padding-top: .5rem;
             transition: border-top 200ms linear;
             width: 100%;
-
-            &:hover {
-                border-top: 1px solid $primary-color;
-            }
         }
     }
 }

--- a/src/onegov/town6/theme/styles/homepage-tiles.scss
+++ b/src/onegov/town6/theme/styles/homepage-tiles.scss
@@ -16,13 +16,26 @@
 
     li {
         border-top: 1px solid #f5f5f5;
+
+        a::after {
+            @include icon-bold($more-link-icon);
+            // float: right;
+            opacity: 0;
+            padding-left: 2rem;
+            transition: all 200ms linear;
+        }
+
+        &:hover a::after {
+            opacity: 1;
+            padding-left: 2.5rem;
+        }
     }
 
     li:first-child {
         border-top: 0;
 
-        a {
-            border-top: 1px solid transparent;
+        a.tile-sub-link {
+            border-top: 1px solid transparent !important;
             padding-top: 0;
         }
     }

--- a/src/onegov/town6/theme/styles/org.scss
+++ b/src/onegov/town6/theme/styles/org.scss
@@ -573,7 +573,6 @@ $pageref-color-hover: $iron;
 }
 
 .more-list li .list-lead {
-    // color: #707070;
     line-height: 1.3;
 }
 


### PR DESCRIPTION
Please fill in the commit message below and work through the checklist. You can delete parts that are not needed, e.g. the optional description, the link to a ticket or irrelevant options of the checklist.

## Commit message

Town6: Homepage tiles pretty hover effect

TYPE: Feature
LINK: OGC-771

## Checklist

- [x] I have performed a self-review of my code
- [x] I have tested my code thoroughly by hand
    - [x] I have tested styling changes/features on different browsers
