### PR TITLE
Make spot availabilty depend on booking end and don't let booking end…

### DIFF
--- a/src/onegov/activity/models/period.py
+++ b/src/onegov/activity/models/period.py
@@ -422,7 +422,9 @@ class Period(Base, TimestampMixin):
         if now > end:
             return True
 
-        return start <= now and not self.booking_phase
+        return start <= now and not (
+            self.booking_phase
+            or self.book_finalized)
 
     @property
     def is_execution_in_past(self):

--- a/src/onegov/feriennet/templates/macros.pt
+++ b/src/onegov/feriennet/templates/macros.pt
@@ -425,7 +425,7 @@
         period occasion.period;
         wrap_occasion_link wrap_occasion_link|lambda url: url">
 
-        <div class="state" tal:condition="period.phase not in ('inactive', 'wishlist')">
+        <div class="state" tal:condition="period.phase not in ('inactive', 'wishlist')">    
             <div class="full" tal:condition="not occasion.cancelled and occasion.full">
                 <span i18n:translate>Fully booked</span>
             </div>
@@ -434,11 +434,11 @@
                 <span i18n:translate>Rescinded</span>
             </div>
 
-            <div class="available-spots" tal:condition="not occasion.cancelled and not occasion.full and not period.finalized">
+            <div class="available-spots" tal:condition="not occasion.cancelled and not occasion.full and not period.is_booking_in_past">
                 <span i18n:translate><tal:b i18n:name="count" replace="occasion.available_spots" /> spots available</span>
             </div>
 
-            <div class="spots" tal:condition="not occasion.cancelled and period.finalized">
+            <div class="spots" tal:condition="not occasion.cancelled and period.is_booking_in_past">
                 <span i18n:translate><tal:b i18n:name="count" replace="occasion.attendee_count" /> attendees</span>
             </div>
         </div>


### PR DESCRIPTION
… early if book_finalized is set.

Please fill in the commit message below and work through the checklist. You can delete parts that are not needed, e.g. the optional description, the link to a ticket or irrelevant options of the checklist.

## Commit message

Feriennet: Display free spots until booking phase has ended

If "Allow bookings after the bills have been created." is checked in the phase settings the booking phase will only end once the actual end date of the booking phase is reached.

TYPE: Feature
LINK: PRO-909

## Checklist

- [x] I have performed a self-review of my code
- [x] I considered adding a reviewer
- [x] I have tested my code thoroughly by hand