### PR TITLE
Feature/ogc 947 vergangene veranstaltungen im veranstaltungskalender anzeigen

### DIFF
--- a/src/onegov/org/templates/macros.pt
+++ b/src/onegov/org/templates/macros.pt
@@ -1053,7 +1053,6 @@
         <p i18n:translate>No events found.</p>
         <br>
         <tal condition="'range' in layout.og_url">
-            <p><a href="${layout.events_url}" i18n:translate>All events</a>
             <br><a href="${layout.events_url}&amp;range=past" i18n:translate>Past events</a>
         </tal>
     </tal:b>

--- a/src/onegov/org/templates/macros.pt
+++ b/src/onegov/org/templates/macros.pt
@@ -1051,10 +1051,7 @@
     </tal:b>
     <tal:b condition="not occurrences" >
         <p i18n:translate>No events found.</p>
-        <br>
-        <tal condition="'range' in layout.og_url">
-            <br><a href="${layout.events_url}&amp;range=past" i18n:translate>Past events</a>
-        </tal>
+        <br><a tal:condition="'range=' not in request.url" href="${layout.events_url}&amp;range=past" i18n:translate>Past events</a>
     </tal:b>
 </metal:occurrences>
 

--- a/src/onegov/town6/templates/macros.pt
+++ b/src/onegov/town6/templates/macros.pt
@@ -1188,7 +1188,6 @@
         <p i18n:translate>No events found.</p>
         <br>
         <tal condition="'range' in layout.og_url">
-            <p><a href="${layout.events_url}" class="button hollow" i18n:translate>All events</a>
             <br><a href="${layout.events_url}&amp;range=past" class="button hollow" i18n:translate>Past events</a>
         </tal>
     </tal:b>

--- a/src/onegov/town6/templates/macros.pt
+++ b/src/onegov/town6/templates/macros.pt
@@ -1186,10 +1186,7 @@
         </div>
     <tal:b condition="not occurrences">
         <p i18n:translate>No events found.</p>
-        <br>
-        <tal condition="'range' in layout.og_url">
-            <br><a href="${layout.events_url}&amp;range=past" class="button hollow" i18n:translate>Past events</a>
-        </tal>
+        <br><a tal:condition="'range' not in request.url" href="${layout.events_url}&amp;range=past" class="button hollow" i18n:translate>Past events</a>
     </tal:b>
 </metal:occurrences>
 


### PR DESCRIPTION
## Commit message

Events: We only show the 'past events' button if no future events were found. 

After customer feedback we reworked the feature to the following. We only show the 'past events' button if no future events were found. 
To evaluate this we look for 'range' as keyword in the request url. If present we skip showing the button.

Feature
LINK: ogc-947