### PR TITLE
Form: Extends pricing options with a credit card payment flag.

### DIFF
--- a/src/onegov/form/locale/de_ch/LC_MESSAGES/onegov.form.po
+++ b/src/onegov/form/locale/de_ch/LC_MESSAGES/onegov.form.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE 1.0\n"
-"POT-Creation-Date: 2022-03-20 09:55+0100\n"
+"POT-Creation-Date: 2023-01-26 13:51+0100\n"
 "PO-Revision-Date: 2022-03-07 13:56+0100\n"
 "Last-Translator: Marc Sommerhalder <marc.sommerhalder@seantis.ch>\n"
 "Language-Team: German\n"
@@ -140,6 +140,12 @@ msgstr ""
 msgid "Define at least one required field"
 msgstr "Definieren Sie mindestens ein benötigtes Feld"
 
+#, python-format
+msgid ""
+"The field '{label}' contains a price that requires a credit card payment. "
+"This is only allowed if credit card payments are optional."
+msgstr "Das Feld '{label}' enthält einen Preis der eine Kreditkartenzahlung voraussetzt. Das ist nur erlaubt wenn Kreditkartenzahlungen optional sind."
+
 msgid "Not a valid phone number."
 msgstr "Ungültige Telefonnummer."
 
@@ -160,6 +166,9 @@ msgstr "Datei löschen"
 
 msgid "Replace file"
 msgstr "Datei ersetzen"
+
+msgid "Text modules"
+msgstr "Textbausteine"
 
 msgid "Select an Option"
 msgstr "Eine Option auswählen"

--- a/src/onegov/form/locale/fr_CH/LC_MESSAGES/onegov.form.po
+++ b/src/onegov/form/locale/fr_CH/LC_MESSAGES/onegov.form.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE 1.0\n"
-"POT-Creation-Date: 2022-03-20 09:55+0100\n"
+"POT-Creation-Date: 2023-01-26 13:51+0100\n"
 "PO-Revision-Date: 2019-01-31 08:31+0100\n"
 "Last-Translator: Marc Sommerhalder <marc.sommerhalder@seantis.ch>\n"
 "Language-Team: French\n"
@@ -138,6 +138,15 @@ msgstr "'{label}' est un nom réservé. Veuillez utiliser un nom différent."
 msgid "Define at least one required field"
 msgstr "Définissez au moins un champs requis"
 
+#, python-format
+msgid ""
+"The field '{label}' contains a price that requires a credit card payment. "
+"This is only allowed if credit card payments are optional."
+msgstr ""
+"Le champ '{label}' contient un prix qui exige un paiement par carte de "
+"crédit. Ceci n'est autorisé que si les paiements par carte de crédit sont "
+"facultatifs."
+
 msgid "Not a valid phone number."
 msgstr "N'est pas un numéro de téléphone valide."
 
@@ -158,6 +167,9 @@ msgstr "Supprimer le fichier"
 
 msgid "Replace file"
 msgstr "Remplacer le fichier"
+
+msgid "Text modules"
+msgstr "Modules de texte"
 
 msgid "Select an Option"
 msgstr "Sélectionnez une option"

--- a/src/onegov/form/locale/it_CH/LC_MESSAGES/onegov.form.po
+++ b/src/onegov/form/locale/it_CH/LC_MESSAGES/onegov.form.po
@@ -1,11 +1,10 @@
-#
 # Italian translations for PACKAGE package
 # Traduzioni italiane per il pacchetto PACKAGE.
 # This file is distributed under the same license as the PACKAGE package.
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE 1.0\n"
-"POT-Creation-Date: 2022-03-20 09:55+0100\n"
+"POT-Creation-Date: 2023-01-26 13:51+0100\n"
 "PO-Revision-Date: 2022-03-07 13:55+0100\n"
 "Last-Translator: Marc Sommerhalder <marc.sommerhalder@seantis.ch>\n"
 "Language-Team: Italian\n"
@@ -137,6 +136,15 @@ msgstr "'{label}' è un nome riservato. Per favore usa un nome diverso."
 msgid "Define at least one required field"
 msgstr "Definire almeno un campo obbligatorio"
 
+#, python-format
+msgid ""
+"The field '{label}' contains a price that requires a credit card payment. "
+"This is only allowed if credit card payments are optional."
+msgstr ""
+"Il campo '{label}' contiene un prezzo che richiede un pagamento con carta di"
+" credito. Ciò è consentito solo se i pagamenti con carta di credito sono "
+"facoltativi."
+
 msgid "Not a valid phone number."
 msgstr "Non è un numero di telefono valido."
 
@@ -157,6 +165,9 @@ msgstr "Cancellare il file"
 
 msgid "Replace file"
 msgstr "Sostituire il file"
+
+msgid "Text modules"
+msgstr "Moduli di testo"
 
 msgid "Select an Option"
 msgstr "Selezionare un'opzione"

--- a/src/onegov/form/locale/rm_CH/LC_MESSAGES/onegov.form.po
+++ b/src/onegov/form/locale/rm_CH/LC_MESSAGES/onegov.form.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE 1.0\n"
-"POT-Creation-Date: 2022-03-20 09:55+0100\n"
+"POT-Creation-Date: 2023-01-26 13:51+0100\n"
 "PO-Revision-Date: 2017-06-28 12:03+0200\n"
 "Last-Translator: Marc Sommerhalder <marc.sommerhalder@seantis.ch>\n"
 "Language-Team: Romansh\n"
@@ -133,6 +133,12 @@ msgstr ""
 msgid "Define at least one required field"
 msgstr ""
 
+#, python-format
+msgid ""
+"The field '{label}' contains a price that requires a credit card payment. "
+"This is only allowed if credit card payments are optional."
+msgstr ""
+
 msgid "Not a valid phone number."
 msgstr "Numer da telefon nunvalaivel."
 
@@ -152,6 +158,9 @@ msgid "Delete file"
 msgstr ""
 
 msgid "Replace file"
+msgstr ""
+
+msgid "Text modules"
 msgstr ""
 
 msgid "Select an Option"

--- a/src/onegov/form/models/submission.py
+++ b/src/onegov/form/models/submission.py
@@ -203,7 +203,11 @@ class FormSubmission(Base, TimestampMixin, Payable, AssociatedFiles,
         """
 
         if price and price.amount > 0:
-            return process_payment(self.payment_method, price, provider, token)
+            if price.credit_card_payment is True:
+                payment_method = 'cc'
+            else:
+                payment_method = self.payment_method
+            return process_payment(payment_method, price, provider, token)
 
         return True
 

--- a/src/onegov/form/parser/core.py
+++ b/src/onegov/form/parser/core.py
@@ -331,8 +331,16 @@ form can be modeled::
         [x] Second IP Address (20 CHF)
         [x] Backup (20 CHF)
 
+    Delivery =
+        (x) Pickup (0 CHF)
+        ( ) Delivery (5 CHF!)
+
 The additional pricing metadata can be used to provide simple order forms.
 As in any other form, dependencies are taken into account.
+
+The optional `!` at the end of the price indicates that credit card payment
+will become mandatory if this option is selected. It is possible to achieve
+this without a price increase too: (0 CHF!)
 
 """
 
@@ -346,7 +354,6 @@ from decimal import Decimal
 from onegov.core.cache import lru_cache
 from onegov.core.utils import Bunch
 from onegov.form import errors
-from onegov.form.errors import MixedTypeError
 from onegov.form.parser.grammar import checkbox, field_help_identifier
 from onegov.form.parser.grammar import code
 from onegov.form.parser.grammar import date
@@ -886,7 +893,7 @@ def parse_field_block(field_block, field_classes,
         assert types <= {'radio', 'checkbox'}
 
         if not len(types) == 1:
-            raise MixedTypeError(key)
+            raise errors.MixedTypeError(key)
 
     result = field_classes[field.type].create(
         field, identifier, parent, fieldset, field_help)
@@ -917,7 +924,7 @@ def parse_field_block(field_block, field_classes,
 
 
 def format_pricing(pricing):
-    if not pricing:
+    if not pricing or not pricing[0]:
         return ''
 
     return ' ({:.2f} {})'.format(pricing[0], pricing[1])

--- a/src/onegov/form/parser/core.py
+++ b/src/onegov/form/parser/core.py
@@ -924,7 +924,7 @@ def parse_field_block(field_block, field_classes,
 
 
 def format_pricing(pricing):
-    if not pricing or not pricing[0]:
+    if not pricing:
         return ''
 
     return ' ({:.2f} {})'.format(pricing[0], pricing[1])

--- a/src/onegov/form/parser/grammar.py
+++ b/src/onegov/form/parser/grammar.py
@@ -388,7 +388,13 @@ def marker_box(characters):
     """
 
     check = mark_enclosed_in(characters)('checked')
-    pricing = Group(enclosed_in(decimal() + currency(), '()'))('pricing')
+
+    cc_payment = Literal('!').setParseAction(matches('!'))
+    cc_payment = Optional(cc_payment, default=False)('credit_card_payment')
+
+    pricing = Group(
+        enclosed_in(decimal() + currency() + cc_payment, '()')
+    )('pricing')
 
     label_text = with_whitespace_inside(text_without(characters + '()'))
     label = MatchFirst((

--- a/src/onegov/org/templates/macros.pt
+++ b/src/onegov/org/templates/macros.pt
@@ -1329,7 +1329,7 @@
             </dd>
         </dl>
 
-        <tal:b condition="price" switch="payment_method">
+        <tal:b condition="price" switch="'cc' if price.credit_card_payment else payment_method">
             <tal:b case="'manual'">
                 <label style="display: none;">
                     <input type="radio" name="payment_method" value="manual" checked>

--- a/src/onegov/pay/models/payment_providers/stripe.py
+++ b/src/onegov/pay/models/payment_providers/stripe.py
@@ -217,7 +217,12 @@ class StripeConnect(PaymentProvider):
             new_price = self.fee_policy.compensate(price.amount)
             new_fee = self.fee_policy.from_amount(new_price)
 
-            return Price(new_price, price.currency, new_fee)
+            return Price(
+                new_price,
+                price.currency,
+                new_fee,
+                price.credit_card_payment
+            )
 
         return price
 

--- a/src/onegov/pay/utils.py
+++ b/src/onegov/pay/utils.py
@@ -5,7 +5,9 @@ from onegov.core.orm import Base
 
 
 @total_ordering
-class Price(namedtuple('PriceBase', ('amount', 'currency', 'fee'))):
+class Price(namedtuple('PriceBase', (
+    'amount', 'currency', 'fee', 'credit_card_payment'
+))):
     """ A single price.
 
     The amount includes the fee. To get the net amount use the net_amount
@@ -13,25 +15,39 @@ class Price(namedtuple('PriceBase', ('amount', 'currency', 'fee'))):
 
     """
 
-    def __new__(cls, amount, currency, fee=0):
-        return super().__new__(cls, Decimal(amount), currency, Decimal(fee))
+    def __new__(cls, amount, currency, fee=0, credit_card_payment=False):
+        return super().__new__(
+            cls,
+            Decimal(amount),
+            currency,
+            Decimal(fee),
+            credit_card_payment
+        )
 
     def __bool__(self):
         return self.amount and True or False
 
     def __lt__(self, other):
+        # FIXME: This probably should assert equal currency as well
         return self.amount < other.amount
 
     def __add__(self, other):
         assert self.currency is None or self.currency == other.currency
+        cc_payment = self.credit_card_payment or other.credit_card_payment
         return self.__class__(
             self.amount + other.amount,
-            self.currency or other.currency
+            self.currency or other.currency,
+            credit_card_payment=cc_payment
         )
 
     def __sub__(self, other):
         assert self.currency == other.currency
-        return self.__class__(self.amount - other.amount, self.currency)
+        cc_payment = self.credit_card_payment or other.credit_card_payment
+        return self.__class__(
+            self.amount - other.amount,
+            self.currency,
+            credit_card_payment=cc_payment
+        )
 
     def __str__(self):
         return '{:.2f} {}'.format(self.amount, self.currency)
@@ -47,7 +63,8 @@ class Price(namedtuple('PriceBase', ('amount', 'currency', 'fee'))):
         return {
             'amount': float(self.amount),
             'currency': self.currency,
-            'fee': float(self.fee)
+            'fee': float(self.fee),
+            'credit_card_payment': self.credit_card_payment
         }
 
     @property

--- a/src/onegov/town6/templates/macros.pt
+++ b/src/onegov/town6/templates/macros.pt
@@ -635,7 +635,7 @@
             </ul>
         </div>
         <div id="after-panels" metal:define-slot="after-panels"></div>
-        
+
         <div class="more-news side-panel" tal:condition="siblings|False">
             <h3 i18n:translate="">More news</h3>
             <ul class="more-list">
@@ -1346,7 +1346,7 @@
             data-link-webm-low-res="${link_webm_low_res}"
         >
             Your browser does not support the video tag.
-        </video> 
+        </video>
         <div style="height: 0; width: 100%; padding-bottom: calc(9 / 16 *100%);" id="spacer"></div>
     </div>
 </metal:autoplay_video>
@@ -1559,7 +1559,7 @@
             </dd>
         </dl>
 
-        <tal:b condition="price" switch="payment_method">
+        <tal:b condition="price" switch="'cc' if price.credit_card_payment else payment_method">
             <tal:b case="'manual'">
                 <label style="display: none;">
                     <input type="radio" name="payment_method" value="manual" checked>

--- a/tests/onegov/form/test_grammar.py
+++ b/tests/onegov/form/test_grammar.py
@@ -239,6 +239,7 @@ def test_prices():
     assert not f.checked
     assert f.pricing.amount == Decimal('100.00')
     assert f.pricing.currency == 'CHF'
+    assert not f.pricing.credit_card_payment
 
     f = field.parseString("(x) Luxurious Choice (200 CHF)")
     assert f.type == 'radio'
@@ -246,6 +247,15 @@ def test_prices():
     assert f.checked
     assert f.pricing.amount == Decimal('200.00')
     assert f.pricing.currency == 'CHF'
+    assert not f.pricing.credit_card_payment
+
+    f = field.parseString("(x) Mail delivery (5 CHF!)")
+    assert f.type == 'radio'
+    assert f.label == 'Mail delivery'
+    assert f.checked
+    assert f.pricing.amount == Decimal('5.00')
+    assert f.pricing.currency == 'CHF'
+    assert f.pricing.credit_card_payment
 
     field = checkbox()
 
@@ -255,6 +265,7 @@ def test_prices():
     assert f.checked
     assert f.pricing.amount == Decimal('150.50')
     assert f.pricing.currency == 'USD'
+    assert not f.pricing.credit_card_payment
 
     f = field.parseString("[ ] Priority Boarding (15.00 USD)")
     assert f.type == 'checkbox'
@@ -262,6 +273,7 @@ def test_prices():
     assert not f.checked
     assert f.pricing.amount == Decimal('15.00')
     assert f.pricing.currency == 'USD'
+    assert not f.pricing.credit_card_payment
 
     f = field.parseString("[ ] Discount (-5.00 USD)")
     assert f.type == 'checkbox'
@@ -269,6 +281,15 @@ def test_prices():
     assert not f.checked
     assert f.pricing.amount == Decimal('-5.00')
     assert f.pricing.currency == 'USD'
+    assert not f.pricing.credit_card_payment
+
+    f = field.parseString("[x] Mail delivery (5 CHF!)")
+    assert f.type == 'checkbox'
+    assert f.label == 'Mail delivery'
+    assert f.checked
+    assert f.pricing.amount == Decimal('5.00')
+    assert f.pricing.currency == 'CHF'
+    assert f.pricing.credit_card_payment
 
 
 def test_non_prices():

--- a/tests/onegov/form/test_parser.py
+++ b/tests/onegov/form/test_parser.py
@@ -347,14 +347,14 @@ def test_parse_radio_with_pricing():
     text = dedent("""
         Drink =
             ( ) Coffee (2.50 CHF)
-            (x) Tea (1.50 CHF)
+            (x) Tea (1.50 CHF!)
         << beer cant be cheaper than water >>
     """)
 
     form = parse_form(text)()
     assert form.drink.pricing.rules == {
-        'Coffee': Price(Decimal(2.5), 'CHF'),
-        'Tea': Price(Decimal(1.5), 'CHF')
+        'Coffee': Price(2.5, 'CHF'),
+        'Tea': Price(1.5, 'CHF', credit_card_payment=True)
     }
     assert form.drink.description == 'beer cant be cheaper than water'
 
@@ -363,17 +363,18 @@ def test_parse_checkbox_with_pricing():
 
     text = dedent("""
         Extras =
-            [ ] Bacon (2.50 CHF)
+            [ ] Bacon (2.50 CHF!)
             [x] Cheese (1.50 CHF)
     """)
 
     form = parse_form(text)()
     assert form.extras.pricing.rules == {
-        'Bacon': Price(Decimal(2.5), 'CHF'),
-        'Cheese': Price(Decimal(1.5), 'CHF')
+        'Bacon': Price(2.5, 'CHF', credit_card_payment=True),
+        'Cheese': Price(1.5, 'CHF')
     }
     assert form.extras.pricing.rules['Bacon'].amount == Decimal(2.5)
     assert form.extras.pricing.rules['Bacon'].currency == 'CHF'
+    assert form.extras.pricing.rules['Bacon'].credit_card_payment is True
 
 
 def test_dependent_validation():

--- a/tests/onegov/pay/test_utils.py
+++ b/tests/onegov/pay/test_utils.py
@@ -11,15 +11,17 @@ def test_price():
     assert Price(10, 'CHF')[0] == Decimal(10)
     assert Price(10, 'CHF')[1] == 'CHF'
 
-    amount, currency, fee = Price(10, 'CHF')
+    amount, currency, fee, cc = Price(10, 'CHF')
     assert amount == Decimal(10)
     assert currency == 'CHF'
     assert fee == Decimal(0)
+    assert cc is False
 
     assert Price(10, 'CHF').as_dict() == {
         'amount': 10.0,
         'currency': 'CHF',
-        'fee': 0
+        'fee': 0,
+        'credit_card_payment': False,
     }
 
     assert str(Price(10, 'CHF')) == '10.00 CHF'


### PR DESCRIPTION
## Commit message

Form: Extends pricing options with a credit card payment flag

This allows users to define custom forms where the credit card payment is mandatory based on whether or not the person submitting the form has selected a certain option or not.

E.g. a delivery field where they have to pay online right away if they want the item to be delivered, but they can pay later in person if they choose to pick it up themselves instead:

```
Delivery *=
    ( ) Pickup (0 CHF)
    ( ) Delivery (5 CHF!)
```

TYPE: Feature
LINK: OGC-910

## Checklist

- [x] I made changes/features for both org and town6
- [x] I have performed a self-review of my code
- [x] I have tested my code thoroughly by hand
- [x] I have added tests for my changes/features
- [x] I have updated the PO files
