### PR TITLE
Form: Adds optional pricing to integer range fields

### DIFF
--- a/src/onegov/form/core.py
+++ b/src/onegov/form/core.py
@@ -98,7 +98,13 @@ class Form(BaseForm):
                 'yes': (10.0, 'CHF')
             })
 
-            delivery = RadioField('Option', choices=[
+            stamps = IntegerRangeField(
+            'No. Stamps',
+            range=range(0, 30),
+            pricing={range(0, 30): (0.85, 'CHF')}
+        )
+
+            delivery = RadioField('Delivery', choices=[
                 ('pick_up', 'Pick up'),
                 ('post', 'Post')
             ], pricing={
@@ -715,29 +721,46 @@ class Pricing:
         )
 
     def price(self, field):
-        if isinstance(field.data, list):
-            total = None
-            credit_card_payment = False
+        values = field.data
+        if not isinstance(field.data, list):
+            values = [values]
 
-            for value in field.data:
-                price = self.rules.get(value, None)
+        total = None
+        credit_card_payment = False
+        for value in values:
+            price = self.rules.get(value, None)
+            amount = None
 
-                if price is not None:
-                    total = (total or Decimal(0)) + price.amount
-                    currency = price.currency
-                    if price.credit_card_payment is True:
-                        credit_card_payment = True
+            if price is not None:
+                amount = price.amount
+            elif isinstance(value, int):
+                # check integer ranges (for integer range fields)
+                for key, price in self.rules.items():
+                    if not isinstance(key, range):
+                        continue
 
-            if total is None:
-                return None
-            else:
-                return Price(
-                    total,
-                    currency,
-                    credit_card_payment=credit_card_payment
-                )
+                    if value in key:
+                        if value != 0:
+                            # we special case this, because we don't
+                            # want to e.g. require credit card payments
+                            # if 0 items have been selected
+                            amount = price.amount * value
+                        break
 
-        return self.rules.get(field.data, None)
+            if amount is not None:
+                total = (total or Decimal(0)) + amount
+                currency = price.currency
+                if price.credit_card_payment is True:
+                    credit_card_payment = True
+
+        if total is None:
+            return None
+        else:
+            return Price(
+                total,
+                currency,
+                credit_card_payment=credit_card_payment
+            )
 
 
 def merge_forms(*forms):

--- a/src/onegov/form/parser/form.py
+++ b/src/onegov/form/parser/form.py
@@ -227,6 +227,7 @@ def handle_field(builder, field, dependency=None):
             label=field.label,
             dependency=dependency,
             required=field.required,
+            pricing=field.pricing,
             validators=[
                 NumberRange(
                     field.range.start,

--- a/tests/onegov/form/test_grammar.py
+++ b/tests/onegov/form/test_grammar.py
@@ -291,6 +291,26 @@ def test_prices():
     assert f.pricing.currency == 'CHF'
     assert f.pricing.credit_card_payment
 
+    field = integer_range_field()
+    f = field.parseString("0..30 (0.85 CHF)")
+    assert f.type == 'integer_range'
+    assert f[0] == range(0, 30)
+    assert f.pricing.amount == Decimal('0.85')
+    assert f.pricing.currency == 'CHF'
+    assert not f.pricing.credit_card_payment
+
+    f = field.parseString("5..10 (2 USD!)")
+    assert f.type == 'integer_range'
+    assert f[0] == range(5, 10)
+    assert f.pricing.amount == Decimal('2')
+    assert f.pricing.currency == 'USD'
+    assert f.pricing.credit_card_payment
+
+    f = field.parseString("0..10")
+    assert f.type == 'integer_range'
+    assert f[0] == range(0, 10)
+    assert not f.pricing
+
 
 def test_non_prices():
     field = radio()


### PR DESCRIPTION

## Commit message

Form: Adds optional pricing to integer range fields

Price will be multiplied by the amount entered into the field.
The credit card payment flag works on this field as well. E.g:

```
Number of stamps *= 0..30 (0.85 CHF!)
```

TYPE: Feature
LINK: OGC-942

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes/features
