### PR TITLE
Add time on event homepage widget

### DIFF
--- a/src/onegov/town6/homepage_widgets.py
+++ b/src/onegov/town6/homepage_widgets.py
@@ -194,9 +194,11 @@ class EventsWidget:
             EventCard(
                 text=o.title,
                 url=layout.request.link(o),
-                subtitle=event_layout.format_date(
-                    o.localized_start, 'event_short')
-                .title(),
+                subtitle=(
+                    event_layout.format_date(
+                        o.localized_start, 'event_short').title() + ", "
+                    + layout.format_time_range(
+                        o.localized_start, o.localized_end).title()),
                 image_url=o.event.image and layout.request.link(o.event.image),
                 location=o.location,
                 lead=get_lead(o.event.title)


### PR DESCRIPTION
Please fill in the commit message below and work through the checklist. You can delete parts that are not needed, e.g. the optional description, the link to a ticket or irrelevant options of the checklist.

## Commit message

Town6: Add time to event widget on homepage

TYPE: Feature
LINK: OGC-836

## Checklist

- [x] I have performed a self-review of my code
- [x] I considered adding a reviewer
- [x] I have tested my code thoroughly by hand
    - [x] I have tested styling changes/features on different browsers