### PR TITLE
Move tests to GitHub Actions

### DIFF
--- a/.buildkite/generic-pipeline.yml
+++ b/.buildkite/generic-pipeline.yml
@@ -11,18 +11,6 @@ steps:
     env:
       CONTAINER: "onegov-cloud:head"
 
-  # check linting
-  - command: "test-container"
-    label: "Linting"
-
-    agents:
-      - queue=generic
-      - ram=2048
-
-    env:
-      CONTAINER: "onegov-cloud:head"
-      CONTAINER_TEST_SCRIPT: ".buildkite/lint"
-
   # run the javascript tests
   - command: "test-container"
     label: "Jesting"

--- a/.buildkite/generic-pipeline.yml
+++ b/.buildkite/generic-pipeline.yml
@@ -36,21 +36,6 @@ steps:
       CONTAINER: "onegov-cloud:head"
       CONTAINER_TEST_SCRIPT: ".buildkite/jest"
 
-  # run the python tests
-  - command: "test-container"
-    label: "Testing"
-
-    parallelism: 4
-
-    agents:
-      - queue=generic
-      - cpu=2
-      - ram=4096
-
-    env:
-      CONTAINER: "onegov-cloud:head"
-      CONTAINER_TEST_SCRIPT: ".buildkite/test"
-
   # build the docs if possible (fails are ignored, only on master)
   - command: "test-container"
     label: "Publishing docs"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -113,7 +113,7 @@ jobs:
       env:
         MATRIX_GROUP: ${{matrix.group}}
       run: |
-        export BUILDKITE_PARALLEL_JOB="$(($MATRIX_GROUP-1))""
+        export BUILDKITE_PARALLEL_JOB="$(($MATRIX_GROUP-1))"
         export BUILDKITE_PARALLEL_JOB_COUNT="6"
         export BUILDKITE_COMMIT="$GITHUB_SHA"
         export CODECOV_ONEGOV_TOKEN="${{ secrets.CODECOV_TOKEN }}"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Install dependencies
       run: |
         apt update
-        apt install \
+        apt install -y --no-install-recommends \
           build-essential \
           git \
           gcc \

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -81,17 +81,8 @@ jobs:
           libxcb-dri3-0 \
           libxshmfence1 \
           libxss1 \
-          xdg-utils \
-          --fix-missing
+          xdg-utils
 
-        wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
-        dpkg -i google-chrome-stable_current_amd64.deb
-
-        export JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64"
-        export LC_ALL="C.UTF-8"
-        export LANG="C.UTF-8"
-
-        redis-server --daemonize yes
         # HACK: our test script tries to remove this
         touch /etc/apt/preferences
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,3 +2,56 @@ name: Tests
 
 on:
   workflow_dispatch:  # allow to run manually
+  push:
+  pull_request:
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        group: [1, 2, 3, 4, 5, 6]
+
+    runs_on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
+    name: Test group ${{ matrix.group }}
+
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v3
+
+    - name: Get branch name (merge)
+      if: github.event_name != 'pull_request'
+      shell: bash
+      run: |
+        echo "CODECOV_BRANCH=$(echo ${GITHUB_REF#refs/heads/} | tr / -)" \
+             >> $GITHUB_ENV
+
+    - name: Get branch name (pull request)
+      if: github.event_name == 'pull_request'
+      shell: bash
+      run: |
+        echo "CODECOV_BRANCH=$(echo ${GITHUB_HEAD_REF} | tr / -)" \
+             >> $GITHUB_ENV
+
+    - name: Install docker
+      run: sudo apt-get install docker
+
+    - name: Create container onegov-cloud:head
+      run: |
+        docker pull eu.gcr.io/seantis-containers/onegov-cloud:head
+        docker create --rm --i --name test \
+          --env BUILDKITE_PARALLEL_JOB="${{ matrix.group - 1 }}" \
+          --env BUILDKITE_PARALLEL_JOB_COUNT="6" \
+          --env BUILDKITE_COMMIT="$GITHUB_SHA" \
+          --env BUILDKITE_BRANCH="$CODECOV_BRANCH" \
+          --env CONTAINER_TEST_ARG="" \
+          --env CODECOV_ONEGOV_TOKEN="${{ secrets.CODECOV_TOKEN }}" \
+          --volume "$PWD":/src \
+          --workdir /src \
+          "eu.gcr.io/seantis-containers/onegov-cloud:head" \
+          /bin/bash ".buildkite/test" > /dev/null
+
+    - name: Run tests
+      run: docker start --interactive --attach test
+

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,8 +30,9 @@ jobs:
     # FIXME: this will not be necessary anymore once can use onegov-cloud:head
     - name: Install dependencies
       run: |
+        echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
         apt update
-        apt install -y --no-install-recommends \
+        apt install -y -q --no-install-recommends \
           build-essential \
           git \
           gcc \

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -115,7 +115,7 @@ jobs:
       # FIXME: Remove the functions once we switch to onegov-cloud:head
       run: |
         install-packages() { apt install -y -q --no-install-recommends $@; }
-        run-as() { usr="$(echo $1 | cut -d ':' -f 2)"; shift; IFS=" " su $usr -c "$*"; }
+        run-as() { shift; exec "$@"; }
         export -f install-packages
         export -f run-as
         export BUILDKITE_PARALLEL_JOB="$(($MATRIX_GROUP-1))"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
       image: eu.gcr.io/seantis-containers/onegov-cloud:head
       volumes:
         - src:/src
-      workdir: /src
+      options: --workdir /src
 
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     name: Test group ${{ matrix.group }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,107 @@ on:
   pull_request:
 
 jobs:
+
+  lint:
+    strategy:
+      fail-fast: false
+
+    runs-on: ubuntu-latest
+
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
+    name: Lint
+
+    steps:
+    - name: Install packages
+      run: |
+        sudo apt update
+        sudo apt install \
+          build-essential \
+          git \
+          gcc \
+          g++ \
+          libcurl4-openssl-dev \
+          libffi-dev \
+          libjpeg-dev \
+          libpq-dev \
+          libxml2-dev \
+          libxslt1-dev \
+          zlib1g-dev \
+          libev-dev \
+          libgnutls28-dev \
+          libkrb5-dev \
+          libpoppler-cpp-dev \
+          pv \
+          libzbar0 \
+          openssl \
+          libssl-dev \
+          xmlsec1 \
+          libxmlsec1-openssl \
+          ghostscript \
+          zip \
+          libev4 \
+          libmagic1 \
+          wget \
+          apparmor \
+          curl \
+          git-core \
+          postgresql \
+          redis \
+          openjdk-8-jre-headless \
+          gcc \
+          libc-dev \
+          fonts-liberation \
+          libappindicator3-1 \
+          libasound2 \
+          libdrm2 \
+          libgbm1 \
+          libnspr4 \
+          libnss3 \
+          libu2f-udev \
+          libvulkan1 \
+          libx11-xcb1 \
+          libxcb-dri3-0 \
+          libxshmfence1 \
+          libxss1 \
+          xdg-utils \
+          --fix-missing
+
+    - name: Checkout repo
+      uses: actions/checkout@v3
+
+    - name: Get branch name (merge)
+      if: github.event_name != 'pull_request'
+      shell: bash
+      run: |
+        echo "BUILDKITE_BRANCH=$(echo ${GITHUB_REF#refs/heads/} | tr / -)" \
+             >> $GITHUB_ENV
+
+    - name: Get branch name (pull request)
+      if: github.event_name == 'pull_request'
+      shell: bash
+      run: |
+        echo "BUILDKITE_BRANCH=$(echo ${GITHUB_HEAD_REF} | tr / -)" \
+             >> $GITHUB_ENV
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install .[mypy] flake8 flake8-bugbear flake8-pyi bandit[toml]
+
+    - name: Linting
+      run: flake8 src/ tests/ stubs/
+
+    - name: Check security issues
+      run: bandit --recursive --configfile pyproject.toml src/
+
+    - name: Static type checking
+       run: mypy -p onegov
+
   test:
     strategy:
       fail-fast: false
@@ -106,7 +207,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install .[test] pytest-split
+        pip install .[test] pytest-split pytest-cov pytest-codecov
 
     - name: Run tests
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -115,7 +115,7 @@ jobs:
       # FIXME: Remove the functions once we switch to onegov-cloud:head
       run: |
         install-packages() { apt install -y -q --no-install-recommends $@; }
-        run-as() { identity="$1"; shift; su $identiy -c "$@"; }
+        run-as() { identity="$1"; shift; su $identity -c "$@"; }
         export -f install-packages
         export -f run-as
         export BUILDKITE_PARALLEL_JOB="$(($MATRIX_GROUP-1))"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,8 +31,9 @@ jobs:
     - name: Install dependencies
       run: |
         echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
+        alias install-packages='apt install -y -q --no-install-recommends'
         apt update
-        apt install -y -q --no-install-recommends \
+        install-packages \
           build-essential \
           git \
           gcc \

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -220,6 +220,6 @@ jobs:
           --codecov-branch="$BUILDKITE_BRANCH" \
           --codecov-commit="$GITHUB_SHA" \
           --codecov-slug=OneGov/onegov-cloud \
-          --codecov-token="${{ secrets.CODECOV_TOKEN }}"
+          --codecov-token="${{ secrets.CODECOV_TOKEN }}" \
           tests
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -115,7 +115,7 @@ jobs:
       # FIXME: Remove the functions once we switch to onegov-cloud:head
       run: |
         install-packages() { apt install -y -q --no-install-recommends $@; }
-        run-as() { uid="$(echo $1 | -d ':' -f 2)"; shift; su-exec "$uid:$uid" "$@"; }
+        run-as() { uid="$(echo $1 | cut -d ':' -f 1)"; shift; su-exec "$uid:$uid" "$@"; }
         export -f install-packages
         export -f run-as
         export BUILDKITE_PARALLEL_JOB="$(($MATRIX_GROUP-1))"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,6 +13,11 @@ jobs:
         group: [1, 2, 3, 4, 5, 6]
 
     runs-on: ubuntu-latest
+    container:
+      image: eu.gcr.io/seantis-containers/onegov-cloud:head
+      volume: src:/src
+      workdir: /src
+
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     name: Test group ${{ matrix.group }}
 
@@ -24,36 +29,24 @@ jobs:
       if: github.event_name != 'pull_request'
       shell: bash
       run: |
-        echo "CODECOV_BRANCH=$(echo ${GITHUB_REF#refs/heads/} | tr / -)" \
+        echo "BUILDKITE_BRANCH=$(echo ${GITHUB_REF#refs/heads/} | tr / -)" \
              >> $GITHUB_ENV
 
     - name: Get branch name (pull request)
       if: github.event_name == 'pull_request'
       shell: bash
       run: |
-        echo "CODECOV_BRANCH=$(echo ${GITHUB_HEAD_REF} | tr / -)" \
+        echo "BUILDKITE_BRANCH=$(echo ${GITHUB_HEAD_REF} | tr / -)" \
              >> $GITHUB_ENV
 
-    - name: Install docker
-      run: sudo apt-get install docker
-
-    - name: Create container onegov-cloud:head
+    - name: Run tests
       env:
         MATRIX_GROUP: ${{matrix.group}}
       run: |
-        docker pull eu.gcr.io/seantis-containers/onegov-cloud:head
-        docker create --rm --i --name test \
-          --env BUILDKITE_PARALLEL_JOB="$(($MATRIX_GROUP-1))" \
-          --env BUILDKITE_PARALLEL_JOB_COUNT="6" \
-          --env BUILDKITE_COMMIT="$GITHUB_SHA" \
-          --env BUILDKITE_BRANCH="$CODECOV_BRANCH" \
-          --env CONTAINER_TEST_ARG="" \
-          --env CODECOV_ONEGOV_TOKEN="${{ secrets.CODECOV_TOKEN }}" \
-          --volume "$PWD":/src \
-          --workdir /src \
-          "eu.gcr.io/seantis-containers/onegov-cloud:head" \
-          /bin/bash ".buildkite/test" > /dev/null
-
-    - name: Run tests
-      run: docker start --interactive --attach test
+        export BUILDKITE_PARALLEL_JOB="$(($MATRIX_GROUP-1))""
+        export BUILDKITE_PARALLEL_JOB_COUNT="6"
+        export BUILDKITE_COMMIT="$GITHUB_SHA"
+        export CODECOV_ONEGOV_TOKEN="${{ secrets.CODECOV_TOKEN }}"
+        export CONTAINER_TEST_ARG=""
+        ./.buildkite/test
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -115,7 +115,7 @@ jobs:
       # FIXME: Remove the functions once we switch to onegov-cloud:head
       run: |
         install-packages() { apt install -y -q --no-install-recommends $@; }
-        run-as() { identity="$1"; shift; su $identity -c "$@"; }
+        run-as() { uid="$(echo $1 | -d ':' -f 2)"; shift; su-exec "$uid:$uid" "$@"; }
         export -f install-packages
         export -f run-as
         export BUILDKITE_PARALLEL_JOB="$(($MATRIX_GROUP-1))"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,18 +14,83 @@ jobs:
 
     runs-on: ubuntu-latest
     container:
-      image: eu.gcr.io/seantis-containers/onegov-cloud:head
-      credentials:
-        username: ${{ secrets.GCR_USERNAME }}
-        password: ${{ secrets.GCR_PASSWORD }}
+      # FIXME: Switch to onegov-cloud:head
+      image: ubuntu:22.04
       volumes:
-        - src:/src
-      options: --workdir /src
+        - ${{ github.workspace }}:/src
+
+    defaults:
+      run:
+        working-directory: /src
 
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     name: Test group ${{ matrix.group }}
 
     steps:
+    # FIXME: this will not be necessary anymore once can use onegov-cloud:head
+    - name: Install dependencies
+      run: |
+        sudo apt update
+        sudo apt install \
+          build-essential \
+          git \
+          gcc \
+          g++ \
+          libcurl4-openssl-dev \
+          libffi-dev \
+          libjpeg-dev \
+          libpq-dev \
+          libxml2-dev \
+          libxslt1-dev \
+          zlib1g-dev \
+          libev-dev \
+          libgnutls28-dev \
+          libkrb5-dev \
+          libpoppler-cpp-dev \
+          pv \
+          libzbar0 \
+          openssl \
+          libssl-dev \
+          xmlsec1 \
+          libxmlsec1-openssl \
+          ghostscript \
+          zip \
+          libev4 \
+          libmagic1 \
+          wget \
+          apparmor \
+          curl \
+          git-core \
+          postgresql \
+          redis \
+          openjdk-8-jre-headless \
+          gcc \
+          libc-dev \
+          fonts-liberation \
+          libappindicator3-1 \
+          libasound2 \
+          libdrm2 \
+          libgbm1 \
+          libnspr4 \
+          libnss3 \
+          libu2f-udev \
+          libvulkan1 \
+          libx11-xcb1 \
+          libxcb-dri3-0 \
+          libxshmfence1 \
+          libxss1 \
+          xdg-utils \
+          --fix-missing
+
+        wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+        sudo dpkg -i google-chrome-stable_current_amd64.deb
+
+        export JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64"
+        export LC_ALL="C.UTF-8"
+        export LANG="C.UTF-8"
+
+        redis-server --daemonize yes
+
     - name: Checkout repo
       uses: actions/checkout@v3
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -108,7 +108,7 @@ jobs:
       shell: bash
       # FIXME: Remove the function once we switch to onegov-cloud:head
       run: |
-        install-packages() {apt install -y -q --no-install-recommends $@}
+        install-packages() { apt install -y -q --no-install-recommends $@ }
         export -f install-packages
         export BUILDKITE_PARALLEL_JOB="$(($MATRIX_GROUP-1))"
         export BUILDKITE_PARALLEL_JOB_COUNT="6"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,6 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: eu.gcr.io/seantis-containers/onegov-cloud:head
+      credentials:
+        username: ${{ secrets.GCR_USERNAME }}
+        password: ${{ secrets.GCR_PASSWORD }}
       volumes:
         - src:/src
       options: --workdir /src

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,8 +30,8 @@ jobs:
     # FIXME: this will not be necessary anymore once can use onegov-cloud:head
     - name: Install dependencies
       run: |
-        sudo apt update
-        sudo apt install \
+        apt update
+        apt install \
           build-essential \
           git \
           gcc \
@@ -83,7 +83,7 @@ jobs:
           --fix-missing
 
         wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
-        sudo dpkg -i google-chrome-stable_current_amd64.deb
+        dpkg -i google-chrome-stable_current_amd64.deb
 
         export JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64"
         export LC_ALL="C.UTF-8"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -108,7 +108,7 @@ jobs:
       shell: bash
       # FIXME: Remove the function once we switch to onegov-cloud:head
       run: |
-        install-packages() { apt install -y -q --no-install-recommends $@ }
+        install-packages() { apt install -y -q --no-install-recommends $@; }
         export -f install-packages
         export BUILDKITE_PARALLEL_JOB="$(($MATRIX_GROUP-1))"
         export BUILDKITE_PARALLEL_JOB_COUNT="6"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -91,6 +91,8 @@ jobs:
         export LANG="C.UTF-8"
 
         redis-server --daemonize yes
+        # HACK: our test script tries to remove this
+        touch /etc/apt/preferences
 
     - name: Checkout repo
       uses: actions/checkout@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         group: [1, 2, 3, 4, 5, 6]
 
-    runs_on: ubuntu-latest
+    runs-on: ubuntu-latest
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     name: Test group ${{ matrix.group }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -207,7 +207,9 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install .[test] pytest-split pytest-cov pytest-codecov
+        pip install pytest-split pytest-cov pytest-codecov
+        # TEMPORARY: editable build so we don't need a path-fix in codecov
+        pip install -e .[test]
 
     - name: Run tests
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -115,7 +115,7 @@ jobs:
       # FIXME: Remove the functions once we switch to onegov-cloud:head
       run: |
         install-packages() { apt install -y -q --no-install-recommends $@; }
-        run-as() { shift; exec "$@"; }
+        run-as() { su "$(echo $1 | cut -d ':' -f 2)"; cd /src; source /app/bin/activate; shift; exec "$@"; exit; }
         export -f install-packages
         export -f run-as
         export BUILDKITE_PARALLEL_JOB="$(($MATRIX_GROUP-1))"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,9 +31,8 @@ jobs:
     - name: Install dependencies
       run: |
         echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
-        alias install-packages='apt install -y -q --no-install-recommends'
         apt update
-        install-packages \
+        apt install -y -q --no-install-recommends \
           build-essential \
           git \
           gcc \
@@ -106,7 +105,10 @@ jobs:
     - name: Run tests
       env:
         MATRIX_GROUP: ${{matrix.group}}
+      # FIXME: Remove the function once we switch to onegov-cloud:head
       run: |
+        install-packages() {apt install -y -q --no-install-recommends $@}
+        export -f install-packages
         export BUILDKITE_PARALLEL_JOB="$(($MATRIX_GROUP-1))"
         export BUILDKITE_PARALLEL_JOB_COUNT="6"
         export BUILDKITE_COMMIT="$GITHUB_SHA"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -80,10 +80,16 @@ jobs:
           libxcb-dri3-0 \
           libxshmfence1 \
           libxss1 \
-          xdg-utils
+          xdg-utils \
+          python3.10 \
+          python3.10-dev \
+          python3.10-venv \
 
-        # HACK: our test script tries to remove this
+        # HACK: setup some of the environment that would be present
+        #       on onegov-cloud:head
         touch /etc/apt/preferences
+        mkdir /app
+        python3.10 -m venv /app
 
     - name: Checkout repo
       uses: actions/checkout@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: eu.gcr.io/seantis-containers/onegov-cloud:head
-      volume: src:/src
+      volumes:
+        - src:/src
       workdir: /src
 
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -112,10 +112,12 @@ jobs:
       env:
         MATRIX_GROUP: ${{matrix.group}}
       shell: bash
-      # FIXME: Remove the function once we switch to onegov-cloud:head
+      # FIXME: Remove the functions once we switch to onegov-cloud:head
       run: |
         install-packages() { apt install -y -q --no-install-recommends $@; }
+        run-as() { identity="$1"; shift; su $identiy -c "$@"; }
         export -f install-packages
+        export -f run-as
         export BUILDKITE_PARALLEL_JOB="$(($MATRIX_GROUP-1))"
         export BUILDKITE_PARALLEL_JOB_COUNT="6"
         export BUILDKITE_COMMIT="$GITHUB_SHA"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,10 +38,12 @@ jobs:
       run: sudo apt-get install docker
 
     - name: Create container onegov-cloud:head
+      env:
+        MATRIX_GROUP: ${{matrix.group}}
       run: |
         docker pull eu.gcr.io/seantis-containers/onegov-cloud:head
         docker create --rm --i --name test \
-          --env BUILDKITE_PARALLEL_JOB="${{ matrix.group - 1 }}" \
+          --env BUILDKITE_PARALLEL_JOB="$(($MATRIX_GROUP-1))" \
           --env BUILDKITE_PARALLEL_JOB_COUNT="6" \
           --env BUILDKITE_COMMIT="$GITHUB_SHA" \
           --env BUILDKITE_BRANCH="$CODECOV_BRANCH" \

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -105,6 +105,7 @@ jobs:
     - name: Run tests
       env:
         MATRIX_GROUP: ${{matrix.group}}
+      shell: bash
       # FIXME: Remove the function once we switch to onegov-cloud:head
       run: |
         install-packages() {apt install -y -q --no-install-recommends $@}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,26 +13,15 @@ jobs:
         group: [1, 2, 3, 4, 5, 6]
 
     runs-on: ubuntu-latest
-    container:
-      # FIXME: Switch to onegov-cloud:head
-      image: ubuntu:22.04
-      volumes:
-        - ${{ github.workspace }}:/src
-
-    defaults:
-      run:
-        working-directory: /src
 
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     name: Test group ${{ matrix.group }}
 
     steps:
-    # FIXME: this will not be necessary anymore once can use onegov-cloud:head
-    - name: Install dependencies
+    - name: Install packages
       run: |
-        echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
-        apt update
-        apt install -y -q --no-install-recommends \
+        sudo apt update
+        sudo apt install \
           build-essential \
           git \
           gcc \
@@ -81,15 +70,16 @@ jobs:
           libxshmfence1 \
           libxss1 \
           xdg-utils \
-          python3.10 \
-          python3.10-dev \
-          python3.10-venv \
+          --fix-missing
 
-        # HACK: setup some of the environment that would be present
-        #       on onegov-cloud:head
-        touch /etc/apt/preferences
-        mkdir /app
-        python3.10 -m venv /app
+        wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+        sudo dpkg -i google-chrome-stable_current_amd64.deb
+
+        export JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64"
+        export LC_ALL="C.UTF-8"
+        export LANG="C.UTF-8"
+
+        redis-server --daemonize yes
 
     - name: Checkout repo
       uses: actions/checkout@v3
@@ -108,20 +98,27 @@ jobs:
         echo "BUILDKITE_BRANCH=$(echo ${GITHUB_HEAD_REF} | tr / -)" \
              >> $GITHUB_ENV
 
-    - name: Run tests
-      env:
-        MATRIX_GROUP: ${{matrix.group}}
-      shell: bash
-      # FIXME: Remove the functions once we switch to onegov-cloud:head
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
+
+    - name: Install dependencies
       run: |
-        install-packages() { apt install -y -q --no-install-recommends $@; }
-        run-as() { su "$(echo $1 | cut -d ':' -f 2)"; cd /src; source /app/bin/activate; shift; exec "$@"; exit; }
-        export -f install-packages
-        export -f run-as
-        export BUILDKITE_PARALLEL_JOB="$(($MATRIX_GROUP-1))"
-        export BUILDKITE_PARALLEL_JOB_COUNT="6"
-        export BUILDKITE_COMMIT="$GITHUB_SHA"
-        export CODECOV_ONEGOV_TOKEN="${{ secrets.CODECOV_TOKEN }}"
-        export CONTAINER_TEST_ARG=""
-        ./.buildkite/test
+        python -m pip install --upgrade pip
+        pip install .[test] pytest-split
+
+    - name: Run tests
+      run: |
+        py.test \
+          --splits "6" \
+          --group "${{matrix.group}}" \
+          --cov \
+          --cov-config=pyproject.toml \
+          --codecov \
+          --codecov-branch="$BUILDKITE_BRANCH" \
+          --codecov-commit="$GITHUB_SHA" \
+          --codecov-slug=OneGov/onegov-cloud \
+          --codecov-token="${{ secrets.CODECOV_TOKEN }}"
+          tests
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -115,7 +115,7 @@ jobs:
       # FIXME: Remove the functions once we switch to onegov-cloud:head
       run: |
         install-packages() { apt install -y -q --no-install-recommends $@; }
-        run-as() { uid="$(echo $1 | cut -d ':' -f 1)"; shift; su-exec "$uid:$uid" "$@"; }
+        run-as() { usr="$(echo $1 | cut -d ':' -f 2)"; shift; IFS=" " su $usr -c "$*"; }
         export -f install-packages
         export -f run-as
         export BUILDKITE_PARALLEL_JOB="$(($MATRIX_GROUP-1))"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -105,7 +105,7 @@ jobs:
       run: bandit --recursive --configfile pyproject.toml src/
 
     - name: Static type checking
-       run: mypy -p onegov
+      run: mypy -p onegov
 
   test:
     strategy:


### PR DESCRIPTION
The general test and lint workflows will be run on GitHub Actions now for normal commits.

Release and commits containing `[test-container]` will still be tested on Buildkite, otherwise
Buildkite will only build the container and publish the docs (on the master branch).

Jest has also not been migrated to GitHub Actions yet.
