### PR TITLE
Election Day: Avoid displaying bar charts with only inactive bars.

### DIFF
--- a/src/onegov/election_day/utils/election/lists.py
+++ b/src/onegov/election_day/utils/election/lists.py
@@ -146,7 +146,7 @@ def get_lists_data(
 ):
     """" View the lists as JSON. Used to for the lists bar chart. """
 
-    completed = election.completed
+    allocated_mandates = election.allocated_mandates
     colors = election.colors
 
     if election.type == 'majorz':
@@ -161,9 +161,10 @@ def get_lists_data(
             {
                 'text': list_.name,
                 'value': list_.votes,
-                'value2': list_.number_of_mandates if completed else None,
+                'value2': list_.number_of_mandates,
                 'class': (
-                    'active' if completed and list_.number_of_mandates
+                    'active'
+                    if list_.number_of_mandates or not allocated_mandates
                     else 'inactive'
                 ),
                 'color': colors.get(list_.name)

--- a/src/onegov/election_day/utils/election_compound/list_groups.py
+++ b/src/onegov/election_day/utils/election_compound/list_groups.py
@@ -44,7 +44,7 @@ def get_list_groups_data(election_compound):
     if not results:
         return {'results': []}
 
-    completed = election_compound.completed
+    allocated_mandates = election_compound.allocated_mandates
     return {
         'results': [
             {
@@ -52,7 +52,8 @@ def get_list_groups_data(election_compound):
                 'value': round(result.voters_count or 0),
                 'value2': result.number_of_mandates,
                 'class': (
-                    'active' if completed and result.number_of_mandates
+                    'active'
+                    if result.number_of_mandates or not allocated_mandates
                     else 'inactive'
                 ),
                 'color': election_compound.colors.get(result.name)

--- a/src/onegov/election_day/utils/parties/parties.py
+++ b/src/onegov/election_day/utils/parties/parties.py
@@ -122,6 +122,7 @@ def get_party_results_horizontal_data(item):
 
     attribute = 'voters_count' if item.voters_counts else 'votes'
     years, parties = get_party_results(item)
+    allocated_mandates = item.allocated_mandates
 
     party_names = {}
     for party_id, party in parties.items():
@@ -159,7 +160,9 @@ def get_party_results_horizontal_data(item):
                     'value': value,
                     'value2': party.get('mandates'),
                     'class': (
-                        'active' if active and party.get('mandates')
+                        'active' if active and (
+                            party.get('mandates') or not allocated_mandates
+                        )
                         else 'inactive'
                     ),
                     'color': party.get('color'),

--- a/tests/onegov/election_day/utils/test_election_compound_utils.py
+++ b/tests/onegov/election_day/utils/test_election_compound_utils.py
@@ -221,42 +221,42 @@ def test_election_compound_utils_parties(import_test_datasets, session):
     assert get_list_groups_data(election_compound) == {
         'results': [
             {
-                'class': 'inactive',
+                'class': 'active',
                 'color': '#EE7F00',
                 'text': 'CVP',
                 'value': 931,
                 'value2': 22
             },
             {
-                'class': 'inactive',
+                'class': 'active',
                 'color': '#019040',
                 'text': 'SVP',
                 'value': 899,
                 'value2': 19
             },
             {
-                'class': 'inactive',
+                'class': 'active',
                 'color': '#0E52A0',
                 'text': 'FDP',
                 'value': 863,
                 'value2': 18
             },
             {
-                'class': 'inactive',
+                'class': 'active',
                 'color': '#99C040',
                 'text': 'AL',
                 'value': 538,
                 'value2': 10
             },
             {
-                'class': 'inactive',
+                'class': 'active',
                 'color': '#E53136',
                 'text': 'SP',
                 'value': 418,
                 'value2': 7
             },
             {
-                'class': 'inactive',
+                'class': 'active',
                 'color': '#acc700',
                 'text': 'GLP',
                 'value': 236,

--- a/tests/onegov/election_day/views/test_views_election_compound.py
+++ b/tests/onegov/election_day/views/test_views_election_compound.py
@@ -497,21 +497,21 @@ def test_view_election_compound_list_groups(election_day_app_gr):
     assert groups == {
         'results': [
             {
-                'class': 'inactive',
+                'class': 'active',
                 'color': '#efb52c',
                 'text': 'BDP',
                 'value': 603,
                 'value2': 1
             },
             {
-                'class': 'inactive',
+                'class': 'active',
                 'color': '#ff6300',
                 'text': 'CVP',
                 'value': 491,
                 'value2': 1
             },
             {
-                'class': 'inactive',
+                'class': 'active',  # no mandates allocated yet
                 'color': None,
                 'text': 'FDP',
                 'value': 351,


### PR DESCRIPTION
## Commit message

Election Day: Avoid displaying bar charts with only inactive bars.

Show bar chart bars as active as long as no mandate has been allocated.

TYPE: Feature
LINK: OGC-934

## Checklist

- [x] I have performed a self-review of my code
- [x] I have tested my code thoroughly by hand