### PR TITLE
Make suggestion panel solely dependant on enable_submissions

### DIFF
--- a/src/onegov/town6/templates/directory.pt
+++ b/src/onegov/town6/templates/directory.pt
@@ -80,7 +80,7 @@
                     </div>
                 </div>
 
-                <div class="submit-yours side-panel" tal:condition="directory.enable_submissions or request.is_manager">
+                <div class="submit-yours side-panel" tal:condition="directory.enable_submissions">
                     <dl>
                         <dt>
                             <a href="${submit}">


### PR DESCRIPTION
Please fill in the commit message below and work through the checklist. You can delete parts that are not needed, e.g. the optional description, the link to a ticket or irrelevant options of the checklist.

## Commit message

Town6: Make suggestion panel solely dependant on enable_submissions

TYPE: Bugfix
LINK: OGC-955