### PR TITLE
Ogc 832 no news homepage tile

### DIFF
--- a/src/onegov/org/homepage_widgets.py
+++ b/src/onegov/org/homepage_widgets.py
@@ -1,7 +1,6 @@
 from collections import namedtuple
 from onegov.directory import DirectoryCollection
 from onegov.event import OccurrenceCollection
-from onegov.newsletter import NewsletterCollection
 from onegov.org import _, OrgApp
 from onegov.org.elements import Link, LinkGroup
 from onegov.org.layout import EventBaseLayout
@@ -289,7 +288,6 @@ class TilesWidget:
         homepage_pages = layout.request.app.homepage_pages
         request = layout.request
         link = request.link
-        session = layout.app.session()
         classes = ('tile-sub-link', )
 
         for ix, page in enumerate(layout.root_pages):

--- a/src/onegov/org/homepage_widgets.py
+++ b/src/onegov/org/homepage_widgets.py
@@ -317,21 +317,7 @@ class TilesWidget:
                 )
 
             elif page.type == 'news':
-                links = [
-                    Link(str(year), link(page.for_year(year)), classes=classes)
-                    for year in page.all_years
-                ]
-                if layout.org.show_newsletter:
-                    links.append(Link(
-                        _("Newsletter"), link(NewsletterCollection(session)),
-                        classes=classes
-                    ))
-
-                yield Tile(
-                    page=Link(page.title, link(page)),
-                    number=ix + 1,
-                    links=links
-                )
+                pass
             else:
                 raise NotImplementedError
 

--- a/tests/onegov/town6/test_views_newsletter.py
+++ b/tests/onegov/town6/test_views_newsletter.py
@@ -26,8 +26,6 @@ def test_show_newsletter(client):
 
     page = client.get('/news')
     assert "Newsletter" in page.text
-    page = client.get('/')
-    assert "Newsletter" in page.text
 
     page = client.get('/newsletter-settings')
     page.form['show_newsletter'] = False
@@ -40,7 +38,7 @@ def test_show_newsletter(client):
     page.form['show_newsletter'] = True
     page = page.form.submit().follow()
 
-    page = client.get('/')
+    page = client.get('/news')
     assert "Newsletter" in page.text
 
 


### PR DESCRIPTION
Please fill in the commit message below and work through the checklist. You can delete parts that are not needed, e.g. the optional description, the link to a ticket or irrelevant options of the checklist.

## Commit message

Town6: No news homepage tile

TYPE: Feature
LINK: OGC-832

## Checklist

- [x] I made changes/features for both org and town6
- [x] I have performed a self-review of my code
- [x] I considered adding a reviewer
- [x] I have tested my code thoroughly by hand
    - [x] I have tested styling changes/features on different browsers
