### PR TITLE
Events: Events from the past can be shown.

### DIFF
--- a/src/onegov/org/assets/js/date-range-selector.js
+++ b/src/onegov/org/assets/js/date-range-selector.js
@@ -1,11 +1,12 @@
 // set date filter on input change
 var set_date_range_selector_filter = function(name, value) {
     var location = new Url();
+    var date;
 
     if (value === "") {
         delete location.query[name];
     } else {
-        var date = moment(value, 'YYYY-MM-DD', true);
+        date = moment(value, 'YYYY-MM-DD', true);
         if (!date.isValid()) {
             return;
         }
@@ -19,7 +20,11 @@ var set_date_range_selector_filter = function(name, value) {
     }
 
     delete location.query.page;
-    delete location.query.range;
+
+    // keep range in query if range is equal 'past' and if date (value) is in the past, otherwise delete
+    if (date.isSame(moment(), 'day') || date.isAfter(moment(), 'day') || location.query.range != 'past') {
+        delete location.query.range;
+    }
 
     var url = location.toString();
     var target = $('.date-range-selector-target');

--- a/src/onegov/org/locale/de_CH/LC_MESSAGES/onegov.org.po
+++ b/src/onegov/org/locale/de_CH/LC_MESSAGES/onegov.org.po
@@ -2135,6 +2135,9 @@ msgstr "Letztes Jahr"
 msgid "Older"
 msgstr "Älter"
 
+msgid "Past events"
+msgstr "Vergangene Veranstaltungen"
+
 msgid "Do you really want to delete this note?"
 msgstr "Möchten Sie diese Notiz wirklich löschen?"
 

--- a/src/onegov/org/locale/fr_CH/LC_MESSAGES/onegov.org.po
+++ b/src/onegov/org/locale/fr_CH/LC_MESSAGES/onegov.org.po
@@ -2136,6 +2136,9 @@ msgstr "L'an dernier"
 msgid "Older"
 msgstr "Plus âgés"
 
+msgid "Past Events"
+msgstr "Événements passées"
+
 msgid "Do you really want to delete this note?"
 msgstr "Voulez-vous vraiment supprimer cette note ?"
 

--- a/src/onegov/org/locale/it_CH/LC_MESSAGES/onegov.org.po
+++ b/src/onegov/org/locale/it_CH/LC_MESSAGES/onegov.org.po
@@ -2146,6 +2146,9 @@ msgstr "Lo scorso anno"
 msgid "Older"
 msgstr "Più vecchia"
 
+msgid "Past Events"
+msgstr "Eventi passate"
+
 msgid "Do you really want to delete this note?"
 msgstr "Vuoi davvero eliminare questa nota?"
 

--- a/src/onegov/org/templates/macros.pt
+++ b/src/onegov/org/templates/macros.pt
@@ -1049,8 +1049,14 @@
             <metal:b use-macro="layout.macros['occurrence_list_view']" />
         </div>
     </tal:b>
-
-    <div tal:condition="not occurrences" i18n:translate>No events found.</div>
+    <tal:b condition="not occurrences" >
+        <p i18n:translate>No events found.</p>
+        <br>
+        <tal condition="'range' in layout.og_url">
+            <p><a href="${layout.events_url}" i18n:translate>All events</a>
+            <br><a href="${layout.events_url}&amp;range=past" i18n:translate>Past events</a>
+        </tal>
+    </tal:b>
 </metal:occurrences>
 
 <metal:occurrence_list_view define-macro="occurrence_list_view">

--- a/src/onegov/org/views/occurrence.py
+++ b/src/onegov/org/views/occurrence.py
@@ -68,6 +68,7 @@ def view_occurrences(self, request, layout=None):
             ('weekend', _("This weekend")),
             ('week', _("This week")),
             ('month', _("This month")),
+            ('past', _("Past events")),
         )
     ]
 

--- a/src/onegov/town6/templates/macros.pt
+++ b/src/onegov/town6/templates/macros.pt
@@ -1184,7 +1184,14 @@
             <metal:b use-macro="layout.macros['occurrence_list_view']" />
     </tal:b>
         </div>
-    <div tal:condition="not occurrences" i18n:translate>No events found.</div>
+    <tal:b condition="not occurrences">
+        <p i18n:translate>No events found.</p>
+        <br>
+        <tal condition="'range' in layout.og_url">
+            <p><a href="${layout.events_url}" class="button hollow" i18n:translate>All events</a>
+            <br><a href="${layout.events_url}&amp;range=past" class="button hollow" i18n:translate>Past events</a>
+        </tal>
+    </tal:b>
 </metal:occurrences>
 
 <metal:occurrence_list_view define-macro="occurrence_list_view" i18n:domain="onegov.town6">

--- a/tests/onegov/event/test_collections.py
+++ b/tests/onegov/event/test_collections.py
@@ -257,12 +257,14 @@ def test_occurrence_collection_query(session):
         assert query(outdated=True, range='weekend').count() == 1
         assert query(outdated=True, range='week').count() == 5
         assert query(outdated=True, range='month').count() == 5
+        assert query(outdated=True, range='past').count() == 1
 
         assert query(outdated=False, range='today').count() == 1
         assert query(outdated=False, range='tomorrow').count() == 2
         assert query(outdated=False, range='weekend').count() == 1
         assert query(outdated=False, range='week').count() == 4
         assert query(outdated=False, range='month').count() == 4
+        assert query(outdated=False, range='past').count() == 1
 
 
 def test_occurrence_collection_pagination(session):
@@ -486,42 +488,49 @@ def test_occurrence_collection_range_to_dates():
         assert to_dates('weekend') == (date(2018, 12, 7), date(2018, 12, 9))
         assert to_dates('week') == (date(2018, 12, 3), date(2018, 12, 9))
         assert to_dates('month') == (date(2018, 12, 1), date(2018, 12, 31))
+        assert to_dates('past') == (date(2000, 1, 1), date(2018, 12, 2))
     with freeze_time("2018-12-06"):
         assert to_dates('today') == (date(2018, 12, 6), date(2018, 12, 6))
         assert to_dates('tomorrow') == (date(2018, 12, 7), date(2018, 12, 7))
         assert to_dates('weekend') == (date(2018, 12, 7), date(2018, 12, 9))
         assert to_dates('week') == (date(2018, 12, 3), date(2018, 12, 9))
         assert to_dates('month') == (date(2018, 12, 1), date(2018, 12, 31))
+        assert to_dates('past') == (date(2000, 1, 1), date(2018, 12, 5))
     with freeze_time("2018-12-07"):
         assert to_dates('today') == (date(2018, 12, 7), date(2018, 12, 7))
         assert to_dates('tomorrow') == (date(2018, 12, 8), date(2018, 12, 8))
         assert to_dates('weekend') == (date(2018, 12, 7), date(2018, 12, 9))
         assert to_dates('week') == (date(2018, 12, 3), date(2018, 12, 9))
         assert to_dates('month') == (date(2018, 12, 1), date(2018, 12, 31))
+        assert to_dates('past') == (date(2000, 1, 1), date(2018, 12, 6))
     with freeze_time("2018-12-08"):
         assert to_dates('today') == (date(2018, 12, 8), date(2018, 12, 8))
         assert to_dates('tomorrow') == (date(2018, 12, 9), date(2018, 12, 9))
         assert to_dates('weekend') == (date(2018, 12, 7), date(2018, 12, 9))
         assert to_dates('week') == (date(2018, 12, 3), date(2018, 12, 9))
         assert to_dates('month') == (date(2018, 12, 1), date(2018, 12, 31))
+        assert to_dates('past') == (date(2000, 1, 1), date(2018, 12, 7))
     with freeze_time("2018-12-09"):
         assert to_dates('today') == (date(2018, 12, 9), date(2018, 12, 9))
         assert to_dates('tomorrow') == (date(2018, 12, 10), date(2018, 12, 10))
         assert to_dates('weekend') == (date(2018, 12, 7), date(2018, 12, 9))
         assert to_dates('week') == (date(2018, 12, 3), date(2018, 12, 9))
         assert to_dates('month') == (date(2018, 12, 1), date(2018, 12, 31))
+        assert to_dates('past') == (date(2000, 1, 1), date(2018, 12, 8))
     with freeze_time("2018-12-10"):
         assert to_dates('today') == (date(2018, 12, 10), date(2018, 12, 10))
         assert to_dates('tomorrow') == (date(2018, 12, 11), date(2018, 12, 11))
         assert to_dates('weekend') == (date(2018, 12, 14), date(2018, 12, 16))
         assert to_dates('week') == (date(2018, 12, 10), date(2018, 12, 16))
         assert to_dates('month') == (date(2018, 12, 1), date(2018, 12, 31))
+        assert to_dates('past') == (date(2000, 1, 1), date(2018, 12, 9))
     with freeze_time("2019-01-31"):
         assert to_dates('today') == (date(2019, 1, 31), date(2019, 1, 31))
         assert to_dates('tomorrow') == (date(2019, 2, 1), date(2019, 2, 1))
         assert to_dates('weekend') == (date(2019, 2, 1), date(2019, 2, 3))
         assert to_dates('week') == (date(2019, 1, 28), date(2019, 2, 3))
         assert to_dates('month') == (date(2019, 1, 1), date(2019, 1, 31))
+        assert to_dates('past') == (date(2000, 1, 1), date(2019, 1, 30))
 
     assert to_dates(None) == (None, None)
     assert to_dates('') == (None, None)


### PR DESCRIPTION
Events: Events from the past can be shown.

In the case of 'No events found' we will display two link buttons. One will point to 'all events' where as the other will show 'past events'. In addition a new time range filter 'past events' was added to achieve the same from filters.

TYPE: Feature
LINK: OGC-947