### PR TITLE
Feature/ogc 1078 api modified date per item

### DIFF
--- a/src/onegov/agency/api.py
+++ b/src/onegov/agency/api.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from cached_property import cached_property
 from onegov.agency.collections import ExtendedPersonCollection
 from onegov.agency.collections import PaginatedAgencyCollection
@@ -21,7 +23,6 @@ class ApisMixin:
 
 
 class PersonApiEndpoint(ApiEndpoint, ApisMixin):
-
     endpoint = 'people'
     filters = []
 
@@ -62,8 +63,9 @@ class PersonApiEndpoint(ApiEndpoint, ApisMixin):
             if attribute not in self.app.org.hidden_people_fields
         }
 
-        modified = getattr(item, 'modified', '')
-        data['modified'] = modified.isoformat()
+        # modified has priority over created but modified may not set
+        data['modified'] = item.modified.isoformat() if isinstance(
+            item.modified, datetime) else item.created.isoformat()
         return data
 
     def item_links(self, item):
@@ -82,7 +84,6 @@ class PersonApiEndpoint(ApiEndpoint, ApisMixin):
 
 
 class AgencyApiEndpoint(ApiEndpoint, ApisMixin):
-
     endpoint = 'agencies'
     filters = ['parent']
 
@@ -98,12 +99,16 @@ class AgencyApiEndpoint(ApiEndpoint, ApisMixin):
         return result
 
     def item_data(self, item):
+        # modified has priority over created but modified may not set
+        modified = item.modified.isoformat() if isinstance(
+            item.modified, datetime) else item.created.isoformat()
+
         return {
             'title': item.title,
             'portrait': item.portrait,
             'location_address': item.location_address,
             'location_code_city': item.location_code_city,
-            'modified': item.modified.isoformat(),
+            'modified': modified,
             'postal_address': item.postal_address,
             'postal_code_city': item.postal_code_city,
             'website': item.website,
@@ -125,7 +130,6 @@ class AgencyApiEndpoint(ApiEndpoint, ApisMixin):
 
 
 class MembershipApiEndpoint(ApiEndpoint, ApisMixin):
-
     endpoint = 'memberships'
     filters = ['agency', 'person']
 
@@ -143,7 +147,6 @@ class MembershipApiEndpoint(ApiEndpoint, ApisMixin):
     def item_data(self, item):
         return {
             'title': item.title,
-            'modified': item.modified.isoformat(),
         }
 
     def item_links(self, item):

--- a/src/onegov/agency/api.py
+++ b/src/onegov/agency/api.py
@@ -22,6 +22,17 @@ class ApisMixin:
         return MembershipApiEndpoint(self.app)
 
 
+def get_modified_iso_format(item):
+    """
+    Returns the iso format of the modified or created field of item.
+
+    :param item: db item e.g. agency, people, membership
+    :return: str iso representation of item last modification
+    """
+    return item.modified.isoformat() if isinstance(
+        item.modified, datetime) else item.created.isoformat()
+
+
 class PersonApiEndpoint(ApiEndpoint, ApisMixin):
     endpoint = 'people'
     filters = []
@@ -63,9 +74,7 @@ class PersonApiEndpoint(ApiEndpoint, ApisMixin):
             if attribute not in self.app.org.hidden_people_fields
         }
 
-        # modified has priority over created but modified may not set
-        data['modified'] = item.modified.isoformat() if isinstance(
-            item.modified, datetime) else item.created.isoformat()
+        data['modified'] = get_modified_iso_format(item)
         return data
 
     def item_links(self, item):
@@ -99,16 +108,12 @@ class AgencyApiEndpoint(ApiEndpoint, ApisMixin):
         return result
 
     def item_data(self, item):
-        # modified has priority over created but modified may not set
-        modified = item.modified.isoformat() if isinstance(
-            item.modified, datetime) else item.created.isoformat()
-
         return {
             'title': item.title,
             'portrait': item.portrait,
             'location_address': item.location_address,
             'location_code_city': item.location_code_city,
-            'modified': modified,
+            'modified': get_modified_iso_format(item),
             'postal_address': item.postal_address,
             'postal_code_city': item.postal_code_city,
             'website': item.website,
@@ -147,6 +152,7 @@ class MembershipApiEndpoint(ApiEndpoint, ApisMixin):
     def item_data(self, item):
         return {
             'title': item.title,
+            'modified': get_modified_iso_format(item),
         }
 
     def item_links(self, item):

--- a/src/onegov/agency/api.py
+++ b/src/onegov/agency/api.py
@@ -36,7 +36,7 @@ class PersonApiEndpoint(ApiEndpoint, ApisMixin):
         return result
 
     def item_data(self, item):
-        return {
+        data = {
             attribute: getattr(item, attribute, None)
             for attribute in (
                 'academic_title',
@@ -61,6 +61,10 @@ class PersonApiEndpoint(ApiEndpoint, ApisMixin):
             )
             if attribute not in self.app.org.hidden_people_fields
         }
+
+        modified = getattr(item, 'modified', '')
+        data['modified'] = modified.isoformat()
+        return data
 
     def item_links(self, item):
         result = {
@@ -99,6 +103,7 @@ class AgencyApiEndpoint(ApiEndpoint, ApisMixin):
             'portrait': item.portrait,
             'location_address': item.location_address,
             'location_code_city': item.location_code_city,
+            'modified': item.modified.isoformat(),
             'postal_address': item.postal_address,
             'postal_code_city': item.postal_code_city,
             'website': item.website,
@@ -137,7 +142,8 @@ class MembershipApiEndpoint(ApiEndpoint, ApisMixin):
 
     def item_data(self, item):
         return {
-            'title': item.title
+            'title': item.title,
+            'modified': item.modified.isoformat(),
         }
 
     def item_links(self, item):

--- a/tests/onegov/agency/test_api.py
+++ b/tests/onegov/agency/test_api.py
@@ -92,6 +92,7 @@ def test_view_api(client):
         assert not links(hospital)['parent']
         assert not collection(links(hospital)['children']).items
         assert data(collection(links(hospital)['memberships']).items[0]) == {
+            'modified': '2023-05-02T14:05:53.473045+00:00',
             'title': 'Doctor',
         }
 
@@ -115,7 +116,10 @@ def test_view_api(client):
         assert data(collection(links(school)['children'])
                     .items[0])['title'] == 'School Board'
         assert data(collection(links(school)['memberships'])
-                    .items[0]) == {'title': 'Teacher'}
+                    .items[0]) == {
+            'modified': '2023-05-02T14:05:53.473045+00:00',
+            'title': 'Teacher'
+        }
 
         board = collection(agencies['School Board']).items[0]
         assert data(board) == {
@@ -171,6 +175,7 @@ def test_view_api(client):
         assert not links(edna)['picture_url']
         assert not links(edna)['website']
         assert data(collection(links(edna)['memberships']).items[0]) == {
+            'modified': '2023-05-02T14:05:53.473045+00:00',
             'title': 'Teacher',
         }
 
@@ -200,6 +205,7 @@ def test_view_api(client):
         assert not links(nick)['picture_url']
         assert not links(nick)['website']
         assert data(collection(links(nick)['memberships']).items[0]) == {
+            'modified': '2023-05-02T14:05:53.473045+00:00',
             'title': 'Doctor',
         }
 
@@ -211,14 +217,20 @@ def test_view_api(client):
         assert set(memberships) == {'Doctor', 'Teacher'}
 
         doctor = collection(memberships['Doctor']).items[0]
-        assert data(doctor) == {'title': 'Doctor'}
+        assert data(doctor) == {
+            'title': 'Doctor',
+            'modified': '2023-05-02T14:05:53.473045+00:00'
+        }
         assert data(collection(links(doctor)['agency']).items[0])['title'] == \
                'Hospital'
         assert data(collection(links(doctor)['person']).items[0])['title'] == \
                'Rivera Nick'
 
         teacher = collection(memberships['Teacher']).items[0]
-        assert data(teacher) == {'title': 'Teacher'}
+        assert data(teacher) == {
+            'title': 'Teacher',
+            'modified': '2023-05-02T14:05:53.473045+00:00'
+        }
         assert data(collection(links(teacher)['agency'])
                     .items[0])['title'] == 'School'
         assert data(collection(links(teacher)['person'])

--- a/tests/onegov/agency/test_api.py
+++ b/tests/onegov/agency/test_api.py
@@ -1,219 +1,225 @@
 from collection_json import Collection
+from freezegun import freeze_time
 
 
 def test_view_api(client):
-    client.login_admin()  # prevent rate limit
+    with freeze_time('2023-05-02T14:05:53.473045+00:00'):
+        client.login_admin()  # prevent rate limit
 
-    def collection(url):
-        return Collection.from_json(client.get(url).body)
+        def collection(url):
+            return Collection.from_json(client.get(url).body)
 
-    def data(item):
-        return {x.name: x.value for x in item.data}
+        def data(item):
+            return {x.name: x.value for x in item.data}
 
-    def links(item):
-        return {x.rel: x.href for x in item.links}
+        def links(item):
+            return {x.rel: x.href for x in item.links}
 
-    # Endpoints with query hints
-    endpoints = collection('/api')
-    assert endpoints.queries[0].rel == 'agencies'
-    assert endpoints.queries[0].href == 'http://localhost/api/agencies'
-    assert data(endpoints.queries[0]) == {'parent': None}
-    assert endpoints.queries[1].rel == 'people'
-    assert endpoints.queries[1].href == 'http://localhost/api/people'
-    assert data(endpoints.queries[1]) == {}
-    assert endpoints.queries[2].rel == 'memberships'
-    assert endpoints.queries[2].href == 'http://localhost/api/memberships'
-    assert data(endpoints.queries[2]) == {'agency': None, 'person': None}
+        # Endpoints with query hints
+        endpoints = collection('/api')
+        assert endpoints.queries[0].rel == 'agencies'
+        assert endpoints.queries[0].href == 'http://localhost/api/agencies'
+        assert data(endpoints.queries[0]) == {'parent': None}
+        assert endpoints.queries[1].rel == 'people'
+        assert endpoints.queries[1].href == 'http://localhost/api/people'
+        assert data(endpoints.queries[1]) == {}
+        assert endpoints.queries[2].rel == 'memberships'
+        assert endpoints.queries[2].href == 'http://localhost/api/memberships'
+        assert data(endpoints.queries[2]) == {'agency': None, 'person': None}
 
-    # No data yet
-    assert not collection('/api/agencies').items
-    assert not collection('/api/people').items
-    assert not collection('/api/memberships').items
+        # No data yet
+        assert not collection('/api/agencies').items
+        assert not collection('/api/people').items
+        assert not collection('/api/memberships').items
 
-    # Add data
-    page = client.get('/people').click('Person', href='new')
-    page.form['academic_title'] = 'Dr.'
-    page.form['first_name'] = 'Nick'
-    page.form['last_name'] = 'Rivera'
-    page.form.submit().follow()
+        # Add data
+        page = client.get('/people').click('Person', href='new')
+        page.form['academic_title'] = 'Dr.'
+        page.form['first_name'] = 'Nick'
+        page.form['last_name'] = 'Rivera'
+        page.form.submit().follow()
 
-    page = client.get('/organizations').click('Organisation', href='new')
-    page.form['title'] = 'Hospital'
-    page = page.form.submit().follow()
+        page = client.get('/organizations').click('Organisation', href='new')
+        page.form['title'] = 'Hospital'
+        page = page.form.submit().follow()
 
-    page = page.click('Mitgliedschaft', href='new')
-    page.form['title'] = 'Doctor'
-    page.form['person_id'].select(text='Rivera Nick')
-    page.form.submit().follow()
+        page = page.click('Mitgliedschaft', href='new')
+        page.form['title'] = 'Doctor'
+        page.form['person_id'].select(text='Rivera Nick')
+        page.form.submit().follow()
 
-    page = client.get('/people').click('Person', href='new')
-    page.form['first_name'] = 'Edna'
-    page.form['last_name'] = 'Krabappel'
-    page.form.submit().follow()
+        page = client.get('/people').click('Person', href='new')
+        page.form['first_name'] = 'Edna'
+        page.form['last_name'] = 'Krabappel'
+        page.form.submit().follow()
 
-    page = client.get('/organizations').click('Organisation', href='new')
-    page.form['title'] = 'School'
-    agency = page.form.submit().follow()
+        page = client.get('/organizations').click('Organisation', href='new')
+        page.form['title'] = 'School'
+        agency = page.form.submit().follow()
 
-    page = agency.click('Mitgliedschaft', href='new')
-    page.form['title'] = 'Teacher'
-    page.form['person_id'].select(text='Krabappel Edna')
-    page.form.submit().follow()
+        page = agency.click('Mitgliedschaft', href='new')
+        page.form['title'] = 'Teacher'
+        page.form['person_id'].select(text='Krabappel Edna')
+        page.form.submit().follow()
 
-    page = agency.click('Organisation', href='new')
-    page.form['title'] = 'School Board'
-    page.form.submit().follow()
+        page = agency.click('Organisation', href='new')
+        page.form['title'] = 'School Board'
+        page.form.submit().follow()
 
-    # Agencies
-    agencies = {
-        item.data[0].value: item.href
-        for item in collection('/api/agencies').items
-    }
-    assert set(agencies) == {'Hospital', 'School', 'School Board'}
+        # Agencies
+        agencies = {
+            item.data[0].value: item.href
+            for item in collection('/api/agencies').items
+        }
+        assert set(agencies) == {'Hospital', 'School', 'School Board'}
 
-    hospital = collection(agencies['Hospital']).items[0]
-    assert data(hospital) == {
-        'email': '',
-        'location_address': '',
-        'location_code_city': '',
-        'opening_hours': '',
-        'phone': '',
-        'phone_direct': '',
-        'portrait': '',
-        'postal_address': '',
-        'postal_code_city': '',
-        'title': 'Hospital',
-        'website': '',
-    }
-    assert not links(hospital)['organigram']
-    assert not links(hospital)['parent']
-    assert not collection(links(hospital)['children']).items
-    assert data(collection(links(hospital)['memberships']).items[0]) == {
-        'title': 'Doctor'
-    }
+        hospital = collection(agencies['Hospital']).items[0]
+        assert data(hospital) == {
+            'email': '',
+            'location_address': '',
+            'location_code_city': '',
+            'modified': '2023-05-02T14:05:53.473045+00:00',
+            'opening_hours': '',
+            'phone': '',
+            'phone_direct': '',
+            'portrait': '',
+            'postal_address': '',
+            'postal_code_city': '',
+            'title': 'Hospital',
+            'website': '',
+        }
+        assert not links(hospital)['organigram']
+        assert not links(hospital)['parent']
+        assert not collection(links(hospital)['children']).items
+        assert data(collection(links(hospital)['memberships']).items[0]) == {
+            'title': 'Doctor',
+        }
 
-    school = collection(agencies['School']).items[0]
-    assert data(school) == {
-        'email': '',
-        'location_address': '',
-        'location_code_city': '',
-        'opening_hours': '',
-        'phone': '',
-        'phone_direct': '',
-        'portrait': '',
-        'postal_address': '',
-        'postal_code_city': '',
-        'title': 'School',
-        'website': '',
-    }
-    assert not links(school)['organigram']
-    assert not links(school)['parent']
-    assert data(collection(links(school)['children']).items[0])['title'] == \
-        'School Board'
-    assert data(collection(links(school)['memberships']).items[0]) == {
-        'title': 'Teacher'
-    }
+        school = collection(agencies['School']).items[0]
+        assert data(school) == {
+            'email': '',
+            'location_address': '',
+            'location_code_city': '',
+            'modified': '2023-05-02T14:05:53.473045+00:00',
+            'opening_hours': '',
+            'phone': '',
+            'phone_direct': '',
+            'portrait': '',
+            'postal_address': '',
+            'postal_code_city': '',
+            'title': 'School',
+            'website': '',
+        }
+        assert not links(school)['organigram']
+        assert not links(school)['parent']
+        assert data(collection(links(school)['children'])
+                    .items[0])['title'] == 'School Board'
+        assert data(collection(links(school)['memberships'])
+                    .items[0]) == {'title': 'Teacher'}
 
-    board = collection(agencies['School Board']).items[0]
-    assert data(board) == {
-        'email': '',
-        'location_address': '',
-        'location_code_city': '',
-        'opening_hours': '',
-        'phone': '',
-        'phone_direct': '',
-        'portrait': '',
-        'postal_address': '',
-        'postal_code_city': '',
-        'title': 'School Board',
-        'website': '',
-    }
-    assert not links(board)['organigram']
-    assert data(collection(links(board)['parent']).items[0])['title'] == \
-        'School'
-    assert not collection(links(board)['children']).items
-    assert not collection(links(board)['memberships']).items
+        board = collection(agencies['School Board']).items[0]
+        assert data(board) == {
+            'email': '',
+            'location_address': '',
+            'location_code_city': '',
+            'modified': '2023-05-02T14:05:53.473045+00:00',
+            'opening_hours': '',
+            'phone': '',
+            'phone_direct': '',
+            'portrait': '',
+            'postal_address': '',
+            'postal_code_city': '',
+            'title': 'School Board',
+            'website': '',
+        }
+        assert not links(board)['organigram']
+        assert data(collection(links(board)['parent']).items[0])['title'] == \
+               'School'
+        assert not collection(links(board)['children']).items
+        assert not collection(links(board)['memberships']).items
 
-    # People
-    people = {
-        data(item)['title']: item.href
-        for item in collection('/api/people').items
-    }
-    assert set(people) == {'Krabappel Edna', 'Rivera Nick'}
+        # People
+        people = {
+            data(item)['title']: item.href
+            for item in collection('/api/people').items
+        }
+        assert set(people) == {'Krabappel Edna', 'Rivera Nick'}
 
-    edna = collection(people['Krabappel Edna']).items[0]
-    assert data(edna) == {
-        'academic_title': '',
-        'born': '',
-        'email': '',
-        'first_name': 'Edna',
-        'function': '',
-        'last_name': 'Krabappel',
-        'location_address': '',
-        'location_code_city': '',
-        'notes': '',
-        'parliamentary_group': '',
-        'phone': '',
-        'phone_direct': '',
-        'political_party': '',
-        'postal_address': '',
-        'postal_code_city': '',
-        'profession': '',
-        'salutation': '',
-        'title': 'Krabappel Edna',
-        'website': '',
-    }
-    assert not links(edna)['picture_url']
-    assert not links(edna)['website']
-    assert data(collection(links(edna)['memberships']).items[0]) == {
-        'title': 'Teacher'
-    }
+        edna = collection(people['Krabappel Edna']).items[0]
+        assert data(edna) == {
+            'academic_title': '',
+            'born': '',
+            'email': '',
+            'first_name': 'Edna',
+            'function': '',
+            'last_name': 'Krabappel',
+            'location_address': '',
+            'location_code_city': '',
+            'modified': '2023-05-02T14:05:53.473045+00:00',
+            'notes': '',
+            'parliamentary_group': '',
+            'phone': '',
+            'phone_direct': '',
+            'political_party': '',
+            'postal_address': '',
+            'postal_code_city': '',
+            'profession': '',
+            'salutation': '',
+            'title': 'Krabappel Edna',
+            'website': '',
+        }
+        assert not links(edna)['picture_url']
+        assert not links(edna)['website']
+        assert data(collection(links(edna)['memberships']).items[0]) == {
+            'title': 'Teacher',
+        }
 
-    nick = collection(people['Rivera Nick']).items[0]
-    assert data(nick) == {
-        'academic_title': 'Dr.',
-        'location_address': '',
-        'location_code_city': '',
-        'postal_address': '',
-        'postal_code_city': '',
-        'born': '',
-        'email': '',
-        'first_name': 'Nick',
-        'function': '',
-        'last_name': 'Rivera',
-        'notes': '',
-        'parliamentary_group': '',
-        'phone_direct': '',
-        'phone': '',
-        'political_party': '',
-        'profession': '',
-        'salutation': '',
-        'title': 'Rivera Nick',
-        'website': '',
-    }
-    assert not links(nick)['picture_url']
-    assert not links(nick)['website']
-    assert data(collection(links(nick)['memberships']).items[0]) == {
-        'title': 'Doctor'
-    }
+        nick = collection(people['Rivera Nick']).items[0]
+        assert data(nick) == {
+            'academic_title': 'Dr.',
+            'location_address': '',
+            'location_code_city': '',
+            'postal_address': '',
+            'postal_code_city': '',
+            'born': '',
+            'email': '',
+            'first_name': 'Nick',
+            'function': '',
+            'last_name': 'Rivera',
+            'modified': '2023-05-02T14:05:53.473045+00:00',
+            'notes': '',
+            'parliamentary_group': '',
+            'phone_direct': '',
+            'phone': '',
+            'political_party': '',
+            'profession': '',
+            'salutation': '',
+            'title': 'Rivera Nick',
+            'website': '',
+        }
+        assert not links(nick)['picture_url']
+        assert not links(nick)['website']
+        assert data(collection(links(nick)['memberships']).items[0]) == {
+            'title': 'Doctor',
+        }
 
-    # Memberships
-    memberships = {
-        item.data[0].value: item.href
-        for item in collection('/api/memberships').items
-    }
-    assert set(memberships) == {'Doctor', 'Teacher'}
+        # Memberships
+        memberships = {
+            item.data[0].value: item.href
+            for item in collection('/api/memberships').items
+        }
+        assert set(memberships) == {'Doctor', 'Teacher'}
 
-    doctor = collection(memberships['Doctor']).items[0]
-    assert data(doctor) == {'title': 'Doctor'}
-    assert data(collection(links(doctor)['agency']).items[0])['title'] == \
-        'Hospital'
-    assert data(collection(links(doctor)['person']).items[0])['title'] == \
-        'Rivera Nick'
+        doctor = collection(memberships['Doctor']).items[0]
+        assert data(doctor) == {'title': 'Doctor'}
+        assert data(collection(links(doctor)['agency']).items[0])['title'] == \
+               'Hospital'
+        assert data(collection(links(doctor)['person']).items[0])['title'] == \
+               'Rivera Nick'
 
-    teacher = collection(memberships['Teacher']).items[0]
-    assert data(teacher) == {'title': 'Teacher'}
-    assert data(collection(links(teacher)['agency']).items[0])['title'] == \
-        'School'
-    assert data(collection(links(teacher)['person']).items[0])['title'] == \
-        'Krabappel Edna'
+        teacher = collection(memberships['Teacher']).items[0]
+        assert data(teacher) == {'title': 'Teacher'}
+        assert data(collection(links(teacher)['agency'])
+                    .items[0])['title'] == 'School'
+        assert data(collection(links(teacher)['person'])
+                    .items[0])['title'] == 'Krabappel Edna'


### PR DESCRIPTION
API: Every items of an API answer has now a 'modified' field

The modified field represents the last modification or creation timestamp in iso format of the corresponding item.

TYPE: Feature
LINK: ogc-1078

Hint for testing
http://localhost:8080/onegov_agency/bs/api/
                                                                   ../people
                                                                   ../agencies
                                                                   ../memberships


