### PR TITLE
Core: Don't use deferral on timestamp columns.

### DIFF
--- a/src/onegov/core/orm/mixins/timestamp.py
+++ b/src/onegov/core/orm/mixins/timestamp.py
@@ -2,7 +2,6 @@ from onegov.core.orm.types import UTCDateTime
 from sedate import utcnow
 from sqlalchemy.ext.declarative import declared_attr
 from sqlalchemy import func
-from sqlalchemy.orm import deferred
 from sqlalchemy.schema import Column
 from sqlalchemy.ext.hybrid import hybrid_property
 
@@ -25,11 +24,11 @@ class TimestampMixin:
 
     @declared_attr
     def created(cls):
-        return deferred(Column(UTCDateTime, default=cls.timestamp))
+        return Column(UTCDateTime, default=cls.timestamp)
 
     @declared_attr
     def modified(cls):
-        return deferred(Column(UTCDateTime, onupdate=cls.timestamp))
+        return Column(UTCDateTime, onupdate=cls.timestamp)
 
     @hybrid_property
     def last_change(self):


### PR DESCRIPTION
## Commit message

Core: Don't use deferral on timestamp columns.

Timestamps don't add a lot of data to queries but accessing them will  lead to a lot of additional queries. Also, nobody expects these  timestamps to be deferred in the first place.

TYPE: Bugfix

Please fill in the commit message below and work through the checklist. You can delete parts that are not needed, e.g. the optional description, the link to a ticket or irrelevant options of the checklist.

## Checklist

- [x] I have performed a self-review of my code