### PR TITLE
Form: Adds `UploadMultipleField` to forms and a modifier to form code.

### DIFF
--- a/src/onegov/form/collection.py
+++ b/src/onegov/form/collection.py
@@ -6,7 +6,7 @@ from onegov.core.utils import normalize_for_url
 from onegov.core.collection import GenericCollection
 from onegov.file.utils import as_fileintent
 from onegov.form.errors import UnableToComplete
-from onegov.form.fields import UploadField
+from onegov.form.fields import UploadField, UploadMultipleField
 from onegov.form.models import (
     FormDefinition,
     FormSubmission,
@@ -312,23 +312,43 @@ class FormSubmissionCollection:
         }
 
         # move uploaded files to a separate table
-        files = set(
-            field_id for field_id, field in form._fields.items()
+        files = {
+            field_id
+            for field_id, field in form._fields.items()
             if isinstance(field, UploadField) and field_id not in exclude
-        )
+            # we exclude files that should be removed
+            and submission.data.get(field_id) != {}
+        }
 
-        files_to_remove = set(
+        files_to_add = {
             id for id in files
-            if submission.data.get(id) == {}
-        )
+            if (file_meta := submission.data.get(id))
+            and not file_meta['data'].startswith('@')
+        }
 
-        files_to_add = set(
-            id for id in (files - files_to_remove)
-            if submission.data.get(id)
-            and not submission.data[id]['data'].startswith('@')
-        )
+        files_to_keep = files - files_to_add
 
-        files_to_keep = files - files_to_remove - files_to_add
+        multi_files = {
+            field_id: [
+                index
+                for index, data in enumerate(submission.data.get(field_id, []))
+                # we exclude files that should be removed or never be added in
+                # the first place
+                if data is not None and data != {}
+            ]
+            for field_id, field in form._fields.items()
+            if isinstance(field, UploadMultipleField)
+            and field_id not in exclude
+        }
+        multi_files_to_keep = {
+            f'{id}:{idx}'
+            for id, indeces in multi_files.items()
+            if (file_metas := submission.data.get(id))
+            for idx in indeces
+            if file_metas[idx]['data'].startswith('@')
+
+        }
+        files_to_keep |= multi_files_to_keep
 
         # delete all files which are not part of the updated form
         # if no files are given, delete all files belonging to the submission
@@ -340,7 +360,7 @@ class FormSubmissionCollection:
         if trash and inspect(submission).persistent:
             self.session.refresh(submission)
 
-        # store the new fields in the separate table
+        # store the new files in the separate table
 
         for field_id in files_to_add:
             field = getattr(form, field_id)
@@ -363,6 +383,46 @@ class FormSubmissionCollection:
             # we need to mark these changes as only top-level json changes
             # are automatically propagated
             submission.data.changed()
+
+        for field_id, indeces in multi_files.items():
+            datalist = []
+            for new_idx, old_idx in enumerate(indeces):
+                data = submission.data[field_id][old_idx]
+                old_key = f'{field_id}:{old_idx}'
+                new_key = f'{field_id}:{new_idx}'
+                if old_key in files_to_keep:
+                    # update the key in the note field if the index changed
+                    if old_idx != new_idx:
+                        for f in submission.files:
+                            if f.note == old_key:
+                                f.note = new_key
+                                break
+                else:
+                    field = getattr(form, field_id)[old_idx]
+
+                    f = FormFile(
+                        id=random_token(),
+                        name=field.filename,
+                        note=new_key,
+                        reference=as_fileintent(
+                            content=field.file,
+                            filename=field.filename
+                        )
+                    )
+
+                    submission.files.append(f)
+
+                    # replace the data in the submission with a reference
+                    data['data'] = '@{}'.format(f.id)
+
+                datalist.append(data)
+
+            if submission.data[field_id] != datalist:
+                submission.data[field_id] = datalist
+
+                # we need to mark these changes as only top-level json changes
+                # are automatically propagated
+                submission.data.changed()
 
     def remove_old_pending_submissions(self, older_than,
                                        include_external=False):

--- a/src/onegov/form/display.py
+++ b/src/onegov/form/display.py
@@ -137,6 +137,18 @@ class UploadFieldRenderer(BaseRenderer):
         )
 
 
+@registry.register_for('UploadMultipleField')
+class UploadMultipleFieldRenderer(BaseRenderer):
+
+    def __call__(self, field):
+        return '<br>'.join(
+            '{filename} ({size})'.format(
+                filename=self.escape(data['filename']),
+                size=humanize.naturalsize(data['size'])
+            ) for data in field.data if data
+        )
+
+
 @registry.register_for('RadioField')
 class RadioFieldRenderer(BaseRenderer):
 

--- a/src/onegov/form/fields.py
+++ b/src/onegov/form/fields.py
@@ -286,9 +286,9 @@ class UploadMultipleField(FieldList, FileField):
         if not valuelist:
             return
 
-        for fieldstorage in valuelist:
-            if not hasattr(fieldstorage, 'file'):
-                # don't create an entry if it's not a new upload
+        for fs in valuelist:
+            if not (hasattr(fs, 'file') or hasattr(fs, 'stream')):
+                # don't create an entry if we didn't get a fieldstorage
                 continue
 
             # we fake the formdata for the new field
@@ -296,7 +296,7 @@ class UploadMultipleField(FieldList, FileField):
             # needs to get wrapped to be usable in WTForms
             formdata = MultiDict()
             name = f'{self.short_name}{self._separator}{len(self)}'
-            formdata.add(name, fieldstorage)
+            formdata.add(name, fs)
             self._add_entry(formdata)
 
 

--- a/src/onegov/form/fields.py
+++ b/src/onegov/form/fields.py
@@ -3,6 +3,7 @@ import phonenumbers
 import sedate
 
 from cssutils.css import CSSStyleSheet
+from itertools import zip_longest
 from onegov.core.html import sanitize_html
 from onegov.core.utils import binary_to_dictionary
 from onegov.core.utils import dictionary_to_binary
@@ -21,15 +22,19 @@ from onegov.form.widgets import PreviewWidget
 from onegov.form.widgets import TagsWidget
 from onegov.form.widgets import TextAreaWithTextModules
 from onegov.form.widgets import UploadWidget
+from onegov.form.widgets import UploadMultipleWidget
+from werkzeug.datastructures import MultiDict
 from wtforms_components import TimeField as DefaultTimeField
 from wtforms.fields import DateTimeLocalField as DateTimeLocalFieldBase
 from wtforms.fields import Field
+from wtforms.fields import FieldList
 from wtforms.fields import FileField
 from wtforms.fields import SelectField
 from wtforms.fields import SelectMultipleField
 from wtforms.fields import StringField
 from wtforms.fields import TelField
 from wtforms.fields import TextAreaField
+from wtforms.utils import unset_value
 from wtforms.validators import DataRequired
 from wtforms.validators import InputRequired
 from wtforms.validators import ValidationError
@@ -198,6 +203,123 @@ class UploadFileWithORMSupport(UploadField):
             }
         else:
             super().process_data(value)
+
+
+class UploadMultipleField(FieldList, FileField):
+    """ A custom file field that turns the uploaded files into a list of
+    compressed base64 strings together with the filename, size and mimetype.
+
+    This acts both like a single file field with multiple and like a list
+    of :class:`onegov.form.fields.UploadFile` for uploaded files. This way
+    we get the best of both worlds.
+
+    """
+
+    widget = UploadMultipleWidget()
+
+    upload_field_class = UploadField
+    upload_widget = UploadWidget()
+
+    def __init__(
+        self,
+        label=None,
+        validators=None,
+        filters=(),
+        description='',
+        id=None,
+        default=(),
+        widget=None,
+        render_kw=None,
+        name=None,
+        upload_widget=None,
+        _form=None,
+        _prefix='',
+        _translations=None,
+        _meta=None,
+    ):
+        if upload_widget is None:
+            upload_widget = self.upload_widget
+
+        # a lot of the arguments we just pass through to the subfield
+        unbound_field = self.upload_field_class(
+            validators=validators,
+            filters=filters,
+            description=description,
+            widget=upload_widget,
+            render_kw=render_kw,
+        )
+        super().__init__(
+            unbound_field,
+            label,
+            min_entries=0,
+            max_entries=None,
+            id=id,
+            default=default,
+            widget=widget,
+            render_kw=render_kw,
+            name=name,
+            _form=_form,
+            _prefix=_prefix,
+            _translations=_translations,
+            _meta=_meta
+        )
+
+    def process(self, formdata, data=unset_value, extra_filters=None):
+        self.process_errors = []
+
+        # process the sub-fields
+        super().process(formdata, data=data, extra_filters=extra_filters)
+
+        # process the top-level multiple file field
+        if formdata is not None:
+            if self.name in formdata:
+                self.raw_data = formdata.getlist(self.name)
+            else:
+                self.raw_data = []
+
+            try:
+                self.process_formdata(self.raw_data)
+            except ValueError as e:
+                self.process_errors.append(e.args[0])
+
+    def process_formdata(self, valuelist):
+        if not valuelist:
+            return
+
+        for fieldstorage in valuelist:
+            if not hasattr(fieldstorage, 'file'):
+                # don't create an entry if it's not a new upload
+                continue
+
+            # we fake the formdata for the new field
+            # we use a werkzeug MultiDict because the webob version
+            # needs to get wrapped to be usable in WTForms
+            formdata = MultiDict()
+            name = f'{self.short_name}{self._separator}{len(self)}'
+            formdata.add(name, fieldstorage)
+            self._add_entry(formdata)
+
+
+class UploadMultipleFilesWithORMSupport(UploadMultipleField):
+    """ Extends the upload multiple field with onegov.file support. """
+
+    upload_field_class = UploadFileWithORMSupport
+
+    def __init__(self, *args, **kwargs):
+        self.file_class = kwargs.pop('file_class')
+        super().__init__(*args, **kwargs)
+
+    def populate_obj(self, obj, name):
+        files = getattr(obj, name, None)
+        output = []
+        for field, file in zip_longest(self.entries, files):
+            dummy = object()
+            dummy.file = file
+            field.populate_obj(dummy, 'file')
+            if dummy.file is not None:
+                output.append(dummy.file)
+
+        setattr(obj, name, output)
 
 
 class TextAreaFieldWithTextModules(TextAreaField):

--- a/src/onegov/form/locale/de_ch/LC_MESSAGES/onegov.form.po
+++ b/src/onegov/form/locale/de_ch/LC_MESSAGES/onegov.form.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE 1.0\n"
-"POT-Creation-Date: 2023-02-02 08:55+0100\n"
+"POT-Creation-Date: 2023-02-16 11:29+0100\n"
 "PO-Revision-Date: 2022-03-07 13:56+0100\n"
 "Last-Translator: Marc Sommerhalder <marc.sommerhalder@seantis.ch>\n"
 "Language-Team: German\n"
@@ -175,6 +175,9 @@ msgstr "Datei löschen"
 
 msgid "Replace file"
 msgstr "Datei ersetzen"
+
+msgid "Upload additional files"
+msgstr "Zusätzliche Dateien hochladen"
 
 msgid "Text modules"
 msgstr "Textbausteine"

--- a/src/onegov/form/locale/fr_CH/LC_MESSAGES/onegov.form.po
+++ b/src/onegov/form/locale/fr_CH/LC_MESSAGES/onegov.form.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE 1.0\n"
-"POT-Creation-Date: 2023-02-02 08:55+0100\n"
+"POT-Creation-Date: 2023-02-16 11:29+0100\n"
 "PO-Revision-Date: 2019-01-31 08:31+0100\n"
 "Last-Translator: Marc Sommerhalder <marc.sommerhalder@seantis.ch>\n"
 "Language-Team: French\n"
@@ -174,6 +174,9 @@ msgstr "Supprimer le fichier"
 
 msgid "Replace file"
 msgstr "Remplacer le fichier"
+
+msgid "Upload additional files"
+msgstr "Télécharger des fichiers supplémentaires"
 
 msgid "Text modules"
 msgstr "Modules de texte"

--- a/src/onegov/form/locale/it_CH/LC_MESSAGES/onegov.form.po
+++ b/src/onegov/form/locale/it_CH/LC_MESSAGES/onegov.form.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE 1.0\n"
-"POT-Creation-Date: 2023-02-02 08:55+0100\n"
+"POT-Creation-Date: 2023-02-16 11:29+0100\n"
 "PO-Revision-Date: 2022-03-07 13:55+0100\n"
 "Last-Translator: Marc Sommerhalder <marc.sommerhalder@seantis.ch>\n"
 "Language-Team: Italian\n"
@@ -172,6 +172,9 @@ msgstr "Cancellare il file"
 
 msgid "Replace file"
 msgstr "Sostituire il file"
+
+msgid "Upload additional files"
+msgstr "Caricare file aggiuntivi"
 
 msgid "Text modules"
 msgstr "Moduli di testo"

--- a/src/onegov/form/locale/rm_CH/LC_MESSAGES/onegov.form.po
+++ b/src/onegov/form/locale/rm_CH/LC_MESSAGES/onegov.form.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE 1.0\n"
-"POT-Creation-Date: 2023-02-02 08:55+0100\n"
+"POT-Creation-Date: 2023-02-16 11:29+0100\n"
 "PO-Revision-Date: 2017-06-28 12:03+0200\n"
 "Last-Translator: Marc Sommerhalder <marc.sommerhalder@seantis.ch>\n"
 "Language-Team: Romansh\n"
@@ -163,6 +163,9 @@ msgid "Delete file"
 msgstr ""
 
 msgid "Replace file"
+msgstr ""
+
+msgid "Upload additional files"
 msgstr ""
 
 msgid "Text modules"

--- a/src/onegov/form/parser/core.py
+++ b/src/onegov/form/parser/core.py
@@ -396,6 +396,7 @@ def create_parser_elements():
     elements.date = date()
     elements.time = time()
     elements.fileinput = fileinput()
+    elements.multiplefileinput = fileinput()
     elements.radio = radio()
     elements.checkbox = checkbox()
     elements.integer_range = integer_range_field()
@@ -515,6 +516,11 @@ def construct_checkbox(loader, node):
 @constructor('!fileinput')
 def construct_fileinput(loader, node):
     return ELEMENTS.fileinput.parseString(node.value)
+
+
+@constructor('!multiplefileinput')
+def construct_multiplefileinput(loader, node):
+    return ELEMENTS.multiplefileinput.parseString(node.value)
 
 
 @constructor('!password')
@@ -806,8 +812,7 @@ class DecimalRangeField(Field):
         return Decimal(value)
 
 
-class FileinputField(Field):
-    type = 'fileinput'
+class FileinputBase:
 
     @classmethod
     def create(cls, field, identifier, parent=None, fieldset=None,
@@ -820,6 +825,14 @@ class FileinputField(Field):
             extensions=field.extensions,
             field_help=field_help
         )
+
+
+class FileinputField(FileinputBase, Field):
+    type = 'fileinput'
+
+
+class MultipleFileinputField(FileinputBase, Field):
+    type = 'multiplefileinput'
 
 
 class OptionsField:

--- a/src/onegov/form/parser/form.py
+++ b/src/onegov/form/parser/form.py
@@ -3,7 +3,7 @@ from onegov.form import errors
 from onegov.form.core import FieldDependency
 from onegov.form.core import Form
 from onegov.form.fields import MultiCheckboxField, DateTimeLocalField
-from onegov.form.fields import UploadField
+from onegov.form.fields import UploadField, UploadMultipleField
 from onegov.form.parser.core import parse_formcode
 from onegov.form.utils import as_internal_id
 from onegov.form.validators import ExpectedExtensions
@@ -177,6 +177,9 @@ def handle_field(builder, field, dependency=None):
         )
 
     elif field.type == 'fileinput':
+        expected_extensions = ExpectedExtensions(field.extensions)
+        # build an accept attribute for the file input
+        accept = ','.join(expected_extensions.whitelist)
         builder.add_field(
             field_class=UploadField,
             field_id=field.id,
@@ -184,9 +187,28 @@ def handle_field(builder, field, dependency=None):
             dependency=dependency,
             required=field.required,
             validators=[
-                ExpectedExtensions(field.extensions),
+                expected_extensions,
                 FileSizeLimit(DEFAULT_UPLOAD_LIMIT)
             ],
+            render_kw={'accept': accept},
+            description=field.field_help
+        )
+
+    elif field.type == 'multiplefileinput':
+        expected_extensions = ExpectedExtensions(field.extensions)
+        # build an accept attribute for the file input
+        accept = ','.join(expected_extensions.whitelist)
+        builder.add_field(
+            field_class=UploadMultipleField,
+            field_id=field.id,
+            label=field.label,
+            dependency=dependency,
+            required=field.required,
+            validators=[
+                expected_extensions,
+                FileSizeLimit(DEFAULT_UPLOAD_LIMIT)
+            ],
+            render_kw={'accept': accept},
             description=field.field_help
         )
 

--- a/src/onegov/form/parser/grammar.py
+++ b/src/onegov/form/parser/grammar.py
@@ -302,20 +302,29 @@ def fileinput():
     For all kindes of files::
         *.*
 
-    For specific files:
+    For specific files::
         *.pdf|*.doc
+
+    For multiple file upload::
+        *.pdf (multiple)
     """
     any_extension = Suppress('*.*')
     some_extension = Suppress('*.') + Word(alphanums) + Optional(Suppress('|'))
+    extensions = Group(any_extension | OneOrMore(some_extension))
+    multiple = enclosed_in(Literal('multiple'), '()')
 
     def extract_file_types(tokens):
-        tokens['type'] = 'fileinput'
+        if len(tokens) == 2 and tokens[1] == 'multiple':
+            tokens['type'] = 'multiplefileinput'
+        else:
+            tokens['type'] = 'fileinput'
+
         if len(tokens[0]) == 0:
             tokens['extensions'] = ['*']
         else:
             tokens['extensions'] = [ext.lower() for ext in tokens[0].asList()]
 
-    parser = Group(any_extension | OneOrMore(some_extension))
+    parser = extensions + Optional(multiple)
     parser.setParseAction(extract_file_types)
 
     return parser

--- a/src/onegov/form/validators.py
+++ b/src/onegov/form/validators.py
@@ -43,7 +43,8 @@ class FileSizeLimit:
     """ Makes sure an uploaded file is not bigger than the given number of
     bytes.
 
-    Expects an :class:`onegov.form.fields.UploadField` instance.
+    Expects an :class:`onegov.form.fields.UploadField` or
+    :class:`onegov.form.fields.UploadMultipleField` instance.
 
     """
 
@@ -66,7 +67,8 @@ class FileSizeLimit:
 class WhitelistedMimeType:
     """ Makes sure an uploaded file is in a whitelist of allowed mimetypes.
 
-    Expects an :class:`onegov.form.fields.UploadField` instance.
+    Expects an :class:`onegov.form.fields.UploadField` or
+    :class:`onegov.form.fields.UploadMultipleField` instance.
     """
 
     whitelist = {
@@ -104,13 +106,20 @@ class ExpectedExtensions(WhitelistedMimeType):
 
     Usage::
 
-        ExpectedFileType('*')  # no check, really
-        ExpectedFileType('pdf')  # makes sure the given file is a pdf
+        ExpectedExtensions(['*'])  # default whitelist
+        ExpectedExtensions(['pdf'])  # makes sure the given file is a pdf
     """
 
     def __init__(self, extensions):
-        mimetypes = set(
-            types_map.get('.' + ext.lstrip('.'), None) for ext in extensions)
+        # normalize extensions
+        if len(extensions) == 1 and extensions[0] == '*':
+            mimetypes = None
+        else:
+            mimetypes = {
+                mimetype for ext in extensions
+                # we silently discard any extensions we don't know for now
+                if (mimetype := types_map.get('.' + ext.lstrip('.'), None))
+            }
         super().__init__(whitelist=mimetypes)
 
 

--- a/src/onegov/form/widgets.py
+++ b/src/onegov/form/widgets.py
@@ -219,7 +219,7 @@ class UploadMultipleWidget(FileInput):
             </div>
         """)
 
-        if not len(field) or force_simple:
+        if force_simple or len(field) == 0:
             return simple_template.format(input_html)
         else:
             existing_html = Markup('').join(

--- a/src/onegov/org/layout.py
+++ b/src/onegov/org/layout.py
@@ -427,21 +427,40 @@ class Layout(ChameleonLayout, OpenGraphMixin):
     def include_code_editor(self):
         self.request.include('code_editor')
 
-    def field_download_link(self, field):
-        if not field.type == 'UploadField':
+    def file_data_download_link(self, file_data):
+        if file_data is None:
             return None
 
-        if field.data.get('data', '').startswith('@'):
+        if (ref := file_data.get('data', '')).startswith('@'):
             return self.request.class_link(File, {
-                'id': field.data['data'].lstrip('@')
+                'id': ref.lstrip('@')
             })
 
-    def field_file(self, field):
-        if not field.type == 'UploadField':
+    def file_data_file(self, file_data):
+        if file_data is None:
             return None
-        if field.data.get('data', '').startswith('@'):
+
+        if (ref := file_data.get('data', '')).startswith('@'):
             return self.request.session.query(File).filter_by(
-                id=field.data['data'].lstrip('@')).first()
+                id=ref.lstrip('@')).first()
+
+    def field_download_link(self, field):
+        if field.type == 'UploadField':
+            return self.file_data_download_link(field.data)
+        elif field.type == 'UploadMultipleField':
+            return [
+                self.file_data_download_link(file_data)
+                for file_data in (field.data or [])
+            ]
+
+    def field_file(self, field):
+        if field.type == 'UploadField':
+            return self.file_data_file(field.data)
+        elif field.type == 'UploadMultipleField':
+            return [
+                self.file_data_file(file_data)
+                for file_data in (field.data or [])
+            ]
 
     @cached_property
     def move_person_url_template(self):

--- a/src/onegov/org/templates/macros.pt
+++ b/src/onegov/org/templates/macros.pt
@@ -330,15 +330,15 @@
                 ${field()}
                 <small class="error" tal:repeat="error field.errors">${error}</small>
             </tal:b>
-            <tal:b condition="input_type != 'hidden'" define="radio_field field.type == 'RadioField'; checkbox_fields (field.type == 'MultiCheckboxField' or field.type == 'OrderedMultiCheckboxField')">
-                <label tal:attributes="class field.errors and 'error' or field.type" tal:condition="not checkbox_fields and not radio_field">
+            <tal:b condition="input_type != 'hidden'" define="radio_field field.type == 'RadioField'; checkbox_fields (field.type == 'MultiCheckboxField' or field.type == 'OrderedMultiCheckboxField'); field_list field.type == 'UploadMultipleField'">
+                <label tal:attributes="class field.errors and not field_list and 'error' or field.type" tal:condition="not checkbox_fields and not radio_field">
                     <metal:b use-macro="layout.macros['field']" />
                 </label>
 
                 <div tal:attributes="class field.errors and 'error group-label' or 'group-label'" tal:condition="checkbox_fields or radio_field">
                     <metal:b use-macro="layout.macros['field']" />
                 </div>
-                <small class="error" tal:repeat="error field.errors">${error}</small>
+                <small class="error" tal:condition="not field_list" tal:repeat="error field.errors">${error}</small>
             </tal:b>
         </tal:b>
     </div></div>
@@ -589,24 +589,47 @@
     <dl class="field-display" tal:repeat="(field, rendered) rendered_fields" tal:define="allow_downloads allow_downloads|request.is_manager; allow_views allow_views|False">
         <dt tal:condition="layout.show_label(field)">${field.label.text}</dt>
         <dd>
-            <tal:b condition="(allow_downloads or allow_views) and field.type == 'UploadField'">
-                <tal:b define="url layout.field_download_link(field)">
-                    <a href="${url}" tal:condition="not allow_views or not field.is_image">
-                        <tal:b replace="structure rendered" />
-                    </a>
-                    <div tal:define="as_thumbnail 'thumbnail' in url|''" tal:condition="allow_views and field.is_image">
-                        <img tal:condition="not: as_thumbnail" src="${url}" alt="" />
-                        <div class="photoswipe" tal:define="image layout.field_file(field)" tal:condition="image and as_thumbnail">
-                            <p class="has-img thumbnail">
-                                <img src="${url}" alt="${image.note}" data-full-width="${image.reference.size[0]}" data-full-height="${image.reference.size[1]}" />
-                            </p>
+            <tal:b tal:switch="field.type" tal:condition="allow_downloads or allow_views">
+                <tal:b tal:case="'UploadField'">
+                        <tal:b tal:define="url layout.field_download_link(field)">
+                        <a href="${url}" tal:condition="not allow_views or not field.is_image">
+                            <tal:b replace="structure rendered" />
+                        </a>
+                        <div tal:define="as_thumbnail 'thumbnail' in url|''" tal:condition="allow_views and field.is_image">
+                            <img tal:condition="not: as_thumbnail" src="${url}" alt="" />
+                            <div class="photoswipe" tal:define="image layout.field_file(field)" tal:condition="image and as_thumbnail">
+                                <p class="has-img thumbnail">
+                                    <img src="${url}" alt="${image.note}" data-full-width="${image.reference.size[0]}" data-full-height="${image.reference.size[1]}" />
+                                </p>
+                            </div>
+                            <tal:b metal:use-macro="layout.macros.photoswipe" />
                         </div>
-                        <tal:b metal:use-macro="layout.macros.photoswipe" />
-                    </div>
 
+                    </tal:b>
+                </tal:b>
+                <tal:b tal:case="'UploadMultipleField'" tal:repeat="iter zip(field.data or [], rendered.split('<br>'))">
+                    <tal:b tal:define="file_data iter[0];
+                                       rendered iter[1];
+                                       url layout.file_data_download_link(file_data);
+                                       show_image allow_views and field.is_image(file_data)">
+                        <a href="${url}" tal:condition="not show_image">
+                            <tal:b replace="structure rendered" />
+                        </a>
+                        <br tal:condition="not show_image and not repeat.iter.end" />
+                        <div tal:define="as_thumbnail 'thumbnail' in url|''" tal:condition="show_image">
+                            <img tal:condition="not: as_thumbnail" src="${url}" alt="" />
+                            <div class="photoswipe" tal:define="image layout.file_data_file(file_data)" tal:condition="image and as_thumbnail">
+                                <p class="has-img thumbnail">
+                                    <img src="${url}" alt="${image.note}" data-full-width="${image.reference.size[0]}" data-full-height="${image.reference.size[1]}" />
+                                </p>
+                            </div>
+                            <tal:b metal:use-macro="layout.macros.photoswipe" />
+                        </div>
+
+                    </tal:b>
                 </tal:b>
             </tal:b>
-            <tal:b condition="not (allow_downloads or allow_views) or field.type != 'UploadField'" >
+            <tal:b condition="not (allow_downloads or allow_views) or field.type not in ('UploadField', 'UploadMultipleField')" >
                 <tal:b tal:switch="linkify_display|False">
                     <tal:b tal:case="True" replace="structure layout.linkify_field(field, rendered)" />
                     <tal:b tal:case="False" replace="structure rendered" />

--- a/src/onegov/town6/templates/macros.pt
+++ b/src/onegov/town6/templates/macros.pt
@@ -387,15 +387,15 @@
                 ${field()}
                 <small class="error" tal:repeat="error field.errors">${error}</small>
             </tal:b>
-            <tal:b condition="input_type != 'hidden'" define="radio_field field.type == 'RadioField'; checkbox_fields (field.type == 'MultiCheckboxField' or field.type == 'OrderedMultiCheckboxField')">
-                <label tal:attributes="class field.errors and 'error' or None" tal:condition="not checkbox_fields and not radio_field">
+            <tal:b condition="input_type != 'hidden'" define="radio_field field.type == 'RadioField'; checkbox_fields (field.type == 'MultiCheckboxField' or field.type == 'OrderedMultiCheckboxField'); field_list field.type == 'UploadMultipleField'">
+                <label tal:attributes="class field.errors and not field_list and 'error' or None" tal:condition="not checkbox_fields and not radio_field">
                     <metal:b use-macro="layout.macros['field']" />
                 </label>
 
                 <div tal:attributes="class field.errors and 'error group-label' or 'group-label'" tal:condition="checkbox_fields or radio_field">
                     <metal:b use-macro="layout.macros['field']" />
                 </div>
-                <small class="error" tal:repeat="error field.errors">${error}</small>
+                <small class="error" tal:condition="not field_list" tal:repeat="error field.errors">${error}</small>
             </tal:b>
         </tal:b>
     </div></div>
@@ -717,24 +717,46 @@
     <dl class="field-display" tal:repeat="(field, rendered) rendered_fields" tal:define="allow_downloads allow_downloads|request.is_manager; allow_views allow_views|False">
         <dt tal:condition="layout.show_label(field)">${field.label.text}</dt>
         <dd>
-            <tal:b condition="(allow_downloads or allow_views) and field.type == 'UploadField'">
-                <tal:b define="url layout.field_download_link(field)">
-                    <a href="${url}" tal:condition="not allow_views or not field.is_image">
-                        <tal:b replace="structure rendered" />
-                    </a>
-                    <div tal:define="as_thumbnail 'thumbnail' in url|''" tal:condition="allow_views and field.is_image">
-                        <img tal:condition="not: as_thumbnail" src="${url}" alt="" />
-                        <div class="photoswipe" tal:define="image layout.field_file(field)" tal:condition="image and as_thumbnail">
-                            <p class="has-img thumbnail">
-                                <img src="${url}" alt="${image.note}" data-full-width="${image.reference.size[0]}" data-full-height="${image.reference.size[1]}" />
-                            </p>
+            <tal:b tal:switch="field.type" condition="allow_downloads or allow_views">
+                <tal:b tal:case="'UploadField'">
+                    <tal:b tal:define="url layout.field_download_link(field)">
+                        <a href="${url}" tal:condition="not allow_views or not field.is_image">
+                            <tal:b replace="structure rendered" />
+                        </a>
+                        <div tal:define="as_thumbnail 'thumbnail' in url|''" tal:condition="allow_views and field.is_image">
+                            <img tal:condition="not: as_thumbnail" src="${url}" alt="" />
+                            <div class="photoswipe" tal:define="image layout.field_file(field)" tal:condition="image and as_thumbnail">
+                                <p class="has-img thumbnail">
+                                    <img src="${url}" alt="${image.note}" data-full-width="${image.reference.size[0]}" data-full-height="${image.reference.size[1]}" />
+                                </p>
+                            </div>
+                            <tal:b metal:use-macro="layout.macros.photoswipe" />
                         </div>
-                        <tal:b metal:use-macro="layout.macros.photoswipe" />
-                    </div>
+                    </tal:b>
+                </tal:b>
+                <tal:b tal:case="'UploadMultipleField'" tal:repeat="iter zip(field.data or [], rendered.split('<br>'))">
+                    <tal:b tal:define="file_data iter[0];
+                                       rendered iter[1];
+                                       url layout.file_data_download_link(file_data);
+                                       show_image allow_views and field.is_image(file_data)">
+                        <a href="${url}" tal:condition="not show_image">
+                            <tal:b replace="structure rendered" />
+                        </a>
+                        <br tal:condition="not show_image and not repeat.iter.end" />
+                        <div tal:define="as_thumbnail 'thumbnail' in url|''" tal:condition="show_image">
+                            <img tal:condition="not: as_thumbnail" src="${url}" alt="" />
+                            <div class="photoswipe" tal:define="image layout.file_data_file(file_data)" tal:condition="image and as_thumbnail">
+                                <p class="has-img thumbnail">
+                                    <img src="${url}" alt="${image.note}" data-full-width="${image.reference.size[0]}" data-full-height="${image.reference.size[1]}" />
+                                </p>
+                            </div>
+                            <tal:b metal:use-macro="layout.macros.photoswipe" />
+                        </div>
 
+                    </tal:b>
                 </tal:b>
             </tal:b>
-            <tal:b condition="not (allow_downloads or allow_views) or field.type != 'UploadField'" >
+            <tal:b condition="not (allow_downloads or allow_views) or field.type not in ('UploadField', 'UploadMultipleField')" >
                 <tal:b tal:switch="linkify_display|False">
                     <tal:b tal:case="True" replace="structure layout.linkify_field(field, rendered)" />
                     <tal:b tal:case="False" replace="structure rendered" />

--- a/src/onegov/town6/theme/styles/forms.scss
+++ b/src/onegov/town6/theme/styles/forms.scss
@@ -34,7 +34,7 @@ form {
 
         min-width: 75%;
 
-        &.error {
+        &.error, .upload-widget.error {
             color: $alert-color;
 
             & input,

--- a/tests/onegov/form/test_display.py
+++ b/tests/onegov/form/test_display.py
@@ -43,6 +43,14 @@ def test_render_upload_field():
     })) == '&lt;b.txt&gt; (1.0 kB)'
 
 
+def test_render_upload_multiple_field():
+    assert render_field(MockField('UploadMultipleField', [
+        {'filename': 'a.txt', 'size': 3000},
+        {},  # deleted file will not be rendered
+        {'filename': '<b.txt>', 'size': 1000},
+    ])) == 'a.txt (3.0 kB)<br>&lt;b.txt&gt; (1.0 kB)'
+
+
 def test_render_radio_field():
     assert render_field(MockField('RadioField', 'selected')) == '✓ selected'
 

--- a/tests/onegov/form/test_grammar.py
+++ b/tests/onegov/form/test_grammar.py
@@ -229,6 +229,10 @@ def test_fileinput():
     assert f.type == 'fileinput'
     assert f.extensions == ['png', 'jpg', 'gif']
 
+    f = field.parseString("*.pdf (multiple)")
+    assert f.type == 'multiplefileinput'
+    assert f.extensions == ['pdf']
+
 
 def test_prices():
     field = radio()

--- a/tests/onegov/form/test_parser.py
+++ b/tests/onegov/form/test_parser.py
@@ -283,6 +283,15 @@ def test_parse_fileinput():
 
     assert form.file.label.text == 'File'
     assert isinstance(form.file, FileField)
+    assert form.file.widget.multiple is False
+
+
+def test_parse_multiplefileinput():
+    form = parse_form("Files = *.pdf|*.doc (multiple)")()
+
+    assert form.files.label.text == 'Files'
+    assert isinstance(form.files, FileField)
+    assert form.files.widget.multiple is True
 
 
 def test_parse_radio():


### PR DESCRIPTION
## Commit message

Form: Adds `UploadMultipleField` to forms and a modifier to form code.

This is especially useful for custom forms defined using form code since sometimes you want people to be able to submit multiple files without having to create a bunch of single file fields. Example:

```
Documents = *.pdf (multiple)
```

TYPE: Feature
LINK: OGC-915

## Checklist

- [x] I made changes/features for both org and town6
- [x] I have performed a self-review of my code
- [x] I have tested my code thoroughly by hand
- [x] I have added tests for my changes/features
- [x] I have updated the PO files
