### PR TITLE
Form: Accepts submissions of 0-values in required numeric fields

### DIFF
--- a/src/onegov/form/parser/form.py
+++ b/src/onegov/form/parser/form.py
@@ -6,6 +6,7 @@ from onegov.form.fields import MultiCheckboxField, DateTimeLocalField
 from onegov.form.fields import UploadField, UploadMultipleField
 from onegov.form.parser.core import parse_formcode
 from onegov.form.utils import as_internal_id
+from onegov.form.validators import LaxDataRequired
 from onegov.form.validators import ExpectedExtensions
 from onegov.form.validators import FileSizeLimit
 from onegov.form.validators import Stdnum
@@ -23,7 +24,6 @@ from wtforms.fields import RadioField
 from wtforms.fields import StringField
 from wtforms.fields import TextAreaField
 from wtforms.fields import URLField
-from wtforms.validators import DataRequired
 from wtforms.validators import Length
 from wtforms.validators import NumberRange
 from wtforms.validators import Regexp
@@ -360,7 +360,7 @@ class WTFormsClassBuilder:
         # InputRequired will fail, but DataRequired will not.
         #
         # As a consequence, falsey values can't be submitted for now.
-        validators.insert(0, DataRequired())
+        validators.insert(0, LaxDataRequired())
 
     def validators_add_dependency(self, validators, dependency):
 
@@ -371,7 +371,7 @@ class WTFormsClassBuilder:
         validators.insert(0, validator)
 
         # if the dependency is fulfilled, the field is required
-        validator = If(dependency.fulfilled, DataRequired())
+        validator = If(dependency.fulfilled, LaxDataRequired())
         validator.field_flags = {'required': True}
         validators.insert(0, validator)
 

--- a/src/onegov/form/validators.py
+++ b/src/onegov/form/validators.py
@@ -261,7 +261,11 @@ class LaxDataRequired(DataRequired):
     """
 
     def __call__(self, form, field):
-        if isinstance(field.data, (int, float, Decimal)):
+        if field.data is False:
+            # guard against False, False is an instance of int, since
+            # bool derives from int, so we need to check this first
+            pass
+        elif isinstance(field.data, (int, float, Decimal)):
             # we just accept any numeric data regardless of amount
             return
 

--- a/tests/onegov/form/test_parser.py
+++ b/tests/onegov/form/test_parser.py
@@ -7,6 +7,7 @@ from onegov.form import parse_formcode, parse_form, flatten_fieldsets
 from onegov.form.fields import DateTimeLocalField
 from onegov.form.parser.form import normalize_label_for_dependency
 from onegov.form.parser.grammar import field_help_identifier
+from onegov.form.validators import LaxDataRequired
 from onegov.pay import Price
 from textwrap import dedent
 from webob.multidict import MultiDict
@@ -15,7 +16,6 @@ from wtforms.fields import DateField
 from wtforms.fields import EmailField
 from wtforms.fields import FileField
 from wtforms.fields import URLField
-from wtforms.validators import DataRequired
 from wtforms.validators import Length
 from wtforms.validators import Optional
 from wtforms.validators import Regexp
@@ -56,7 +56,7 @@ def test_parse_text():
     assert form.first_name.label.text == 'First name'
     assert form.first_name.description == 'Fill in all in UPPER case'
     assert len(form.first_name.validators) == 1
-    assert isinstance(form.first_name.validators[0], DataRequired)
+    assert isinstance(form.first_name.validators[0], LaxDataRequired)
 
     assert form.last_name.label.text == 'Last name'
     assert len(form.last_name.validators) == 1
@@ -832,9 +832,10 @@ def test_integer_range():
     form.validate()
     assert form.errors
 
-    form_class = parse_form("Age *= 21..150")
+    # 0 should validate on a required field
+    form_class = parse_form("Items *= 0..10")
     form = form_class(MultiDict([
-        ('age', '21')
+        ('items', '0')
     ]))
 
     form.validate()
@@ -920,9 +921,10 @@ def test_decimal_range():
     form.validate()
     assert form.errors
 
+    # 0 should validate on a decimal field
     form_class = parse_form("Percentage = 0.00..100.00")
     form = form_class(MultiDict([
-        ('percentage', '33.33')
+        ('percentage', '0.0')
     ]))
 
     form.validate()


### PR DESCRIPTION
## Commit message

Form: Accepts submissions of 0-values in required numeric fields

Previously due to 0-values not being truthy, they would get rejected by the DataRequired validator on required fields in user-defined forms.

TYPE: Bugfix
LINK: OGC-1014

## Checklist

- [x] I have performed a self-review of my code
- [x] I have tested my code thoroughly by hand
- [x] I have added tests for my changes/features
