### PR TITLE
Org: Catch exception to prevent unresponsive 'link insert' overlay.

### DIFF
--- a/src/onegov/org/assets/js/redactor.js
+++ b/src/onegov/org/assets/js/redactor.js
@@ -7701,7 +7701,11 @@
 						node = node[0] || node;
 
 						var range = document.createRange();
-						range.selectNodeContents(node);
+						try {
+							range.selectNodeContents(node);
+						} catch (e) {
+							console.error("Catched Error: " + e.message);
+						}
 					}
 					else
 					{


### PR DESCRIPTION
## Commit message

Org: Catch exception to prevent unresponsive 'link insert' overlay

Even if the call `selectNodeContents` fails – it still works.

TYPE: Bugfix
LINK:  OGC-1013

## Checklist

- [X] I made changes/features for both org and town6
- [X] I considered adding a reviewer
- [X] I have tested my code thoroughly by hand
