### PR TITLE
Org: Allows publication dates on directory entries to be required

### DIFF
--- a/src/onegov/org/forms/directory.py
+++ b/src/onegov/org/forms/directory.py
@@ -283,6 +283,12 @@ class DirectoryBaseForm(Form):
         fieldset=_("Publication"),
         default=False)
 
+    required_publication = BooleanField(
+        label=_("Required publication dates"),
+        fieldset=_("Publication"),
+        depends_on=('enable_publication', 'y'),
+        default=False)
+
     submitter_meta_fields = MultiCheckboxField(
         label=_("Information to be provided in addition to the E-mail"),
         choices=(

--- a/src/onegov/org/locale/de_CH/LC_MESSAGES/onegov.org.po
+++ b/src/onegov/org/locale/de_CH/LC_MESSAGES/onegov.org.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE 1.0\n"
-"POT-Creation-Date: 2023-02-07 09:26+0100\n"
+"POT-Creation-Date: 2023-02-09 09:04+0100\n"
 "PO-Revision-Date: 2022-03-15 10:21+0100\n"
 "Last-Translator: Marc Sommerhalder <marc.sommerhalder@seantis.ch>\n"
 "Language-Team: German\n"
@@ -474,6 +474,9 @@ msgstr ""
 
 msgid "Publication"
 msgstr "Publikation"
+
+msgid "Required publication dates"
+msgstr "Publikationsdaten erforderlich"
 
 msgid "Information to be provided in addition to the E-mail"
 msgstr "Zusätzliche zur E-Mail benötigte Informationen des Antragstellers"

--- a/src/onegov/org/locale/fr_CH/LC_MESSAGES/onegov.org.po
+++ b/src/onegov/org/locale/fr_CH/LC_MESSAGES/onegov.org.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE 1.0\n"
-"POT-Creation-Date: 2023-02-07 09:26+0100\n"
+"POT-Creation-Date: 2023-02-09 09:04+0100\n"
 "PO-Revision-Date: 2022-03-15 10:50+0100\n"
 "Last-Translator: Marc Sommerhalder <marc.sommerhalder@seantis.ch>\n"
 "Language-Team: French\n"
@@ -475,6 +475,9 @@ msgstr ""
 
 msgid "Publication"
 msgstr "Publication"
+
+msgid "Required publication dates"
+msgstr "Les dates de publication sont requises"
 
 msgid "Information to be provided in addition to the E-mail"
 msgstr "Informations complémentaires du demandeur requises à l'e-mail"

--- a/src/onegov/org/locale/it_CH/LC_MESSAGES/onegov.org.po
+++ b/src/onegov/org/locale/it_CH/LC_MESSAGES/onegov.org.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"POT-Creation-Date: 2023-02-07 09:26+0100\n"
+"POT-Creation-Date: 2023-02-09 09:04+0100\n"
 "PO-Revision-Date: 2022-03-15 10:52+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -476,6 +476,9 @@ msgstr ""
 
 msgid "Publication"
 msgstr "Pubblicazione"
+
+msgid "Required publication dates"
+msgstr "Date di pubblicazione obbligatorie"
 
 msgid "Information to be provided in addition to the E-mail"
 msgstr "Informazioni da fornire in aggiunta all'e-mail"

--- a/src/onegov/org/models/directory.py
+++ b/src/onegov/org/models/directory.py
@@ -221,6 +221,7 @@ class ExtendedDirectory(Directory, AccessExtension, Extendable):
     enable_submissions = meta_property()
     enable_change_requests = meta_property()
     enable_publication = meta_property()
+    required_publication = meta_property()
     submitter_meta_fields = meta_property()
 
     submissions_guideline = content_property()

--- a/src/onegov/org/views/directory.py
+++ b/src/onegov/org/views/directory.py
@@ -29,6 +29,7 @@ from onegov.core.elements import Link
 from purl import URL
 from tempfile import NamedTemporaryFile
 from webob.exc import HTTPForbidden
+from wtforms.validators import InputRequired
 
 from onegov.org.models.directory import ExtendedDirectoryEntryCollection
 
@@ -49,6 +50,9 @@ def get_directory_entry_form_class(model, request):
             if not model.directory.enable_publication and not request.is_admin:
                 self.delete_field('publication_start')
                 self.delete_field('publication_end')
+            elif model.directory.required_publication:
+                self.publication_start.validators[0] = InputRequired()
+                self.publication_end.validators[0] = InputRequired()
 
     return OptionalMapPublicationForm
 

--- a/tests/onegov/org/test_views_directory.py
+++ b/tests/onegov/org/test_views_directory.py
@@ -44,9 +44,9 @@ def strip_s(dt, timezone=None):
     return standardize_date(dt, timezone)
 
 
-def create_directory(client, publication=True, change_reqs=True,
-                     submission=True, extended_submitter=False,
-                     title='Meetings', lead=None
+def create_directory(client, publication=True, required_publication=False,
+                     change_reqs=True, submission=True,
+                     extended_submitter=False, title='Meetings', lead=None
                      ):
     client.login_admin()
     page = client.get('/directories').click('Verzeichnis')
@@ -63,6 +63,7 @@ def create_directory(client, publication=True, change_reqs=True,
     page.form['enable_map'] = 'entry'
     page.form['thumbnail'] = 'Pic'
     page.form['enable_publication'] = publication
+    page.form['required_publication'] = required_publication
     page.form['enable_change_requests'] = change_reqs
     if submission:
         page.form['enable_submissions'] = True
@@ -134,6 +135,29 @@ def test_publication_added_by_admin(client):
     # check new submission
     page = meetings.click('Eintrag', index=1)
     assert 'publication_start' not in page.form.fields
+
+
+def test_required_publication(client):
+    utc_now = utcnow()
+    now = to_timezone(utc_now, 'Europe/Zurich')
+
+    meetings = create_directory(client, required_publication=True)
+
+    # These url should be available for people who know it
+    client.get('/directories/meetings/+submit')
+
+    # create one entry as admin, publications is still available for admin
+    page = meetings.click('Eintrag', index=0)
+    page.form['name'] = 'Annual'
+    page.form['pic'] = Upload('annual.jpg', create_image().read())
+    page.form['publication_start'] = dt_for_form(now)
+    page = page.form.submit()
+    assert 'Dieses Feld wird benötigt' in page
+    # we have to submit the file again, can't evade that
+    page.form['pic'] = Upload('annual.jpg', create_image().read())
+    annual_end = now + timedelta(days=1)
+    page.form['publication_end'] = dt_for_form(annual_end)
+    page.form.submit().follow()
 
 
 def test_publication_with_submission(client):


### PR DESCRIPTION
## Commit message

Org: Allows publication dates on directory entries to be required
This is useful for directories where the publication has to be limited e.g. for planning applications, where a public participation period is mandated, but publishing it beyond that would raise privacy concerns.

TYPE: Feature
LINK: OGC-913

## Checklist

- [x] I have performed a self-review of my code
- [x] I have tested my code thoroughly by hand
- [x] I have added tests for my changes/features
- [x] I have updated the PO files
