### PR TITLE
Bugfix/ogc 977 parsererror yamlparser in parse block mapping key

### DIFF
--- a/src/onegov/form/errors.py
+++ b/src/onegov/form/errors.py
@@ -24,6 +24,11 @@ class InvalidFormSyntax(FormError):
         self.line = line
 
 
+class InvalidIndentSyntax(FormError):
+    def __init__(self, line):
+        self.line = line
+
+
 class FieldCompileError(FormError):
     def __init__(self, field_name):
         self.field_name = field_name

--- a/src/onegov/form/parser/core.py
+++ b/src/onegov/form/parser/core.py
@@ -1068,6 +1068,15 @@ def ensure_a_fieldset(lines):
             yield ix, line
 
 
+def validate_indent(indent):
+    """
+    Returns `False` if indent is other than a multiple of 4, else True
+    """
+    if len(indent) % 4 != 0:
+        return False
+    return True
+
+
 def translate_to_yaml(text):
     """ Takes the given form text and constructs an easier to parse yaml
     string.
@@ -1088,6 +1097,8 @@ def translate_to_yaml(text):
     for ix, line in lines:
 
         indent = ' ' * (4 + (len(line) - len(line.lstrip())))
+        if not validate_indent(indent):
+            raise errors.InvalidIndentSyntax(line=ix + 1)
 
         # the top level are the fieldsets
         if match(ELEMENTS.fieldset_title, line):

--- a/src/onegov/form/validators.py
+++ b/src/onegov/form/validators.py
@@ -10,7 +10,7 @@ from datetime import datetime
 from dateutil.relativedelta import relativedelta
 from mimetypes import types_map
 from onegov.form import _
-from onegov.form.errors import DuplicateLabelError
+from onegov.form.errors import DuplicateLabelError, InvalidIndentSyntax
 from onegov.form.errors import FieldCompileError
 from onegov.form.errors import InvalidFormSyntax
 from onegov.form.errors import MixedTypeError
@@ -134,6 +134,8 @@ class ValidFormDefinition:
     message = _("The form could not be parsed.")
     email = _("Define at least one required e-mail field ('E-Mail * = @@@')")
     syntax = _("The syntax on line {line} is not valid.")
+    indent = _("The indentation on line {line} is not valid. "
+               "Please use a multiple of 4 spaces")
     duplicate = _("The field '{label}' exists more than once.")
     reserved = _("'{label}' is a reserved name. Please use a different name.")
     required = _("Define at least one required field")
@@ -169,6 +171,9 @@ class ValidFormDefinition:
                 raise ValidationError(
                     field.gettext(self.syntax).format(line=e.line)
                 )
+            except InvalidIndentSyntax as e:
+                raise ValidationError(
+                    field.gettext(self.indent).format(line=e.line))
             except DuplicateLabelError as e:
                 raise ValidationError(
                     field.gettext(self.duplicate).format(label=e.label)

--- a/tests/onegov/form/test_parser.py
+++ b/tests/onegov/form/test_parser.py
@@ -4,6 +4,7 @@ from dateutil.relativedelta import relativedelta
 from decimal import Decimal
 from onegov.form import Form, errors, find_field
 from onegov.form import parse_formcode, parse_form, flatten_fieldsets
+from onegov.form.errors import InvalidIndentSyntax
 from onegov.form.fields import DateTimeLocalField
 from onegov.form.parser.form import normalize_label_for_dependency
 from onegov.form.parser.grammar import field_help_identifier
@@ -1035,3 +1036,33 @@ def test_normalization():
     label = "Ich möchte die Bestellung mittels Post erhalten (200.00 CHF)"
     norm = normalize_label_for_dependency(label)
     assert norm == "Ich möchte die Bestellung mittels Post erhalten"
+
+
+@pytest.mark.parametrize('indent,shall_raise', [
+    ('', False),
+    (' ', True),
+    ('  ', True),
+    ('   ', True),
+])
+def test_raise_indentation_error(indent, shall_raise):
+    # wrong indent see 'Telefonnummer'
+    text = dedent(
+        """
+        # Kiosk
+        Name des Kiosks = ___
+        # Kontaktangaben
+        Kontaktperson = ___
+        {}Telefonnummer = ___
+        """.format(indent)
+    )
+
+    if shall_raise:
+        with pytest.raises(InvalidIndentSyntax) as excinfo:
+            parse_formcode(text)
+
+        assert excinfo.value.line == 6
+    else:
+        try:
+            parse_formcode(text)
+        except InvalidIndentSyntax as e:
+            pytest.fail('Unexpected exception {}'.format(type(e).__name__))

--- a/tests/onegov/form/test_parser.py
+++ b/tests/onegov/form/test_parser.py
@@ -1044,7 +1044,7 @@ def test_normalization():
     ('  ', True),
     ('   ', True),
 ])
-def test_raise_indentation_error(indent, shall_raise):
+def test_indentation_error(indent, shall_raise):
     # wrong indent see 'Telefonnummer'
     text = dedent(
         """

--- a/tests/onegov/org/test_views_forms.py
+++ b/tests/onegov/org/test_views_forms.py
@@ -45,11 +45,11 @@ def test_render_form(client):
         Field('Textfield long', '*= ___', long_field_help),
         Field('Email long', '* = @@@', long_field_help),
         Field('Checkbox', """*=
-                [ ] 4051
-                [ ] 4052""", long_field_help),
+    [ ] 4051
+    [ ] 4052""", long_field_help),
         Field('Select', """=
-                (x) A
-                ( ) B""", long_field_help),
+    (x) A
+    ( ) B""", long_field_help),
         Field('Alter', '= 0..150', long_field_help),
         Field('Percentage', '= 0.00..100.00', long_field_help),
         Field('IBAN', '= # iban', long_field_help),
@@ -62,11 +62,11 @@ def test_render_form(client):
     # Those should render description externally, checked visually
     not_rendering_placeholder = [
         Field('Checkbox2', """*=
-                   [ ] 4051
-                   [ ] 4052""", short_comment),
+    [ ] 4051
+    [ ] 4052""", short_comment),
         Field('Select2', """=
-                    (x) A
-                    ( ) B""", short_comment),
+    (x) A
+    ( ) B""", short_comment),
         Field('Image2', '= *.jpg|*.png|*.gif', short_comment),
         Field('Dokument2', '= *.pdf', short_comment)
     ]


### PR DESCRIPTION
## Commit message

Forms: Introduce indentation check for yaml forms

The indentation check for yaml forms is used to provide a hint to the user about wrong indentations.

Feature
LINK: ogc-977
