### PR TITLE
Ogc 947 show events in the past from link

### DIFF
--- a/src/onegov/event/collections/occurrences.py
+++ b/src/onegov/event/collections/occurrences.py
@@ -218,7 +218,7 @@ class OccurrenceCollection(Pagination):
         if self.start is not None or self.outdated is False:
             if self.start is None:
                 start = date.today()
-            elif self.range:
+            elif self.range == 'past':
                 start = self.start
             else:
                 start = self.start

--- a/src/onegov/event/collections/occurrences.py
+++ b/src/onegov/event/collections/occurrences.py
@@ -118,9 +118,9 @@ class OccurrenceCollection(Pagination):
             start = today.replace(day=1)
             return start, start + relativedelta(months=1, days=-1)
         if range == 'past':
-            milenium = date(2000, 1, 1)
+            millennium = date(2000, 1, 1)
             yesterday = today - timedelta(days=1)
-            return milenium, yesterday
+            return millennium, yesterday
         pass
 
     def for_filter(self, **kwargs):

--- a/src/onegov/event/collections/occurrences.py
+++ b/src/onegov/event/collections/occurrences.py
@@ -24,9 +24,9 @@ class OccurrenceCollection(Pagination):
     automatically when adding a new event.
 
     Occurrences can be filtered by relative date ranges (``today``,
-    ``tomorrow``, ``weekend``, ``week``, ``month``) or by a given start date
-    and/or end date. The range filter is dominant and overwrites the start and
-    end dates if provided.
+    ``tomorrow``, ``weekend``, ``week``, ``month``, ``past``) or by a
+    given start date and/or end date. The range filter is dominant and
+    overwrites the start and end dates if provided.
 
     By default, only current occurrences are used.
 
@@ -34,7 +34,7 @@ class OccurrenceCollection(Pagination):
 
     """
 
-    date_ranges = ('today', 'tomorrow', 'weekend', 'week', 'month')
+    date_ranges = ('today', 'tomorrow', 'weekend', 'week', 'month', 'past')
 
     def __init__(
         self,
@@ -90,6 +90,7 @@ class OccurrenceCollection(Pagination):
             - weekend (next or current Friday to Sunday)
             - week (current Monday to Sunday)
             - month (current)
+            - past (events in the past)
 
         """
         if range not in self.date_ranges:
@@ -116,6 +117,10 @@ class OccurrenceCollection(Pagination):
         if range == 'month':
             start = today.replace(day=1)
             return start, start + relativedelta(months=1, days=-1)
+        if range == 'past':
+            milenium = date(2000, 1, 1)
+            yesterday = today - timedelta(days=1)
+            return milenium, yesterday
         pass
 
     def for_filter(self, **kwargs):
@@ -213,6 +218,8 @@ class OccurrenceCollection(Pagination):
         if self.start is not None or self.outdated is False:
             if self.start is None:
                 start = date.today()
+            elif self.range:
+                start = self.start
             else:
                 start = self.start
                 if self.outdated is False:
@@ -267,7 +274,11 @@ class OccurrenceCollection(Pagination):
                 ])
             )
 
-        query = query.order_by(Occurrence.start, Occurrence.title)
+        if self.range == 'past':
+            # reverse order for past events: most recent event on top
+            query = query.order_by(Occurrence.start.desc(), Occurrence.title)
+        else:
+            query = query.order_by(Occurrence.start, Occurrence.title)
 
         return query
 

--- a/src/onegov/org/assets/js/date-range-selector.js
+++ b/src/onegov/org/assets/js/date-range-selector.js
@@ -1,11 +1,12 @@
 // set date filter on input change
 var set_date_range_selector_filter = function(name, value) {
     var location = new Url();
+    var date;
 
     if (value === "") {
         delete location.query[name];
     } else {
-        var date = moment(value, 'YYYY-MM-DD', true);
+        date = moment(value, 'YYYY-MM-DD', true);
         if (!date.isValid()) {
             return;
         }
@@ -19,7 +20,11 @@ var set_date_range_selector_filter = function(name, value) {
     }
 
     delete location.query.page;
-    delete location.query.range;
+
+    // keep range in query if range is equal 'past' and if date (value) is in the past, otherwise delete
+    if (date.isSame(moment(), 'day') || date.isAfter(moment(), 'day') || location.query.range != 'past') {
+        delete location.query.range;
+    }
 
     var url = location.toString();
     var target = $('.date-range-selector-target');

--- a/src/onegov/org/locale/de_CH/LC_MESSAGES/onegov.org.po
+++ b/src/onegov/org/locale/de_CH/LC_MESSAGES/onegov.org.po
@@ -2132,6 +2132,9 @@ msgstr "Letztes Jahr"
 msgid "Older"
 msgstr "Älter"
 
+msgid "Past events"
+msgstr "Vergangene Veranstaltungen"
+
 msgid "Do you really want to delete this note?"
 msgstr "Möchten Sie diese Notiz wirklich löschen?"
 

--- a/src/onegov/org/locale/fr_CH/LC_MESSAGES/onegov.org.po
+++ b/src/onegov/org/locale/fr_CH/LC_MESSAGES/onegov.org.po
@@ -2133,6 +2133,9 @@ msgstr "L'an dernier"
 msgid "Older"
 msgstr "Plus âgés"
 
+msgid "Past Events"
+msgstr "Événements passées"
+
 msgid "Do you really want to delete this note?"
 msgstr "Voulez-vous vraiment supprimer cette note ?"
 

--- a/src/onegov/org/locale/it_CH/LC_MESSAGES/onegov.org.po
+++ b/src/onegov/org/locale/it_CH/LC_MESSAGES/onegov.org.po
@@ -2143,6 +2143,9 @@ msgstr "Lo scorso anno"
 msgid "Older"
 msgstr "Più vecchia"
 
+msgid "Past Events"
+msgstr "Eventi passate"
+
 msgid "Do you really want to delete this note?"
 msgstr "Vuoi davvero eliminare questa nota?"
 

--- a/src/onegov/org/templates/macros.pt
+++ b/src/onegov/org/templates/macros.pt
@@ -1030,8 +1030,8 @@
         <p i18n:translate>No events found.</p>
         <br>
         <tal condition="'range' in layout.og_url">
-            <p><a href="${layout.events_url}">Alle Veranstaltungen</a>
-            <br><a href="${layout.events_url}&amp;range=past">Vergangene Veranstaltungen</a>
+            <p><a href="${layout.events_url}" i18n:translate>All events</a>
+            <br><a href="${layout.events_url}&amp;range=past" i18n:translate>Past events</a>
         </tal>
     </tal:b>
 </metal:occurrences>

--- a/src/onegov/org/templates/macros.pt
+++ b/src/onegov/org/templates/macros.pt
@@ -1028,6 +1028,12 @@
     </tal:b>
 
     <div tal:condition="not occurrences" i18n:translate>No events found.</div>
+    <div tal:condition="not occurrences">
+        <br>
+        <a href="${layout.events_url}" class="">Alle Veranstaltungen</a>
+        <br>
+        <a href="${layout.events_url}&amp;range=past" class="">Vergangene Veranstaltungen</a>
+    </div>
 </metal:occurrences>
 
 <metal:occurrence_list_view define-macro="occurrence_list_view">

--- a/src/onegov/org/templates/macros.pt
+++ b/src/onegov/org/templates/macros.pt
@@ -1029,8 +1029,10 @@
 
     <div tal:condition="not occurrences" i18n:translate>No events found.</div>
     <div tal:condition="not occurrences">
-        <br>
-        <a href="${layout.events_url}" class="">Alle Veranstaltungen</a>
+        <div tal:condition="'range' not in layout.og_url">
+            <br>
+            <a href="${layout.events_url}" class="">Alle Veranstaltungen</a>
+        </div>
         <br>
         <a href="${layout.events_url}&amp;range=past" class="">Vergangene Veranstaltungen</a>
     </div>

--- a/src/onegov/org/templates/macros.pt
+++ b/src/onegov/org/templates/macros.pt
@@ -1029,7 +1029,7 @@
 
     <div tal:condition="not occurrences" i18n:translate>No events found.</div>
     <div tal:condition="not occurrences">
-        <div tal:condition="'range' not in layout.og_url">
+        <div tal:condition="'range' in layout.og_url">
             <br>
             <a href="${layout.events_url}" class="">Alle Veranstaltungen</a>
         </div>

--- a/src/onegov/org/templates/macros.pt
+++ b/src/onegov/org/templates/macros.pt
@@ -1026,17 +1026,14 @@
             <metal:b use-macro="layout.macros['occurrence_list_view']" />
         </div>
     </tal:b>
-
-    <div tal:condition="not occurrences" i18n:translate>No events found.</div>
-    <div tal:condition="not occurrences">
+    <tal:b condition="not occurrences" >
+        <p i18n:translate>No events found.</p>
         <br>
-        <div tal:condition="'range' in layout.og_url">
-            <a href="${layout.events_url}">Alle Veranstaltungen</a>
-        </div>
-        <div>
-            <a href="${layout.events_url}&amp;range=past">Vergangene Veranstaltungen</a>
-        </div>
-    </div>
+        <tal condition="'range' in layout.og_url">
+            <p><a href="${layout.events_url}">Alle Veranstaltungen</a>
+            <br><a href="${layout.events_url}&amp;range=past">Vergangene Veranstaltungen</a>
+        </tal>
+    </tal:b>
 </metal:occurrences>
 
 <metal:occurrence_list_view define-macro="occurrence_list_view">

--- a/src/onegov/org/templates/macros.pt
+++ b/src/onegov/org/templates/macros.pt
@@ -1029,12 +1029,13 @@
 
     <div tal:condition="not occurrences" i18n:translate>No events found.</div>
     <div tal:condition="not occurrences">
-        <div tal:condition="'range' in layout.og_url">
-            <br>
-            <a href="${layout.events_url}" class="">Alle Veranstaltungen</a>
-        </div>
         <br>
-        <a href="${layout.events_url}&amp;range=past" class="">Vergangene Veranstaltungen</a>
+        <div tal:condition="'range' in layout.og_url">
+            <a href="${layout.events_url}">Alle Veranstaltungen</a>
+        </div>
+        <div>
+            <a href="${layout.events_url}&amp;range=past">Vergangene Veranstaltungen</a>
+        </div>
     </div>
 </metal:occurrences>
 

--- a/src/onegov/org/views/occurrence.py
+++ b/src/onegov/org/views/occurrence.py
@@ -68,6 +68,7 @@ def view_occurrences(self, request, layout=None):
             ('weekend', _("This weekend")),
             ('week', _("This week")),
             ('month', _("This month")),
+            ('past', _("Past events")),
         )
     ]
 

--- a/src/onegov/town6/templates/macros.pt
+++ b/src/onegov/town6/templates/macros.pt
@@ -1163,6 +1163,13 @@
     </tal:b>
         </div>
     <div tal:condition="not occurrences" i18n:translate>No events found.</div>
+    <div tal:condition="not occurrences">
+        <!-- "${layout.events_url}" -->
+        <br>
+        <a href="${layout.events_url}" class="">Alle Veranstaltungen</a>
+        <br>
+        <a href="${layout.events_url}&amp;range=past" class="">Vergangene Veranstaltungen</a>
+    </div>
 </metal:occurrences>
 
 <metal:occurrence_list_view define-macro="occurrence_list_view" i18n:domain="onegov.town6">

--- a/src/onegov/town6/templates/macros.pt
+++ b/src/onegov/town6/templates/macros.pt
@@ -1164,12 +1164,13 @@
         </div>
     <div tal:condition="not occurrences" i18n:translate>No events found.</div>
     <div tal:condition="not occurrences">
-        <div tal:condition="'range' in layout.og_url">
-            <br>
-            <a href="${layout.events_url}" class="">Alle Veranstaltungen</a>
-        </div>
         <br>
-        <a href="${layout.events_url}&amp;range=past" class="">Vergangene Veranstaltungen</a>
+        <div tal:condition="'range' in layout.og_url">
+            <a href="${layout.events_url}" class="button hollow">Alle Veranstaltungen</a>
+        </div>
+        <div>
+            <a href="${layout.events_url}&amp;range=past" class="button hollow">Vergangene Veranstaltungen</a>
+        </div>
     </div>
 </metal:occurrences>
 

--- a/src/onegov/town6/templates/macros.pt
+++ b/src/onegov/town6/templates/macros.pt
@@ -1164,7 +1164,6 @@
         </div>
     <div tal:condition="not occurrences" i18n:translate>No events found.</div>
     <div tal:condition="not occurrences">
-        <!-- "${layout.events_url}" -->
         <br>
         <a href="${layout.events_url}" class="">Alle Veranstaltungen</a>
         <br>

--- a/src/onegov/town6/templates/macros.pt
+++ b/src/onegov/town6/templates/macros.pt
@@ -1164,7 +1164,7 @@
         </div>
     <div tal:condition="not occurrences" i18n:translate>No events found.</div>
     <div tal:condition="not occurrences">
-        <div tal:condition="'range' not in layout.og_url">
+        <div tal:condition="'range' in layout.og_url">
             <br>
             <a href="${layout.events_url}" class="">Alle Veranstaltungen</a>
         </div>

--- a/src/onegov/town6/templates/macros.pt
+++ b/src/onegov/town6/templates/macros.pt
@@ -1164,8 +1164,10 @@
         </div>
     <div tal:condition="not occurrences" i18n:translate>No events found.</div>
     <div tal:condition="not occurrences">
-        <br>
-        <a href="${layout.events_url}" class="">Alle Veranstaltungen</a>
+        <div tal:condition="'range' not in layout.og_url">
+            <br>
+            <a href="${layout.events_url}" class="">Alle Veranstaltungen</a>
+        </div>
         <br>
         <a href="${layout.events_url}&amp;range=past" class="">Vergangene Veranstaltungen</a>
     </div>

--- a/src/onegov/town6/templates/macros.pt
+++ b/src/onegov/town6/templates/macros.pt
@@ -1166,8 +1166,8 @@
         <p i18n:translate>No events found.</p>
         <br>
         <tal condition="'range' in layout.og_url">
-            <p><a href="${layout.events_url}" class="button hollow">Alle Veranstaltungen</a>
-            <br><a href="${layout.events_url}&amp;range=past" class="button hollow">Vergangene Veranstaltungen</a>
+            <p><a href="${layout.events_url}" class="button hollow" i18n:translate>All events</a>
+            <br><a href="${layout.events_url}&amp;range=past" class="button hollow" i18n:translate>Past events</a>
         </tal>
     </tal:b>
 </metal:occurrences>

--- a/src/onegov/town6/templates/macros.pt
+++ b/src/onegov/town6/templates/macros.pt
@@ -1162,16 +1162,14 @@
             <metal:b use-macro="layout.macros['occurrence_list_view']" />
     </tal:b>
         </div>
-    <div tal:condition="not occurrences" i18n:translate>No events found.</div>
-    <div tal:condition="not occurrences">
+    <tal:b condition="not occurrences">
+        <p i18n:translate>No events found.</p>
         <br>
-        <div tal:condition="'range' in layout.og_url">
-            <a href="${layout.events_url}" class="button hollow">Alle Veranstaltungen</a>
-        </div>
-        <div>
-            <a href="${layout.events_url}&amp;range=past" class="button hollow">Vergangene Veranstaltungen</a>
-        </div>
-    </div>
+        <tal condition="'range' in layout.og_url">
+            <p><a href="${layout.events_url}" class="button hollow">Alle Veranstaltungen</a>
+            <br><a href="${layout.events_url}&amp;range=past" class="button hollow">Vergangene Veranstaltungen</a>
+        </tal>
+    </tal:b>
 </metal:occurrences>
 
 <metal:occurrence_list_view define-macro="occurrence_list_view" i18n:domain="onegov.town6">

--- a/tests/onegov/event/test_collections.py
+++ b/tests/onegov/event/test_collections.py
@@ -257,12 +257,14 @@ def test_occurrence_collection_query(session):
         assert query(outdated=True, range='weekend').count() == 1
         assert query(outdated=True, range='week').count() == 5
         assert query(outdated=True, range='month').count() == 5
+        assert query(outdated=True, range='past').count() == 1
 
         assert query(outdated=False, range='today').count() == 1
         assert query(outdated=False, range='tomorrow').count() == 2
         assert query(outdated=False, range='weekend').count() == 1
         assert query(outdated=False, range='week').count() == 4
         assert query(outdated=False, range='month').count() == 4
+        assert query(outdated=False, range='past').count() == 1
 
 
 def test_occurrence_collection_pagination(session):
@@ -486,42 +488,49 @@ def test_occurrence_collection_range_to_dates():
         assert to_dates('weekend') == (date(2018, 12, 7), date(2018, 12, 9))
         assert to_dates('week') == (date(2018, 12, 3), date(2018, 12, 9))
         assert to_dates('month') == (date(2018, 12, 1), date(2018, 12, 31))
+        assert to_dates('past') == (date(2000, 1, 1), date(2018, 12, 2))
     with freeze_time("2018-12-06"):
         assert to_dates('today') == (date(2018, 12, 6), date(2018, 12, 6))
         assert to_dates('tomorrow') == (date(2018, 12, 7), date(2018, 12, 7))
         assert to_dates('weekend') == (date(2018, 12, 7), date(2018, 12, 9))
         assert to_dates('week') == (date(2018, 12, 3), date(2018, 12, 9))
         assert to_dates('month') == (date(2018, 12, 1), date(2018, 12, 31))
+        assert to_dates('past') == (date(2000, 1, 1), date(2018, 12, 5))
     with freeze_time("2018-12-07"):
         assert to_dates('today') == (date(2018, 12, 7), date(2018, 12, 7))
         assert to_dates('tomorrow') == (date(2018, 12, 8), date(2018, 12, 8))
         assert to_dates('weekend') == (date(2018, 12, 7), date(2018, 12, 9))
         assert to_dates('week') == (date(2018, 12, 3), date(2018, 12, 9))
         assert to_dates('month') == (date(2018, 12, 1), date(2018, 12, 31))
+        assert to_dates('past') == (date(2000, 1, 1), date(2018, 12, 6))
     with freeze_time("2018-12-08"):
         assert to_dates('today') == (date(2018, 12, 8), date(2018, 12, 8))
         assert to_dates('tomorrow') == (date(2018, 12, 9), date(2018, 12, 9))
         assert to_dates('weekend') == (date(2018, 12, 7), date(2018, 12, 9))
         assert to_dates('week') == (date(2018, 12, 3), date(2018, 12, 9))
         assert to_dates('month') == (date(2018, 12, 1), date(2018, 12, 31))
+        assert to_dates('past') == (date(2000, 1, 1), date(2018, 12, 7))
     with freeze_time("2018-12-09"):
         assert to_dates('today') == (date(2018, 12, 9), date(2018, 12, 9))
         assert to_dates('tomorrow') == (date(2018, 12, 10), date(2018, 12, 10))
         assert to_dates('weekend') == (date(2018, 12, 7), date(2018, 12, 9))
         assert to_dates('week') == (date(2018, 12, 3), date(2018, 12, 9))
         assert to_dates('month') == (date(2018, 12, 1), date(2018, 12, 31))
+        assert to_dates('past') == (date(2000, 1, 1), date(2018, 12, 8))
     with freeze_time("2018-12-10"):
         assert to_dates('today') == (date(2018, 12, 10), date(2018, 12, 10))
         assert to_dates('tomorrow') == (date(2018, 12, 11), date(2018, 12, 11))
         assert to_dates('weekend') == (date(2018, 12, 14), date(2018, 12, 16))
         assert to_dates('week') == (date(2018, 12, 10), date(2018, 12, 16))
         assert to_dates('month') == (date(2018, 12, 1), date(2018, 12, 31))
+        assert to_dates('past') == (date(2000, 1, 1), date(2018, 12, 9))
     with freeze_time("2019-01-31"):
         assert to_dates('today') == (date(2019, 1, 31), date(2019, 1, 31))
         assert to_dates('tomorrow') == (date(2019, 2, 1), date(2019, 2, 1))
         assert to_dates('weekend') == (date(2019, 2, 1), date(2019, 2, 3))
         assert to_dates('week') == (date(2019, 1, 28), date(2019, 2, 3))
         assert to_dates('month') == (date(2019, 1, 1), date(2019, 1, 31))
+        assert to_dates('past') == (date(2000, 1, 1), date(2019, 1, 30))
 
     assert to_dates(None) == (None, None)
     assert to_dates('') == (None, None)


### PR DESCRIPTION
## Commit message

Events: Events from the past can be shown.

In the case of 'No events found' we will display two link buttons. One will point to 'all events' where as the other will show 'past events'. In addition a new time range filter 'past events' was added to achieve the same from filters.

TYPE: Feature
LINK: OGC-947