### PR TITLE
Town6: Hide Gever Upload in navbar if it is not set in settings

### DIFF
--- a/src/onegov/org/views/ticket.py
+++ b/src/onegov/org/views/ticket.py
@@ -89,16 +89,9 @@ def view_ticket(self, request, layout=None):
 
     counts = request.session.execute(
         select(stmt.c).where(stmt.c.channel_id == self.number)).first()
-    layout = layout or TicketLayout(self, request)
-
-    # if we have gever, show the upload button
-    org = request.app.org
-    if not org.gever_endpoint:
-        links = layout.editbar_links
-        links = filter(lambda link: link.text != _("Upload to Gever"), links)
-        layout.editbar_links = links
 
     # if we have a payment, show the payment button
+    layout = layout or TicketLayout(self, request)
     payment_button = None
     payment = handler.payment
     edit_amount_url = None

--- a/src/onegov/org/views/ticket.py
+++ b/src/onegov/org/views/ticket.py
@@ -89,9 +89,16 @@ def view_ticket(self, request, layout=None):
 
     counts = request.session.execute(
         select(stmt.c).where(stmt.c.channel_id == self.number)).first()
+    layout = layout or TicketLayout(self, request)
+
+    # if we have gever, show the upload button
+    org = request.app.org
+    if not org.gever_endpoint:
+        links = layout.editbar_links
+        links = filter(lambda link: link.text != _("Upload to Gever"), links)
+        layout.editbar_links = links
 
     # if we have a payment, show the payment button
-    layout = layout or TicketLayout(self, request)
     payment_button = None
     payment = handler.payment
     edit_amount_url = None

--- a/src/onegov/town6/layout.py
+++ b/src/onegov/town6/layout.py
@@ -719,22 +719,23 @@ class TicketLayout(DefaultLayout):
                     attrs={'class': 'ticket-pdf'}
                 )
             )
-            links.append(
-                Link(
-                    text=_("Upload to Gever"),
-                    url=self.request.link(self.model, 'send-to-gever'),
-                    attrs={'class': 'upload'},
-                    traits=(
-                        Confirm(
-                            _("Do you really want to upload this ticket?"),
-                            _("This will upload this ticket to the "
-                              "Gever instance, if configured."),
-                            _("Upload Ticket"),
-                            _("Cancel")
+            if self.request.app.org.gever_endpoint:
+                links.append(
+                    Link(
+                        text=_("Upload to Gever"),
+                        url=self.request.link(self.model, 'send-to-gever'),
+                        attrs={'class': 'upload'},
+                        traits=(
+                            Confirm(
+                                _("Do you really want to upload this ticket?"),
+                                _("This will upload this ticket to the "
+                                  "Gever instance, if configured."),
+                                _("Upload Ticket"),
+                                _("Cancel")
+                            )
                         )
                     )
                 )
-            )
             return links
 
 

--- a/tests/onegov/town6/test_views_forms.py
+++ b/tests/onegov/town6/test_views_forms.py
@@ -232,3 +232,36 @@ def test_form_group_sort(client):
 
     assert groups == page.pyquery(
         '.page-content-main h2').text().strip().split(' ')
+
+
+def test_navbar_links_visibility(client):
+    collection = FormCollection(client.app.session())
+    collection.definitions.add('Profile', definition=textwrap.dedent("""
+        First name * = ___
+        Last name * = ___
+        E-Mail * = @@@
+    """), type='custom')
+
+    transaction.commit()
+
+    client.login_admin()
+
+    page = client.get("/forms").click("Profile")
+    page.form["first_name"] = "Foo"
+    page.form["last_name"] = "Bar"
+    page.form["e_mail"] = "admin@example.org"
+    page = page.form.submit().follow().form.submit().follow()
+    ticket_number = page.pyquery(".ticket-number").text()
+    page = client.get("/tickets/ALL/open").click(ticket_number)
+    # the Gever upload button should not be shown ...
+    assert "Hochladen auf Gever" not in page
+
+    settings = client.get('/settings').click('Gever API')
+    settings.form['gever_username'] = 'foo'
+    settings.form['gever_password'] = 'bar'
+    settings.form['gever_endpoint'] = 'https://example.org/'
+    settings.form.submit()
+
+    page = client.get("/tickets/ALL/open").click(ticket_number)
+    # ... until it has been activated in settings
+    assert "Hochladen auf Gever" in page


### PR DESCRIPTION
## Commit message

Town6: Hide Gever Upload in navbar if it is not set in settings

TYPE: Bugfix
LINK:  OGC-922

## Checklist

- [x] I considered adding a reviewer
- [x] I have tested my code thoroughly by hand
- [x] I have added tests for my changes/features

