### PR TITLE
File: Set X-Robots-Tag to noindex if the file's access is `secret`.

### DIFF
--- a/src/onegov/file/integration.py
+++ b/src/onegov/file/integration.py
@@ -383,6 +383,13 @@ def respond_with_caching_header(reference, request):
             response.headers.add('Cache-Control', 'private')
 
 
+def respond_with_x_robots_tag_header(reference, request):
+    if getattr(reference, 'access', None) == 'secret':
+        @request.after
+        def include_private_header(response):
+            response.headers.add('X-Robots-Tag', 'noindex')
+
+
 @DepotApp.path(model=File, path='/storage/{id}')
 def get_file(app, id):
     return FileCollection(app.session()).by_id(id)
@@ -392,6 +399,7 @@ def get_file(app, id):
 def view_file(self, request):
     respond_with_alt_text(self, request)
     respond_with_caching_header(self, request)
+    respond_with_x_robots_tag_header(self, request)
     return self.reference.file
 
 
@@ -409,6 +417,7 @@ def view_thumbnail(self, request):
 
     respond_with_alt_text(self, request)
     respond_with_caching_header(self, request)
+    respond_with_x_robots_tag_header(self, request)
 
     thumbnail_id = self.get_thumbnail_id(size)
 

--- a/src/onegov/file/integration.py
+++ b/src/onegov/file/integration.py
@@ -386,7 +386,7 @@ def respond_with_caching_header(reference, request):
 def respond_with_x_robots_tag_header(reference, request):
     if getattr(reference, 'access', None) == 'secret':
         @request.after
-        def include_private_header(response):
+        def include_x_robots_tag_header(response):
             response.headers.add('X-Robots-Tag', 'noindex')
 
 

--- a/src/onegov/form/models/submission.py
+++ b/src/onegov/form/models/submission.py
@@ -255,3 +255,8 @@ class CompleteFormSubmission(FormSubmission):
 
 class FormFile(File):
     __mapper_args__ = {'polymorphic_identity': 'formfile'}
+
+    @property
+    def access(self):
+        # we don't want these files to show up in search engines
+        return 'secret' if self.published else 'private'


### PR DESCRIPTION
## Commit message

File: Set X-Robots-Tag to noindex if the file's access is `secret`.

By default attachments to directory entries and form submissions are set to `secret` now. They will still be listed in the rendered form.

TYPE: Feature
LINK: OGC-916

## Checklist

- [x] I have performed a self-review of my code
- [x] I have tested my code thoroughly by hand
- [x] I have added tests for my changes/features
