### PR TITLE
Town6: Fixes news not being displayed if it's the first item.

### DIFF
--- a/src/onegov/org/homepage_widgets.py
+++ b/src/onegov/org/homepage_widgets.py
@@ -175,7 +175,7 @@ class NewsWidget:
                 news_index = index
                 break
 
-        if not news_index:
+        if news_index is False:
             return {'news': ()}
 
         # request more than the required amount of news to account for hidden


### PR DESCRIPTION
## Commit message

Town6: Fixes news not being displayed if it's the first item

Fix root-level page interpretation bug for news, 
which was mistakenly being treated as falsy (index 0). 

TYPE: Bugfix
LINK: OGC-863


## Checklist


- [x] I have performed a self-review of my code
- [x] I have tested my code thoroughly by hand

