### PR TITLE
Election Day: Add websocket notification fallback.

### DIFF
--- a/src/onegov/election_day/assets/js/notifications.js
+++ b/src/onegov/election_day/assets/js/notifications.js
@@ -1,14 +1,41 @@
-var onWebsocketNotification = function(message, websocket) {
-    if (message.event === 'refresh' && window.location.href.search(message.path) !== -1) {
-        $(".page-refresh").show();
-        websocket.close();
-    }
-};
-
 $(document).ready(function() {
     const endpoint = $('body').data('websocket-endpoint');
     const schema = $('body').data('websocket-schema');
+    const fallback = $('body').data('websocket-fallback');
+
+    function onWebsocketNotification(message, websocket) {
+        if (message.event === 'refresh' && window.location.href.search(message.path) !== -1) {
+            $(".page-refresh").show();
+            websocket.close();
+        }
+    }
+
+    var lastNotified;
+    var intervalId;
+    function poll() {
+        if (fallback) {
+            fetch(fallback)
+                .then((response) => response.json())
+                .then((data) => {
+                    const notified = Date.parse(data['last-notified']) || 1;
+                    if (lastNotified && notified !== lastNotified) {
+                        $(".page-refresh").show();
+                        clearInterval(intervalId);
+                    }
+                    lastNotified = notified;
+                })
+                .catch((_error) => {});
+        }
+    }
+
+    function onWebsocketError(_event, websocket) {
+        websocket.close();
+        if (fallback) {
+            intervalId = setInterval(poll, 60000);
+        }
+    }
+
     if (endpoint && schema) {
-        openWebsocket(endpoint, schema, null, onWebsocketNotification);
+        openWebsocket(endpoint, schema, null, onWebsocketNotification, onWebsocketError);
     }
 });

--- a/src/onegov/election_day/layouts/detail.py
+++ b/src/onegov/election_day/layouts/detail.py
@@ -53,7 +53,10 @@ class DetailLayout(DefaultLayout, HiddenTabsMixin):
                 'data-websocket-endpoint': self.app.websockets_client_url(
                     request
                 ),
-                'data-websocket-schema': self.app.schema
+                'data-websocket-schema': self.app.schema,
+                'data-websocket-fallback': request.link(
+                    self.model, 'last-notified'
+                )
             }
 
     @cached_property

--- a/src/onegov/election_day/utils/__init__.py
+++ b/src/onegov/election_day/utils/__init__.py
@@ -1,8 +1,9 @@
 from onegov.election_day.utils.common import add_cors_header
 from onegov.election_day.utils.common import add_last_modified_header
 from onegov.election_day.utils.common import add_local_results
-from onegov.election_day.utils.common import get_parameter
 from onegov.election_day.utils.common import get_entity_filter
+from onegov.election_day.utils.common import get_last_notified
+from onegov.election_day.utils.common import get_parameter
 from onegov.election_day.utils.filenames import pdf_filename
 from onegov.election_day.utils.filenames import svg_filename
 from onegov.election_day.utils.summaries import get_election_compound_summary
@@ -19,6 +20,7 @@ __all__ = [
     'get_election_compound_summary',
     'get_election_summary',
     'get_entity_filter',
+    'get_last_notified',
     'get_parameter',
     'get_summaries',
     'get_summary',

--- a/src/onegov/election_day/utils/common.py
+++ b/src/onegov/election_day/utils/common.py
@@ -2,6 +2,7 @@ from collections import OrderedDict
 from onegov.ballot import ComplexVote
 from onegov.ballot import Vote
 from onegov.election_day import _
+from sqlalchemy import desc
 
 
 def sublist_name_from_connection_id(conn_name, subconn_name):
@@ -100,6 +101,14 @@ def add_local_results(source, target, principal, session):
                 target.local_answer = answer
                 target.local_yeas_percentage = yeas
                 target.local_nays_percentage = 100 - yeas
+
+
+def get_last_notified(model):
+    from onegov.election_day.models.notification import Notification
+
+    result = model.notifications.filter(Notification.type == 'websocket')
+    result = result.order_by(desc(Notification.created)).first()
+    return result.created.isoformat() if result else None
 
 
 def get_parameter(request, name, type_, default):

--- a/src/onegov/election_day/views/election/main.py
+++ b/src/onegov/election_day/views/election/main.py
@@ -7,6 +7,7 @@ from onegov.election_day import ElectionDayApp
 from onegov.election_day.layouts import ElectionLayout
 from onegov.election_day.utils import add_cors_header
 from onegov.election_day.utils import add_last_modified_header
+from onegov.election_day.utils import get_last_notified
 from onegov.election_day.utils import get_election_summary
 from onegov.election_day.utils.election import get_candidates_results
 from onegov.election_day.utils.election import get_connection_results
@@ -220,6 +221,23 @@ def view_election_summary(self, request):
         add_last_modified_header(response, self.last_modified)
 
     return get_election_summary(self, request)
+
+
+@ElectionDayApp.json(
+    model=Election,
+    name='last-notified',
+    permission=Public
+)
+def view_election_last_notified(self, request):
+
+    """ View the timestamp of the last notification. """
+
+    @request.after
+    def add_headers(response):
+        add_cors_header(response)
+        add_last_modified_header(response, self.last_modified)
+
+    return {'last-notified': get_last_notified(self)}
 
 
 @ElectionDayApp.pdf_file(model=Election, name='pdf')

--- a/src/onegov/election_day/views/election_compound/main.py
+++ b/src/onegov/election_day/views/election_compound/main.py
@@ -8,6 +8,7 @@ from onegov.election_day.layouts import ElectionCompoundLayout
 from onegov.election_day.utils import add_cors_header
 from onegov.election_day.utils import add_last_modified_header
 from onegov.election_day.utils import get_election_compound_summary
+from onegov.election_day.utils import get_last_notified
 from onegov.election_day.utils.election_compound import \
     get_candidate_statistics
 from onegov.election_day.utils.election_compound import get_elected_candidates
@@ -162,6 +163,23 @@ def view_election_compound_summary(self, request):
         add_last_modified_header(response, self.last_modified)
 
     return get_election_compound_summary(self, request)
+
+
+@ElectionDayApp.json(
+    model=ElectionCompound,
+    name='last-notified',
+    permission=Public
+)
+def view_election_compound_last_notified(self, request):
+
+    """ View the timestamp of the last notification. """
+
+    @request.after
+    def add_headers(response):
+        add_cors_header(response)
+        add_last_modified_header(response, self.last_modified)
+
+    return {'last-notified': get_last_notified(self)}
 
 
 @ElectionDayApp.pdf_file(model=ElectionCompound, name='pdf')

--- a/src/onegov/election_day/views/election_compound_part/main.py
+++ b/src/onegov/election_day/views/election_compound_part/main.py
@@ -6,6 +6,7 @@ from onegov.election_day.layouts import ElectionCompoundPartLayout
 from onegov.election_day.utils import add_cors_header
 from onegov.election_day.utils import add_last_modified_header
 from onegov.election_day.utils import get_election_compound_summary
+from onegov.election_day.utils import get_last_notified
 from onegov.election_day.utils.election_compound import \
     get_candidate_statistics
 from onegov.election_day.utils.election_compound import \
@@ -23,9 +24,7 @@ def view_election_compound_part_head(self, request):
     @request.after
     def add_headers(response):
         add_cors_header(response)
-        add_last_modified_header(
-            response, self.election_compound.last_modified
-        )
+        add_last_modified_header(response, self.last_modified)
 
 
 @ElectionDayApp.html(
@@ -139,3 +138,20 @@ def view_election_compound_part_summary(self, request):
     return get_election_compound_summary(
         self, request, type_='election_compound_part'
     )
+
+
+@ElectionDayApp.json(
+    model=ElectionCompoundPart,
+    name='last-notified',
+    permission=Public
+)
+def view_election_compound_part_last_notified(self, request):
+
+    """ View the timestamp of the last notification. """
+
+    @request.after
+    def add_headers(response):
+        add_cors_header(response)
+        add_last_modified_header(response, self.last_modified)
+
+    return {'last-notified': get_last_notified(self.election_compound)}

--- a/src/onegov/election_day/views/manage/election_compounds.py
+++ b/src/onegov/election_day/views/manage/election_compounds.py
@@ -249,6 +249,7 @@ def trigger_election(self, request, form):
     if form.submitted(request):
         notifications.trigger(request, self, form.notifications.data)
         request.message(_("Notifications triggered."), 'success')
+        request.app.pages_cache.flush()
         return redirect(layout.manage_model_link)
 
     callout = None

--- a/src/onegov/election_day/views/manage/elections.py
+++ b/src/onegov/election_day/views/manage/elections.py
@@ -249,6 +249,7 @@ def trigger_election(self, request, form):
     if form.submitted(request):
         notifications.trigger(request, self, form.notifications.data)
         request.message(_("Notifications triggered."), 'success')
+        request.app.pages_cache.flush()
         return redirect(layout.manage_model_link)
 
     callout = None

--- a/src/onegov/election_day/views/manage/notifications.py
+++ b/src/onegov/election_day/views/manage/notifications.py
@@ -30,6 +30,7 @@ def view_trigger_notficiations(self, request, form):
             form.notifications.data
         )
         request.message(_("Notifications triggered."), 'success')
+        request.app.pages_cache.flush()
         return redirect(layout.manage_link)
 
     latest_date = form.latest_date(session)

--- a/src/onegov/election_day/views/manage/votes.py
+++ b/src/onegov/election_day/views/manage/votes.py
@@ -249,6 +249,7 @@ def trigger_vote(self, request, form):
     if form.submitted(request):
         notifications.trigger(request, self, form.notifications.data)
         request.message(_("Notifications triggered."), 'success')
+        request.app.pages_cache.flush()
         return redirect(layout.manage_model_link)
 
     callout = None

--- a/src/onegov/election_day/views/vote/main.py
+++ b/src/onegov/election_day/views/vote/main.py
@@ -7,6 +7,7 @@ from onegov.election_day import ElectionDayApp
 from onegov.election_day.layouts import VoteLayout
 from onegov.election_day.utils import add_cors_header
 from onegov.election_day.utils import add_last_modified_header
+from onegov.election_day.utils import get_last_notified
 from onegov.election_day.utils import get_vote_summary
 
 
@@ -174,6 +175,23 @@ def view_vote_summary(self, request):
         add_last_modified_header(response, self.last_modified)
 
     return get_vote_summary(self, request)
+
+
+@ElectionDayApp.json(
+    model=Vote,
+    name='last-notified',
+    permission=Public
+)
+def view_vote_last_notified(self, request):
+
+    """ View the timestamp of the last notification. """
+
+    @request.after
+    def add_headers(response):
+        add_cors_header(response)
+        add_last_modified_header(response, self.last_modified)
+
+    return {'last-notified': get_last_notified(self)}
 
 
 @ElectionDayApp.pdf_file(model=Vote, name='pdf')

--- a/src/onegov/org/assets/js/notifications.js
+++ b/src/onegov/org/assets/js/notifications.js
@@ -1,13 +1,15 @@
-var onWebsocketNotification = function(message, _websocket) {
-    if (message.event === 'browser-notification' && message.title && "Notification" in window) {
-        if (Notification.permission === "granted") {
-            // eslint-disable-next-line no-new
-            new Notification(message.title, {tag: message.created});
+$(document).ready(function() {
+    function onWebsocketNotification(message, _websocket) {
+        if (message.event === 'browser-notification' && message.title && "Notification" in window) {
+            if (Notification.permission === "granted") {
+                // eslint-disable-next-line no-new
+                new Notification(message.title, {tag: message.created});
+            }
         }
     }
-};
 
-$(document).ready(function() {
+    function onWebsocketError(_event, _websocket) {}
+
     if ("Notification" in window) {
         if (Notification.permission === "granted") {
             $('.ticket-notifications').addClass("granted");
@@ -17,7 +19,7 @@ $(document).ready(function() {
             const schema = $('body').data('websocket-schema');
             const channel = $('body').data('websocket-channel');
             if (endpoint && schema && channel) {
-                openWebsocket(endpoint, schema, channel, onWebsocketNotification);
+                openWebsocket(endpoint, schema, channel, onWebsocketNotification, onWebsocketError);
             }
         } else {
             $('.ticket-notifications').click(function() {

--- a/src/onegov/websockets/assets/js/websockets.js
+++ b/src/onegov/websockets/assets/js/websockets.js
@@ -1,5 +1,10 @@
-var openWebsocket = function(endpoint, schema, channel, onnotifcation) {
+var openWebsocket = function(endpoint, schema, channel, onNotifcation, onError) {
     const websocket = new WebSocket(endpoint);
+    websocket.addEventListener("error", function(event) {
+        if (onError) {
+            onError(event, websocket);
+        }
+    });
     websocket.addEventListener("open", function() {
         const payload = {
             type: "register",
@@ -11,7 +16,10 @@ var openWebsocket = function(endpoint, schema, channel, onnotifcation) {
     websocket.addEventListener('message', function(message) {
         const data = JSON.parse(message.data);
         if (data.type === 'notification') {
-            onnotifcation(data.message, websocket);
+            onNotifcation(data.message, websocket);
+        }
+        if (data.type === 'error' && onError) {
+            onError(data.message, websocket);
         }
     });
 };

--- a/tests/onegov/election_day/common.py
+++ b/tests/onegov/election_day/common.py
@@ -159,6 +159,7 @@ class DummyPrincipal:
         self.has_superregions = False
         self._is_year_available = True
         self.reply_to = None
+        self.superregions = []
 
     @property
     def notifications(self):
@@ -178,6 +179,9 @@ class DummyPrincipal:
 
     def get_superregion(self, region, year):
         return ''
+
+    def get_superregions(self, year):
+        return self.superregions
 
 
 class DummyApp:

--- a/tests/onegov/election_day/utils/test_common_utils.py
+++ b/tests/onegov/election_day/utils/test_common_utils.py
@@ -1,6 +1,59 @@
+from datetime import date
+from onegov.ballot import Election
+from onegov.ballot import ElectionCompound
+from onegov.ballot import Vote
 from onegov.core.utils import Bunch
+from onegov.election_day.models import Notification
+from onegov.election_day.models import WebsocketNotification
+from onegov.election_day.utils import get_last_notified
 from onegov.election_day.utils import get_parameter
 from pytest import raises
+
+
+def test_get_last_notified(session):
+    vote = Vote(
+        title="Vote",
+        domain='federation',
+        date=date(2011, 1, 1),
+    )
+    election = Election(
+        title="election",
+        domain='region',
+        date=date(2011, 1, 1),
+    )
+    compound = ElectionCompound(
+        title="Elections",
+        domain='canton',
+        date=date(2011, 1, 1),
+    )
+
+    for model in (vote, election, compound):
+        session.add(model)
+        session.flush()
+
+        assert get_last_notified(model) is None
+
+        notification = WebsocketNotification()
+        notification.update_from_model(model)
+        session.add(notification)
+        session.flush()
+
+        last_notified = get_last_notified(model)
+        assert last_notified is not None
+
+        notification = Notification()
+        notification.update_from_model(model)
+        session.add(notification)
+        session.flush()
+
+        assert get_last_notified(model) == last_notified
+
+        notification = WebsocketNotification()
+        notification.update_from_model(model)
+        session.add(notification)
+        session.flush()
+
+        assert get_last_notified(model) > last_notified
 
 
 def test_get_param():

--- a/tests/onegov/election_day/views/test_views_notifications.py
+++ b/tests/onegov/election_day/views/test_views_notifications.py
@@ -22,6 +22,8 @@ def test_view_notifications_votes(election_day_app_zg):
     new.form['domain'] = 'federation'
     new.form.submit()
 
+    assert client.get('/vote/vote/last-notified').json['last-notified'] is None
+
     # Test retrigger messages
     assert "Benachrichtigungen auslösen" in client.get('/manage/votes')
     assert "Benachrichtigungen auszulösen" in upload_vote(client, False)
@@ -38,6 +40,8 @@ def test_view_notifications_votes(election_day_app_zg):
     trigger.form['notifications'] = ['webhooks']
     trigger.form.submit()
 
+    assert client.get('/vote/vote/last-notified').json['last-notified'] is None
+
     form = client.get('/vote/vote/trigger')
     assert "erneut auslösen" in form
     assert ": webhooks (" in form
@@ -45,7 +49,7 @@ def test_view_notifications_votes(election_day_app_zg):
     upload_vote(client, False)
     assert "erneut auslösen" not in client.get('/vote/vote/trigger')
 
-    # Test email
+    # Test email and last notified
     principal = election_day_app_zg.principal
     principal.email_notification = True
     election_day_app_zg.cache.set('principal', principal)
@@ -66,7 +70,7 @@ def test_view_notifications_votes(election_day_app_zg):
     client.get_email(0, flush_queue=True)
 
     trigger = client.get('/vote/vote/trigger')
-    trigger.form['notifications'] = ['email']
+    trigger.form['notifications'] = ['email', 'websocket']
     trigger.form.submit()
 
     message = client.get_email(0, flush_queue=True)
@@ -74,6 +78,10 @@ def test_view_notifications_votes(election_day_app_zg):
     assert message['Subject'] == 'Vote - Refusé'
     message = message['HtmlBody']
     assert "Vote - Refusé" in message
+
+    assert client.get(
+        '/vote/vote/last-notified'
+    ).json['last-notified'] is not None
 
 
 def test_view_notifications_elections(election_day_app_gr):
@@ -89,6 +97,10 @@ def test_view_notifications_elections(election_day_app_gr):
     new.form['election_type'] = 'majorz'
     new.form['domain'] = 'federation'
     new.form.submit()
+
+    assert client.get(
+        '/election/majorz-election/last-notified'
+    ).json['last-notified'] is None
 
     # Test retrigger messages
     assert "Benachrichtigungen auslösen" in client.get('/manage/elections')
@@ -111,6 +123,10 @@ def test_view_notifications_elections(election_day_app_gr):
     trigger.form['notifications'] = ['webhooks']
     trigger.form.submit()
 
+    assert client.get(
+        '/election/majorz-election/last-notified'
+    ).json['last-notified'] is None
+
     form = client.get('/election/majorz-election/trigger')
     assert "erneut auslösen" in form
     assert ": webhooks (" in form
@@ -120,7 +136,7 @@ def test_view_notifications_elections(election_day_app_gr):
         '/election/majorz-election/trigger'
     )
 
-    # Test email
+    # Test email and last notified
     principal = election_day_app_gr.principal
     principal.email_notification = True
     election_day_app_gr.cache.set('principal', principal)
@@ -142,7 +158,7 @@ def test_view_notifications_elections(election_day_app_gr):
     client.get_email(0, flush_queue=True)
 
     trigger = client.get('/election/majorz-election/trigger')
-    trigger.form['notifications'] = ['email']
+    trigger.form['notifications'] = ['email', 'websocket']
     trigger.form.submit()
 
     message = client.get_email(0, flush_queue=True)
@@ -153,6 +169,10 @@ def test_view_notifications_elections(election_day_app_gr):
     message = message['HtmlBody']
     assert "Majorz Election - Nouveaux résultats intermédiaires" in message
 
+    assert client.get(
+        '/election/majorz-election/last-notified'
+    ).json['last-notified'] is not None
+
 
 def test_view_notifications_election_compouds(election_day_app_gr):
     client = Client(election_day_app_gr)
@@ -161,6 +181,13 @@ def test_view_notifications_election_compouds(election_day_app_gr):
     login(client)
 
     create_election_compound(client)
+
+    assert client.get(
+        '/elections/elections/last-notified'
+    ).json['last-notified'] is None
+    assert client.get(
+        '/elections-part/elections/district/Albula/last-notified'
+    ).json['last-notified'] is None
 
     # Test retrigger messages
     assert "Benachrichtigungen auslösen" in client.get(
@@ -186,6 +213,13 @@ def test_view_notifications_election_compouds(election_day_app_gr):
     trigger.form['notifications'] = ['webhooks']
     trigger.form.submit()
 
+    assert client.get(
+        '/elections/elections/last-notified'
+    ).json['last-notified'] is None
+    assert client.get(
+        '/elections-part/elections/district/Albula/last-notified'
+    ).json['last-notified'] is None
+
     form = client.get('/elections/elections/trigger')
     assert "erneut auslösen" in form
     assert ": webhooks (" in form
@@ -193,7 +227,7 @@ def test_view_notifications_election_compouds(election_day_app_gr):
     upload_election_compound(client, False)
     assert "erneut auslösen" not in client.get('/elections/elections/trigger')
 
-    # Test email
+    # Test email and last notified
     principal = election_day_app_gr.principal
     principal.email_notification = True
     election_day_app_gr.cache.set('principal', principal)
@@ -215,7 +249,7 @@ def test_view_notifications_election_compouds(election_day_app_gr):
     client.get_email(0, flush_queue=True)
 
     trigger = client.get('/elections/elections/trigger')
-    trigger.form['notifications'] = ['email']
+    trigger.form['notifications'] = ['email', 'websocket']
     trigger.form.submit()
 
     message = client.get_email(0, flush_queue=True)
@@ -227,6 +261,13 @@ def test_view_notifications_election_compouds(election_day_app_gr):
     assert 'Elections - Nouveaux résultats intermédiaires' in message
     assert 'Winner Carol' in message
     assert 'Sieger Hans' in message
+
+    assert client.get(
+        '/elections/elections/last-notified'
+    ).json['last-notified'] is not None
+    assert client.get(
+        '/elections-part/elections/district/Albula/last-notified'
+    ).json['last-notified'] is not None
 
 
 def test_view_notifications_summarized(election_day_app_zg):

--- a/tests/onegov/websockets/test_browser.py
+++ b/tests/onegov/websockets/test_browser.py
@@ -22,7 +22,8 @@ async def test_browser_integration(browser):
                             "two",
                             function(message, websocket) {{
                                 messageReceived = true;
-                            }}
+                            }},
+                            function(error) {{}}
                         );
                     }});
                 </script>


### PR DESCRIPTION
## Commit message

Election Day: Add websocket notification fallback.

Falls back to short polling using a cached endpoint, in case the  websocket server is unreachable or out of workers.

TYPE: Feature
LINK: OGC-991

Please fill in the commit message below and work through the checklist. You can delete parts that are not needed, e.g. the optional description, the link to a ticket or irrelevant options of the checklist.

## Checklist

- [x] I made changes/features for both org and town6
- [x] I have performed a self-review of my code
- [x] I have tested my code thoroughly by hand
    - [x] I have tested javascript changes/features on different browsers
- [x] I have added tests for my changes/features
    - [x] I considered using browser tests für javascript changes/features