### PR TITLE
Org: Adds an optional user definable notice when a directory is empty

### DIFF
--- a/src/onegov/directory/types/directory_configuration.py
+++ b/src/onegov/directory/types/directory_configuration.py
@@ -87,6 +87,7 @@ class DirectoryConfiguration(Mutable, StoredConfiguration):
     fields = (
         'title',
         'lead',
+        'empty_notice',
         'order',
         'keywords',
         'searchable',
@@ -100,14 +101,15 @@ class DirectoryConfiguration(Mutable, StoredConfiguration):
         'show_as_thumbnails',
     )
 
-    def __init__(self, title=None, lead=None, order=None, keywords=None,
-                 searchable=None, display=None, direction=None,
+    def __init__(self, title=None, lead=None, empty_notice=None, order=None,
+                 keywords=None, searchable=None, display=None, direction=None,
                  link_pattern=None, link_title=None, link_visible=None,
                  thumbnail=None, address_block_title=None,
                  show_as_thumbnails=None, **kwargs):
 
         self.title = title
         self.lead = lead
+        self.empty_notice = empty_notice
         self.order = order
         self.keywords = keywords
         self.searchable = searchable

--- a/src/onegov/org/forms/directory.py
+++ b/src/onegov/org/forms/directory.py
@@ -110,6 +110,15 @@ class DirectoryBaseForm(Form):
         fieldset=_("Display"),
         render_kw={'class_': 'formcode-format'})
 
+    empty_notice = StringField(
+        label=_("Empty Directory Notice"),
+        fieldset=_("Display"),
+        description=_(
+            "This text will be displayed when the directory "
+            "contains no (visible) entries. When left empty "
+            "a generic default text will be shown instead."
+        ))
+
     numbering = RadioField(
         label=_("Numbering"),
         fieldset=_("Display"),
@@ -508,6 +517,7 @@ class DirectoryBaseForm(Form):
         return DirectoryConfiguration(
             title=self.title_format.data,
             lead=self.lead_format.data,
+            empty_notice=self.empty_notice.data,
             order=safe_format_keys(order_format),
             keywords=keyword_fields,
             searchable=searchable_content_fields + contact_fields,
@@ -539,6 +549,7 @@ class DirectoryBaseForm(Form):
 
         self.title_format.data = cfg.title
         self.lead_format.data = cfg.lead or ''
+        self.empty_notice = cfg.empty_notice
         self.content_fields.data = '\n'.join(cfg.display.get('content', ''))
         self.content_hide_labels.data = '\n'.join(
             cfg.display.get('content_hide_labels', ''))

--- a/src/onegov/org/locale/de_CH/LC_MESSAGES/onegov.org.po
+++ b/src/onegov/org/locale/de_CH/LC_MESSAGES/onegov.org.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE 1.0\n"
-"POT-Creation-Date: 2023-05-25 11:48+0200\n"
+"POT-Creation-Date: 2023-06-15 11:42+0200\n"
 "PO-Revision-Date: 2022-03-15 10:21+0100\n"
 "Last-Translator: Marc Sommerhalder <marc.sommerhalder@seantis.ch>\n"
 "Language-Team: German\n"
@@ -339,6 +339,17 @@ msgstr "Anzeige"
 
 msgid "Lead-Format"
 msgstr "Lead-Format"
+
+msgid "Empty Directory Notice"
+msgstr "Leeres Verzeichnis Hinweis"
+
+msgid ""
+"This text will be displayed when the directory contains no (visible) "
+"entries. When left empty a generic default text will be shown instead."
+msgstr ""
+"Dieser Text wird dargestellt wenn das Verzeichnis keine (sichtbaren) "
+"Einträge enthält. Falls leergelassen, wird stattdessen ein generischer "
+"Standardtext angezeigt."
 
 msgid "Numbering"
 msgstr "Nummerierung"
@@ -905,6 +916,9 @@ msgstr "Excel Datei"
 
 msgid "JSON File"
 msgstr "JSON Datei"
+
+msgid "XML File"
+msgstr "XML Datei"
 
 msgid "Minimum price total"
 msgstr "Minimalpreis"
@@ -2409,8 +2423,8 @@ msgstr "Die Absage von ${title} kann nicht rückgängig gemacht werden."
 msgid "Reject reservation"
 msgstr "Reservation absagen"
 
-#. Used in sentence: "${event} published."
 #.
+#. Used in sentence: "${event} published."
 msgid "Event"
 msgstr "Veranstaltung"
 
@@ -3565,6 +3579,9 @@ msgstr ""
 "werden. Bitte überprüfen Sie die Internetadresse oder verwenden Sie die "
 "Suche im Navigationsbereich."
 
+msgid "Back"
+msgstr "Zurück"
+
 msgid "Link to organizers page"
 msgstr "Link zur Veranstalterseite"
 
@@ -4218,8 +4235,8 @@ msgstr "Der Eintrag wurde gelöscht"
 msgid ""
 "On the right side, you can filter the entries of this directory to export."
 msgstr ""
-"Auf der rechten Seite können Sie die Einträge des Verzeichnisses für den Export "
-"filtern."
+"Auf der rechten Seite können Sie die Einträge des Verzeichnisses für den "
+"Export filtern."
 
 msgid "Exports all entries of this directory."
 msgstr "Exportiert alle Einträge dieses Verzeichniseses."

--- a/src/onegov/org/locale/fr_CH/LC_MESSAGES/onegov.org.po
+++ b/src/onegov/org/locale/fr_CH/LC_MESSAGES/onegov.org.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE 1.0\n"
-"POT-Creation-Date: 2023-05-25 11:48+0200\n"
+"POT-Creation-Date: 2023-06-15 11:42+0200\n"
 "PO-Revision-Date: 2022-03-15 10:50+0100\n"
 "Last-Translator: Marc Sommerhalder <marc.sommerhalder@seantis.ch>\n"
 "Language-Team: French\n"
@@ -339,6 +339,17 @@ msgstr "Afficher"
 
 msgid "Lead-Format"
 msgstr "Format Principal"
+
+msgid "Empty Directory Notice"
+msgstr "Avis de dossier vide"
+
+msgid ""
+"This text will be displayed when the directory contains no (visible) "
+"entries. When left empty a generic default text will be shown instead."
+msgstr ""
+"Ce texte sera affiché lorsque le dossier ne contient pas d'entrées "
+"(visibles). S'il est laissé vide, un texte générique par défaut sera affiché "
+"à la place."
 
 msgid "Numbering"
 msgstr "Numérotation"
@@ -904,6 +915,9 @@ msgstr "Fichier Excel"
 
 msgid "JSON File"
 msgstr "Fichier JSON"
+
+msgid "XML File"
+msgstr "Fichier XML"
 
 msgid "Minimum price total"
 msgstr "Prix minimum total"
@@ -2409,8 +2423,8 @@ msgstr "Refuser ${title} est irréversible."
 msgid "Reject reservation"
 msgstr "Refuser la réservation"
 
-#. Used in sentence: "${event} published."
 #.
+#. Used in sentence: "${event} published."
 msgid "Event"
 msgstr "Événement"
 
@@ -3571,6 +3585,9 @@ msgstr ""
 "Désolé, la page que vous cherchez n'a pu être trouvée. Essayez de vérifier "
 "qu'il n'y a pas d'erreurs dans l'URL ou utilisez la fenêtre de recherche "
 "située en haut."
+
+msgid "Back"
+msgstr "Retour"
 
 msgid "Link to organizers page"
 msgstr "Lien vers la page de l'organisateur"

--- a/src/onegov/org/locale/it_CH/LC_MESSAGES/onegov.org.po
+++ b/src/onegov/org/locale/it_CH/LC_MESSAGES/onegov.org.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"POT-Creation-Date: 2023-05-25 11:48+0200\n"
+"POT-Creation-Date: 2023-06-15 11:42+0200\n"
 "PO-Revision-Date: 2022-03-15 10:52+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -340,6 +340,17 @@ msgstr "Visualizza"
 
 msgid "Lead-Format"
 msgstr "Formato principale"
+
+msgid "Empty Directory Notice"
+msgstr "Avviso di cartella vuota"
+
+msgid ""
+"This text will be displayed when the directory contains no (visible) "
+"entries. When left empty a generic default text will be shown instead."
+msgstr ""
+"Questo testo viene visualizzato quando la cartella non contiene voci "
+"(visibili). Se lasciato vuoto, verrà visualizzato un testo generico "
+"predefinito."
 
 msgid "Numbering"
 msgstr "Numerazione"
@@ -907,6 +918,9 @@ msgstr "File Excel"
 
 msgid "JSON File"
 msgstr "File JSON"
+
+msgid "XML File"
+msgstr "File XML"
 
 msgid "Minimum price total"
 msgstr "Prezzo minimo totale"
@@ -2419,8 +2433,8 @@ msgstr "Il rifiuto di ${title} non può essere annullato."
 msgid "Reject reservation"
 msgstr "Rifiuta prenotazione"
 
-#. Used in sentence: "${event} published."
 #.
+#. Used in sentence: "${event} published."
 msgid "Event"
 msgstr "Evento"
 
@@ -3564,6 +3578,9 @@ msgstr ""
 "Spiacenti, la pagina che stai cercando non è stata trovata. Prova a "
 "controllare l'URL per eventuali errori o utilizza la casella di ricerca in "
 "alto."
+
+msgid "Back"
+msgstr "Indietro"
 
 msgid "Link to organizers page"
 msgstr "Link alla pagina dell'organizzatore"

--- a/src/onegov/org/templates/directory.pt
+++ b/src/onegov/org/templates/directory.pt
@@ -20,7 +20,10 @@
 
         <div class="row reverse-on-mobile">
             <div class="columns medium-8">
-                <p tal:condition="not:entries" i18n:translate="">No entries found.</p>
+                <tal:b tal:condition="not:entries" tal:switch="not:directory.configuration.empty_notice">
+                    <p tal:case="True" i18n:translate="">No entries found.</p>
+                    <p tal:case="False">${directory.configuration.empty_notice}</p>
+                </tal:b>
 
                 <ul class="directory-list with-lead ${show_thumbnails and 'with-thumbnails' or ''}  ${'row' if overview_two_columns else ''}" tal:condition="entries">
                     <li tal:repeat="entry entries" class="small-12 ${'medium-6' if overview_two_columns else ''} columns">

--- a/src/onegov/town6/templates/directory.pt
+++ b/src/onegov/town6/templates/directory.pt
@@ -19,7 +19,10 @@
                 </div>
 
                 <p id="directory-lead" tal:condition="directory.lead" tal:content="structure layout.linkify(directory.lead)" />
-                <p tal:condition="not:entries" i18n:translate="">No entries found.</p>
+                <tal:b tal:condition="not:entries" tal:switch="not:directory.configuration.empty_notice">
+                    <p tal:case="True" i18n:translate="">No entries found.</p>
+                    <p tal:case="False">${directory.configuration.empty_notice}</p>
+                </tal:b>
 
                 <div class="further-information" tal:define="text directory.content.get('text'); title directory.content.get('title_further_information'); above directory.content.get('position')=='above'" tal:condition="text and above">
                     <h2 tal:condition="title">${title}</h2>


### PR DESCRIPTION
## Commit message

Org: Adds an optional user definable notice when a directory is empty

Empty in this context means no visible entries

TYPE: Feature
LINK: OGC-1005

## Checklist

- [x] I have performed a self-review of my code
- [x] I have updated the PO files
- [x] I made changes/features for both org and town6
- [x] I have tested my code thoroughly by hand
- [ ] ~I have added tests for my changes/features~
