### PR TITLE
Skip migration for complex addresses, just take over

### DIFF
--- a/src/onegov/people/cli.py
+++ b/src/onegov/people/cli.py
@@ -239,6 +239,16 @@ def migrate_people_address_field(dry_run):
             if not person.address:
                 continue
 
+            # skip auto migration for complex multiline addresses for BS
+            # just take it over
+            if '\r\n' in person.address:
+                # Example:
+                # 'Bau- und Verkehrsdepartement Basel-Stadt\r\nGrundbuch- und
+                # Vermessungsamt\r\nDufourstrasse 40/50\r\nPostfach,
+                # 4001 Basel'
+                person.postal_address = person.address
+                continue
+
             person.location_address, person.location_code_city, \
                 person.postal_address, person.postal_code_city = \
                 parse_and_split_address_field(person.address)


### PR DESCRIPTION
agency: Skip migration for complex addresses, just take over

TYPE: Feature
LINK: ogc-966
HINT: for Basel Stadt (BS): sudo ogc people --select /agency_with_msal/bs migrate-people-address-field --dry-run