### PR TITLE
Town6: Allows steps in layouts to be hidden on a per view basis.

### DIFF
--- a/src/onegov/stepsequence/extension.py
+++ b/src/onegov/stepsequence/extension.py
@@ -32,6 +32,10 @@ class StepsLayoutExtension(StepBaseExtension):
     For steps registered on layouts.
     """
 
+    def __init__(self, *args, **kwargs):
+        self.hide_steps = kwargs.pop('hide_steps', False)
+        super().__init__(*args, **kwargs)
+
     @property
     def step_position(self):
         """ Can be overwritten by the model and based request params. """
@@ -42,10 +46,13 @@ class StepsLayoutExtension(StepBaseExtension):
         return step_sequences.registry[self.__class__.__name__]
 
     def get_step_sequence(self, position=None):
-        """ Retrieve the full step sequence for thue current model.
+        """ Retrieve the full step sequence for the current model.
         If the latter has multiple steps registered, you must provide
         the position or a ValueError gets raised.
         """
+        if self.hide_steps is True:
+            return []
+
         step = self.registered_steps.get(
             position=position or self.step_position)
         return step and step_sequences.by_id(step.id)

--- a/src/onegov/town6/layout.py
+++ b/src/onegov/town6/layout.py
@@ -337,7 +337,7 @@ class FormEditorLayout(DefaultLayout):
     cls_before='DirectoryEntryLayout',
     cls_after='TicketChatMessageLayout'
 )
-class FormSubmissionLayout(DefaultLayout, StepsLayoutExtension):
+class FormSubmissionLayout(StepsLayoutExtension, DefaultLayout):
 
     def __init__(self, model, request, title=None):
         super().__init__(model, request)
@@ -719,22 +719,6 @@ class TicketLayout(DefaultLayout):
                     attrs={'class': 'ticket-pdf'}
                 )
             )
-            links.append(
-                Link(
-                    text=_("Upload to Gever"),
-                    url=self.request.link(self.model, 'send-to-gever'),
-                    attrs={'class': 'upload'},
-                    traits=(
-                        Confirm(
-                            _("Do you really want to upload this ticket?"),
-                            _("This will upload this ticket to the "
-                              "Gever instance, if configured."),
-                            _("Upload Ticket"),
-                            _("Cancel")
-                        )
-                    )
-                )
-            )
 
             return links
 
@@ -767,7 +751,7 @@ class TicketNoteLayout(DefaultLayout):
 @step_sequences.registered_step(
     3, _('Confirmation'),
     cls_before='ReservationLayout')
-class TicketChatMessageLayout(DefaultLayout, StepsLayoutExtension):
+class TicketChatMessageLayout(StepsLayoutExtension, DefaultLayout):
 
     def __init__(self, model, request, internal=False):
         super().__init__(model, request)
@@ -1141,7 +1125,7 @@ class ResourceLayout(DefaultLayout):
 @step_sequences.registered_step(
     2, _("Check"),
     cls_before='ReservationLayout', cls_after='TicketChatMessageLayout')
-class ReservationLayout(ResourceLayout, StepsLayoutExtension):
+class ReservationLayout(StepsLayoutExtension, ResourceLayout):
     editbar_links = None
 
     @property
@@ -1418,7 +1402,7 @@ class OccurrenceLayout(EventBaseLayout):
     cls_before='EventLayout',
     cls_after='TicketChatMessageLayout'
 )
-class EventLayout(EventBaseLayout, StepsLayoutExtension):
+class EventLayout(StepsLayoutExtension, EventBaseLayout):
 
     @cached_property
     def breadcrumbs(self):
@@ -2067,8 +2051,8 @@ class DirectoryEntryBaseLayout(DefaultLayout):
 @step_sequences.registered_step(
     1, _('Form'), cls_after='FormSubmissionLayout'
 )
-class DirectoryEntryCollectionLayout(DirectoryEntryBaseLayout,
-                                     StepsLayoutExtension):
+class DirectoryEntryCollectionLayout(StepsLayoutExtension,
+                                     DirectoryEntryBaseLayout):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -2223,7 +2207,7 @@ class DirectoryEntryCollectionLayout(DirectoryEntryBaseLayout,
 
 
 @step_sequences.registered_step(1, _('Form'), cls_after='FormSubmissionLayout')
-class DirectoryEntryLayout(DirectoryEntryBaseLayout, StepsLayoutExtension):
+class DirectoryEntryLayout(StepsLayoutExtension, DirectoryEntryBaseLayout):
 
     @property
     def step_position(self):

--- a/src/onegov/town6/views/directory.py
+++ b/src/onegov/town6/views/directory.py
@@ -33,7 +33,8 @@ def town_view_directories(self, request):
               permission=Secret, form=get_directory_form_class)
 def town_handle_new_directory(self, request, form):
     return handle_new_directory(
-        self, request, form, DirectoryCollectionLayout(self, request))
+        self, request, form,
+        DirectoryCollectionLayout(self, request, hide_steps=True))
 
 
 @TownApp.form(model=ExtendedDirectoryEntryCollection, name='edit',

--- a/tests/onegov/stepsequence/test_steps.py
+++ b/tests/onegov/stepsequence/test_steps.py
@@ -36,20 +36,20 @@ def test_step_layout_extension(sequences):
             self.model = model
 
     @sequences.registered_step(1, 'Start', cls_after='MiddleLayout')
-    class StartLayout(BaseLayout, StepsLayoutExtension):
+    class StartLayout(StepsLayoutExtension, BaseLayout):
         @property
         def step_position(self):
             return 1
 
     @sequences.registered_step(2, 'Middle', cls_after='MiddleLayout',
                                cls_before='StartLayout')
-    class MiddleLayout(BaseLayout, StepsLayoutExtension):
+    class MiddleLayout(StepsLayoutExtension, BaseLayout):
         @property
         def step_position(self):
             return 2
 
     @sequences.registered_step(3, 'End', cls_before='MiddleLayout')
-    class EndLayout(BaseLayout, StepsLayoutExtension):
+    class EndLayout(StepsLayoutExtension, BaseLayout):
         @property
         def step_position(self):
             return 3
@@ -60,6 +60,9 @@ def test_step_layout_extension(sequences):
 
     assert start.get_step_sequence() == end.get_step_sequence() == \
            middle.get_step_sequence()
+
+    start_with_hidden_steps = StartLayout(None, hide_steps=True)
+    assert start_with_hidden_steps.get_step_sequence() == []
 
 
 def test_step_registry(sequences):


### PR DESCRIPTION
## Commit message

Town6: Allows steps in layouts to be hidden on a per view basis.

This allows sharing the same layout between e.g. a guest view which has a sequence of steps and an editor view which does not.

Hides the step sequence when adding a new directory entry as admin.

TYPE: Feature
LINK: OGC-956

## Checklist

- [x] I have performed a self-review of my code
- [x] I have tested my code thoroughly by hand
- [x] I have added tests for my changes/features
