### PR TITLE
Org: Replaces the entry count in the DirectoriesWidget with the lead

### DIFF
--- a/src/onegov/org/homepage_widgets.py
+++ b/src/onegov/org/homepage_widgets.py
@@ -132,11 +132,7 @@ class DirectoriesWidget:
                     ExtendedDirectoryEntryCollection,
                     {'directory_name': d.name}
                 ),
-                subtitle=(
-                    d.count == 1
-                    and _("1 entry")
-                    or _("${count} entries", mapping={'count': d.count})
-                )
+                subtitle=d.lead
             ) for d in layout.request.exclude_invisible(directories.query())
         ]
 


### PR DESCRIPTION
## Commit message

Org: Replaces the entry count in the DirectoriesWidget with the lead

The entry count was misleading because it did not take the entry's visibility into account. Counting properly would be too slow for a widget, so we show the lead instead.

TYPE: Bugfix
LINK: OGC-1006

Please fill in the commit message below and work through the checklist. You can delete parts that are not needed, e.g. the optional description, the link to a ticket or irrelevant options of the checklist.

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have tested my code thoroughly by hand
