### PR TITLE
Town6: Adds Missing commas in the error message.

### DIFF
--- a/src/onegov/town6/locale/de_CH/LC_MESSAGES/onegov.town6.po
+++ b/src/onegov/town6/locale/de_CH/LC_MESSAGES/onegov.town6.po
@@ -839,7 +839,7 @@ msgid ""
 "Persons living outside the following zipcodes may only reserve this "
 "allocation on the ${date}: ${zipcodes}"
 msgstr ""
-"Personen die ausserhalb der folgenden Postleitzahlen leben können diese "
+"Personen, die ausserhalb der folgenden Postleitzahlen leben, können diese "
 "Reservation erst am ${date} tätigen: ${zipcodes}"
 
 msgid "Quota"


### PR DESCRIPTION
Please fill in the commit message below and work through the checklist. You can delete parts that are not needed, e.g. the optional description, the link to a ticket or irrelevant options of the checklist.

## Commit message

Town6: Adds Missing commas in the error message

TYPE: Bugfix
LINK: OGC-943

## Checklist

- [x] I have performed a self-review of my code
- [x] I have updated the PO files

