### PR TITLE
Activate indent check only for form validation but not for viewing th…

### DIFF
--- a/src/onegov/form/parser/core.py
+++ b/src/onegov/form/parser/core.py
@@ -923,12 +923,16 @@ class CheckboxField(OptionsField, Field):
 
 
 @lru_cache(maxsize=1)
-def parse_formcode(formcode):
+def parse_formcode(formcode, enable_indent_check=False):
     """ Takes the given formcode and returns an intermediate representation
     that can be used to generate forms or do other things.
 
+    :param formcode: string representing formcode to be parsed
+    :param enable_indent_check: bool to activate indent check while parsing.
+    Should only be active originating from forms.validators.py
     """
-    parsed = yaml.load('\n'.join(translate_to_yaml(formcode)), CustomLoader)
+    parsed = yaml.load('\n'.join(
+        translate_to_yaml(formcode, enable_indent_check)), CustomLoader)
 
     fieldsets = []
     field_classes = {cls.type: cls for cls in Field.__subclasses__()}
@@ -1077,10 +1081,13 @@ def validate_indent(indent):
     return True
 
 
-def translate_to_yaml(text):
+def translate_to_yaml(text, enable_indent_check=False):
     """ Takes the given form text and constructs an easier to parse yaml
     string.
 
+    :param text: string to be parsed
+    :param enable_indent_check: bool to activate indent check while parsing.
+    Should only be active originating from forms.validators.py
     """
 
     lines = ((ix, l) for ix, l in prepare(text))
@@ -1097,7 +1104,7 @@ def translate_to_yaml(text):
     for ix, line in lines:
 
         indent = ' ' * (4 + (len(line) - len(line.lstrip())))
-        if not validate_indent(indent):
+        if enable_indent_check and not validate_indent(indent):
             raise errors.InvalidIndentSyntax(line=ix + 1)
 
         # the top level are the fieldsets

--- a/src/onegov/form/parser/form.py
+++ b/src/onegov/form/parser/form.py
@@ -41,15 +41,18 @@ MEGABYTE = 1000 ** 2
 DEFAULT_UPLOAD_LIMIT = 15 * MEGABYTE
 
 
-def parse_form(text, base_class=Form):
+def parse_form(text, enable_indent_check=False, base_class=Form):
     """ Takes the given form text, parses it and returns a WTForms form
     class (not an instance of it).
 
+    :type text: string form text to be parsed
+    :param enable_indent_check: bool to activate indent check while parsing.
+    :param base_class: Form base class
     """
 
     builder = WTFormsClassBuilder(base_class)
 
-    for fieldset in parse_formcode(text):
+    for fieldset in parse_formcode(text, enable_indent_check):
         builder.set_current_fieldset(fieldset.label)
 
         for field in fieldset.fields:

--- a/src/onegov/form/validators.py
+++ b/src/onegov/form/validators.py
@@ -168,7 +168,8 @@ class ValidFormDefinition:
             from onegov.form import parse_form
 
             try:
-                parsed_form = parse_form(field.data)()
+                parsed_form = parse_form(field.data,
+                                         enable_indent_check=True)()
             except InvalidFormSyntax as exception:
                 field.render_kw = field.render_kw or {}
                 field.render_kw['data-highlight-line'] = exception.line


### PR DESCRIPTION
Org: Indent check only activated for new and edit forms but not for displaying.

Activate indent check while parsing form code only if originating from core validators which means there is either a new or an edited form code to be parsed. 

TYPE: Bugfix
LINK: ogc-1027

## Checklist

- [x] I made changes/features for both org and town6
- [x] I have performed a self-review of my code
- [x] I have tested my code thoroughly by hand
    - [ ] I have tested styling changes/features on different browsers
    - [ ] I have tested javascript changes/features on different browsers
    - [ ] I have tested database upgrades
    - [ ] I have tested sending mails
    - [ ] I have tested building the documentation
- [ ] I have added tests for my changes/features

- Tests:
    - only affects new or edited form code
    - town6: forms
    - org: tickets for course registration
- Result:
    - Even wrongly indented form code will be parsed and displayed correctly. Once editing user needs to adjust the wrong indents for the old parts of the form code
