### PR TITLE
Event: Make Test less flaky

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -65,7 +65,7 @@ install_requires =
     bleach
     blinker
     cached_property
-    chameleon
+    chameleon<4.0.0
     certifi
     click
     colour


### PR DESCRIPTION
## Commit message

Event: Make Test less flaky

Test has repeatedly failed depending on the time, so we freeze the time. It appears that the assert statements have failed in the past because the comparison is off by just about 0.12 seconds: 

![microseconds](https://user-images.githubusercontent.com/36520284/223215616-25f47a2a-f518-47c6-9216-4337b7b837b2.png)


TYPE: Bugfix


## Checklist

- [X] I considered adding a reviewer

