### PR TITLE
Extends code doc for xml view

### DIFF
--- a/src/onegov/event/collections/occurrences.py
+++ b/src/onegov/event/collections/occurrences.py
@@ -322,6 +322,9 @@ class OccurrenceCollection(Pagination):
         """
         Returns all published occurrences as xml.
 
+        The xml format was Winterthur's wish (no specs behind). Their mobile
+        app will consume the events from xml
+
         Format:
         <events>
             <event>

--- a/src/onegov/org/views/occurrence.py
+++ b/src/onegov/org/views/occurrence.py
@@ -197,6 +197,9 @@ def json_export_occurences(self, request):
 def xml_export_all_occurrences(self, request):
     """
     Returns events as xml.
+    This view was requested by Winterthur for their mobile app that displays
+    the events provided by this xml view.
+
     Url for xml view: ../events/xml
     """
 


### PR DESCRIPTION

winterthur: add hint in doc that xml view was made for Winterthur to consume the events from xml

TYPE: Feature
LINK: ogc-1048
