### PR TITLE
Revert adding try/catch block but handle event with no end +L349. Add…

### DIFF
--- a/src/onegov/event/cli.py
+++ b/src/onegov/event/cli.py
@@ -297,13 +297,18 @@ def import_json(group_context, url, tagmap, clear):
 @cli.command('import-ical')
 @pass_group_context
 @click.argument('ical', type=click.File())
+@click.option('--future-events-only', is_flag=True, default=False)
 @click.option('--event-image', type=click.File('rb'))
-def import_ical(group_context, ical, event_image=None):
+def import_ical(group_context, ical, future_events_only=False,
+                event_image=None):
     """ Imports events from an iCalendar file.
 
     Example:
 
         onegov-event --select '/veranstaltungen/zug' import-ical import.ics
+
+        onegov-event --select '/veranstaltungen/zug' import-ical import.ics
+        --future-events-only
 
         onegov-event --select '/veranstaltungen/zug' import-ical import.ics
         --event-image /path/to/image.jpg
@@ -312,7 +317,8 @@ def import_ical(group_context, ical, event_image=None):
 
     def _import_ical(request, app):
         collection = EventCollection(app.session())
-        added, updated, purged = collection.from_ical(ical.read(), event_image)
+        added, updated, purged = \
+            collection.from_ical(ical.read(), future_events_only, event_image)
         click.secho(
             f"Events successfully imported "
             f"({len(added)} added, {len(updated)} updated, "

--- a/src/onegov/event/collections/events.py
+++ b/src/onegov/event/collections/events.py
@@ -147,7 +147,8 @@ class EventCollection(Pagination):
         return query.first()
 
     def from_import(self, items, purge=None, publish_immediately=True,
-                    valid_state_transfers=None, published_only=False):
+                    valid_state_transfers=None, published_only=False,
+                    future_events_only=False):
         """ Add or updates the given events.
 
         Only updates events which have changed. Uses ``Event.source_updated``
@@ -167,7 +168,7 @@ class EventCollection(Pagination):
         :param publish_immediately:
             Set newly added events to published, else let them be initiated.
 
-        :param allowed_state_transfers:
+        :param valid_state_transfers:
             Dict of existing : remote state should be considered when updating.
 
             Example:
@@ -186,6 +187,8 @@ class EventCollection(Pagination):
             Do not import unpublished events. Still do not ignore state
             like withdrawn.
 
+        :param future_events_only:
+            If set only events in the future will be imported
         """
 
         if purge:
@@ -202,9 +205,10 @@ class EventCollection(Pagination):
                 purge = {x for x in purge if not x.startswith(item)}
                 continue
 
-            # skip importing past events
-            if datetime.fromisoformat(str(item.event.end)) < datetime.now(
-                    timezone.utc):
+            # skip past events if option is set
+            if future_events_only and \
+                    datetime.fromisoformat(str(item.event.end)) < \
+                    datetime.now(timezone.utc):
                 continue
 
             event = item.event
@@ -298,100 +302,106 @@ class EventCollection(Pagination):
 
         return added, updated, purged_event_ids
 
-    def from_ical(self, ical, event_image_path=None):
+    def from_ical(self, ical, future_events_only=False, event_image_path=None):
         """ Imports the events from an iCalender string.
 
         We assume the timezone to be Europe/Zurich!
+        :type future_events_only: str
+        :param ical: ical to be imported
+        :param future_events_only: if set only events in the future will be
+        imported
+        :type future_events_only: bool
+        :param event_image_path: path and filename to image
+        :type event_image_path: str
 
         """
         items = []
 
         cal = vCalendar.from_ical(ical)
         for vevent in cal.walk('vevent'):
-            try:
-                timezone = 'Europe/Zurich'
-                start = vevent.get('dtstart')
-                start = start.dt if start else None
-                if type(start) is date:
-                    start = replace_timezone(as_datetime(start), timezone)
-                elif type(start) is datetime:
-                    if start.tzinfo is None:
-                        start = standardize_date(start, timezone)
-                    else:
-                        start = to_timezone(start, UTC)
+            timezone = 'Europe/Zurich'
+            start = vevent.get('dtstart')
+            start = start.dt if start else None
+            if type(start) is date:
+                start = replace_timezone(as_datetime(start), timezone)
+            elif type(start) is datetime:
+                if start.tzinfo is None:
+                    start = standardize_date(start, timezone)
+                else:
+                    start = to_timezone(start, UTC)
 
-                end = vevent.get('dtend')
-                end = end.dt if end else None
-                if type(end) is date:
-                    end = replace_timezone(as_datetime(end), timezone)
-                    end = end + timedelta(days=1, minutes=-1)
-                elif type(end) is datetime:
-                    if end.tzinfo is None:
-                        end = standardize_date(end, timezone)
-                    else:
-                        end = to_timezone(end, UTC)
+            end = vevent.get('dtend')
+            end = end.dt if end else None
+            if type(end) is date:
+                end = replace_timezone(as_datetime(end), timezone)
+                end = end + timedelta(days=1, minutes=-1)
+            elif type(end) is datetime:
+                if end.tzinfo is None:
+                    end = standardize_date(end, timezone)
+                else:
+                    end = to_timezone(end, UTC)
 
-                duration = vevent.get('duration')
-                duration = duration.dt if duration else None
-                if start and not end and duration:
-                    end = start + duration
+            duration = vevent.get('duration')
+            duration = duration.dt if duration else None
+            if start and not end and duration:
+                end = start + duration
 
-                if not start or not end:
-                    raise (ValueError("Invalid date"))
+            if start and not end:
+                # assume event duration is 1 hour
+                end = start + timedelta(hours=1)
 
-                recurrence = vevent.get('rrule', '')
-                if recurrence:
-                    recurrence = 'RRULE:{}'.format(recurrence.to_ical().
-                                                   decode())
+            if not start or not end:
+                raise (ValueError("Invalid date"))
 
-                coordinates = vevent.get('geo')
-                if coordinates:
-                    coordinates = Coordinates(
-                        coordinates.latitude, coordinates.longitude
-                    )
+            recurrence = vevent.get('rrule', '')
+            if recurrence:
+                recurrence = 'RRULE:{}'.format(recurrence.to_ical().
+                                               decode())
 
-                tags = vevent.get('categories')
-                if tags:
-                    # categories may be in lists or they may be single values
-                    # whose 'cats' member contains the texts
-                    if not hasattr(tags, '__iter__'):
-                        tags = [tags]
-
-                    tags = [str(c) for tag in tags for c in tag.cats]
-
-                uid = str(vevent.get('uid', ''))
-                title = str(vevent.get('summary', ''))
-                description = str(vevent.get('description', ''))
-                organizer = str(vevent.get('organizer', ''))
-                location = str(vevent.get('location', ''))
-
-                items.append(
-                    EventImportItem(
-                        event=Event(
-                            state='initiated',
-                            title=title,
-                            start=start,
-                            end=end,
-                            timezone=timezone,
-                            recurrence=recurrence,
-                            description=description,
-                            organizer=organizer,
-                            location=location,
-                            coordinates=coordinates,
-                            tags=tags or [],
-                            source=f'ical-{uid}',
-                        ),
-                        image=event_image_path,
-                        image_filename=event_image_path.name if
-                        event_image_path else None,
-                        pdf=None,
-                        pdf_filename=None,
-                    )
+            coordinates = vevent.get('geo')
+            if coordinates:
+                coordinates = Coordinates(
+                    coordinates.latitude, coordinates.longitude
                 )
-            except Exception as ex:
-                print(f'Error \'{ex}\' importing from ical: Event \'{title}\''
-                      f'starting \'{start}\' and ending \'{end}\'. Skip '
-                      f'event..')
-                continue
 
-        return self.from_import(items, publish_immediately=True)
+            tags = vevent.get('categories')
+            if tags:
+                # categories may be in lists or they may be single values
+                # whose 'cats' member contains the texts
+                if not hasattr(tags, '__iter__'):
+                    tags = [tags]
+
+                tags = [str(c) for tag in tags for c in tag.cats]
+
+            uid = str(vevent.get('uid', ''))
+            title = str(vevent.get('summary', ''))
+            description = str(vevent.get('description', ''))
+            organizer = str(vevent.get('organizer', ''))
+            location = str(vevent.get('location', ''))
+
+            items.append(
+                EventImportItem(
+                    event=Event(
+                        state='initiated',
+                        title=title,
+                        start=start,
+                        end=end,
+                        timezone=timezone,
+                        recurrence=recurrence,
+                        description=description,
+                        organizer=organizer,
+                        location=location,
+                        coordinates=coordinates,
+                        tags=tags or [],
+                        source=f'ical-{uid}',
+                    ),
+                    image=event_image_path,
+                    image_filename=event_image_path.name if
+                    event_image_path else None,
+                    pdf=None,
+                    pdf_filename=None,
+                )
+            )
+
+        return self.from_import(items, publish_immediately=True,
+                                future_events_only=future_events_only)

--- a/tests/onegov/event/test_collections.py
+++ b/tests/onegov/event/test_collections.py
@@ -958,6 +958,60 @@ def test_from_import(session):
     ]) == ([], [], [])
     assert events.by_name('title-c').state == 'withdrawn'
 
+    # future only events option
+    a, u, p = events.from_import([
+        EventImportItem(
+            event=Event(
+                state='initiated',
+                title='Title D past',
+                location='Location D past',
+                tags=['Tag D.1', 'Tag D.2'],
+                start=tzdatetime(2020, 6, 16, 9, 30, 'US/Eastern'),
+                end=tzdatetime(2020, 6, 16, 18, 00, 'US/Eastern'),
+                timezone='US/Eastern',
+                description='Description D past',
+                organizer='Organizer D past',
+                recurrence=(
+                    'RRULE:FREQ=WEEKLY;'
+                    'UNTIL=20200616T220000Z;'
+                    'BYDAY=MO,TU,WE,TH,FR,SA,SU'
+                ),
+                coordinates=Coordinates(48.051752750515746, 9.305739625357093),
+                source='import-2-D'
+            ),
+            image=None,
+            image_filename=None,
+            pdf=None,
+            pdf_filename=None,
+        ),
+        EventImportItem(
+            event=Event(
+                state='initiated',
+                title='Title D future',
+                location='Location D future',
+                tags=['Tag D.1', 'Tag D.2'],
+                start=tzdatetime(next_year, 6, 16, 9, 30, 'US/Eastern'),
+                end=tzdatetime(next_year, 6, 16, 18, 00, 'US/Eastern'),
+                timezone='US/Eastern',
+                description='Description D future',
+                organizer='Organizer D future',
+                recurrence=(
+                    'RRULE:FREQ=WEEKLY;'
+                    f'UNTIL={next_year}0616T220000Z;'
+                    'BYDAY=MO,TU,WE,TH,FR,SA,SU'
+                ),
+                coordinates=Coordinates(48.051752750515746, 9.305739625357093),
+                source='import-2-D'
+            ),
+            image=None,
+            image_filename=None,
+            pdf=None,
+            pdf_filename=None,
+        )
+    ], future_events_only=True)
+    # only adding the future event
+    assert (len(a), len(u), len(p)) == (1, 0, 0)
+
 
 def test_from_ical(session):
     events = EventCollection(session)


### PR DESCRIPTION
event: Adding cli option to import future events only

Fix: Revert adding try/catch block in function from_ical() but handling the event with no end date (see events.py +L349)
                                                                                
TYPE: Feature                                                                   
LINK: ogc-1051                                                                  
                                                                                
                                                                                
## Checklist                                                                    
                                                                                
- [x] I have performed a self-review of my code                                 
- [x] I considered adding a reviewer                                            
- [x] I have tested my code thoroughly by hand                                  
- [x] I have added tests for my changes/features     