### PR TITLE
Websockets: Add content security policiy tween.

### DIFF
--- a/onegov.yml.example
+++ b/onegov.yml.example
@@ -128,6 +128,7 @@ configuration: &global-config
   # Websocket server configuration.
   websockets:
     client_url: ws://localhost:8765
+    client_csp: ws://localhost:8765
     manage_url: ws://localhost:8765
     manage_token: super-secret-token
 

--- a/src/onegov/websockets/assets/js/websockets.js
+++ b/src/onegov/websockets/assets/js/websockets.js
@@ -1,21 +1,21 @@
 window.addEventListener("DOMContentLoaded", function() {
-    if (typeof(WebsocketConfig) !== "undefined") {
-      try {
-        const websocket = new WebSocket(WebsocketConfig.endpoint);
-        websocket.addEventListener("open", function() {
-          let payload = {
-            type: "register",
-            schema: WebsocketConfig.schema,
-            channel: WebsocketConfig.channel
+  if (typeof(WebsocketConfig) !== "undefined") {
+    try {
+      const websocket = new WebSocket(WebsocketConfig.endpoint);
+      websocket.addEventListener("open", function() {
+        let payload = {
+          type: "register",
+          schema: WebsocketConfig.schema,
+          channel: WebsocketConfig.channel
+        }
+        websocket.send(JSON.stringify(payload));
+      });
+      websocket.addEventListener('message', function(message) {
+          const data = JSON.parse(message.data)
+          if (data.type === 'notification' && WebsocketConfig.onnotifcation) {
+              WebsocketConfig.onnotifcation(data.message);
           }
-          websocket.send(JSON.stringify(payload));
-        });
-        websocket.addEventListener('message', function(message) {
-            const data = JSON.parse(message.data)
-            if (data.type === 'notification' && WebsocketConfig.onnotifcation) {
-                WebsocketConfig.onnotifcation(data.message);
-            }
-        });
-      } catch (error) {}
+      });
+    } catch (error) {}
   }
 });

--- a/src/onegov/websockets/integration.py
+++ b/src/onegov/websockets/integration.py
@@ -1,4 +1,5 @@
 from asyncio import run
+from more.content_security.core import content_security_policy_tween_factory
 from more.webassets import WebassetsApp
 from onegov.websockets import log
 from onegov.websockets.client import authenticate
@@ -105,6 +106,26 @@ class WebsocketsApp(WebassetsApp):
             return False
 
         return True
+
+
+@WebsocketsApp.tween_factory(under=content_security_policy_tween_factory)
+def websocket_csp_tween_factory(app, handler):
+
+    def websocket_csp_tween(request):
+        """
+        Adds the websocket client to the connect-src content security policy.
+        """
+
+        result = handler(request)
+        configuration = request.app.configuration
+        if 'websockets' in configuration:
+            csp = configuration['websockets'].get('client_csp')
+            if csp:
+                request.content_security_policy.connect_src.add(csp)
+
+        return result
+
+    return websocket_csp_tween
 
 
 @WebsocketsApp.webasset_path()

--- a/tests/onegov/websockets/conftest.py
+++ b/tests/onegov/websockets/conftest.py
@@ -4,6 +4,7 @@ from onegov.websockets import WebsocketsApp
 from onegov.websockets.server import main
 from pytest import fixture
 from pytest_localserver.http import WSGIServer
+from tests.shared.client import Client
 from tests.shared.utils import create_app
 from threading import Thread
 
@@ -56,7 +57,6 @@ class WebsocketsRoot:
 @WebsocketsApp.html(model=WebsocketsRoot)
 def view_root(self, request):
     request.include('websockets')
-    request.content_security_policy.connect_src.add('ws:')
     return self.html
 
 
@@ -64,6 +64,7 @@ def view_root(self, request):
 def websockets_app(request, websocket_config):
     websockets = {
         'client_url': websocket_config['url'],
+        'client_csp': websocket_config['url'],
         'manage_url': websocket_config['url'],
         'manage_token': websocket_config['token']
     }
@@ -75,6 +76,11 @@ def websockets_app(request, websocket_config):
     )
     yield app
     app.session_manager.dispose()
+
+
+@fixture(scope='function')
+def client(websockets_app):
+    yield Client(websockets_app)
 
 
 @fixture(scope='function')

--- a/tests/onegov/websockets/test_integration.py
+++ b/tests/onegov/websockets/test_integration.py
@@ -31,3 +31,8 @@ def test_integration(broadcast, authenticate, connect, websockets_app):
     assert broadcast.call_args[0][1] == websockets_app.schema
     assert broadcast.call_args[0][2] == 'one'
     assert broadcast.call_args[0][3] == {'custom': 'data'}
+
+
+def test_csp_tween(client):
+    csp = client.get('/').headers['content-security-policy']
+    assert 'connect-src ws://127.0.0.1:9876' in csp


### PR DESCRIPTION
## Commit message

Websockets: Add content security policiy tween.

Allows to optionally add a websocket endpoint to the connect-src content  security policy.

TYPE: Feature
LINK: OGC-935

## Checklist

- [x] I have performed a self-review of my code
- [x] I have tested my code thoroughly by hand
- [x] I have added tests for my changes/features