### PR TITLE
Bugfix/ogc 1211 assert error when confirming registration on full class

### DIFF
--- a/src/onegov/form/models/submission.py
+++ b/src/onegov/form/models/submission.py
@@ -216,6 +216,7 @@ class FormSubmission(Base, TimestampMixin, Payable, AssociatedFiles,
         """ Claimes the given number of spots (defaults to the requested
         number of spots).
 
+        :return bool: Weather or not claiming spots is possible
         """
         spots = spots or self.spots
 
@@ -225,10 +226,15 @@ class FormSubmission(Base, TimestampMixin, Payable, AssociatedFiles,
             limit = self.registration_window.limit
             claimed = self.registration_window.claimed_spots
 
+            # check if limit of participants is reached
+            if spots > (limit - claimed):
+                return False
+
             assert spots <= (limit - claimed)
 
         assert ((self.claimed or 0) + spots) <= self.spots
         self.claimed = (self.claimed or 0) + spots
+        return True
 
     def disclaim(self, spots=None):
         """ Disclaims the given number of spots (defaults to all spots that

--- a/src/onegov/org/locale/de_CH/LC_MESSAGES/onegov.org.po
+++ b/src/onegov/org/locale/de_CH/LC_MESSAGES/onegov.org.po
@@ -4534,8 +4534,8 @@ msgstr "Ihre Anmeldung wurde bestätigt"
 msgid "The registration has been confirmed"
 msgstr "Die Anmeldung wurde bestätigt"
 
-msgid "The registration could not be confirmed"
-msgstr "Die Anmeldung konnte nicht bestätigt werden"
+msgid "The registration could not be confirmed because the maximum number of participants has been reached"
+msgstr "Die Anmeldung konnte nicht bestätigt werden da die maximale Teilnehmerzahl erreicht ist"
 
 msgid "Your registration has been denied"
 msgstr "Ihre Anmeldung wurde abgelehnt"

--- a/src/onegov/org/locale/fr_CH/LC_MESSAGES/onegov.org.po
+++ b/src/onegov/org/locale/fr_CH/LC_MESSAGES/onegov.org.po
@@ -4555,8 +4555,8 @@ msgstr "Votre inscription a été confirmée"
 msgid "The registration has been confirmed"
 msgstr "L'inscription a été confirmée"
 
-msgid "The registration could not be confirmed"
-msgstr "L'inscription n'a pas pu être confirmée"
+msgid "The registration could not be confirmed because the maximum number of participants has been reached"
+msgstr "L'inscription n'a pas pu être confirmée car le nombre maximum de participants a été atteint."
 
 msgid "Your registration has been denied"
 msgstr "Votre inscription a été refusée"

--- a/src/onegov/org/locale/it_CH/LC_MESSAGES/onegov.org.po
+++ b/src/onegov/org/locale/it_CH/LC_MESSAGES/onegov.org.po
@@ -4552,8 +4552,8 @@ msgstr "La tua registrazione è stata confermata"
 msgid "The registration has been confirmed"
 msgstr "La registrazione è stata confermata"
 
-msgid "The registration could not be confirmed"
-msgstr "Non è stato possibile confermare la registrazione"
+msgid "The registration could not be confirmed because the maximum number of participants has been reached"
+msgstr "Non è stato possibile confermare la registrazione perché è stato raggiunto il numero massimo di partecipanti."
 
 msgid "Your registration has been denied"
 msgstr "La tua registrazione è stata rifiutata"

--- a/src/onegov/org/views/form_submission.py
+++ b/src/onegov/org/views/form_submission.py
@@ -319,11 +319,12 @@ def handle_submission_action(
     if action == 'confirmed':
         subject = _("Your registration has been confirmed")
         success = _("The registration has been confirmed")
-        failure = _("The registration could not be confirmed")
+        failure = _("The registration could not be confirmed because the "
+                    "maximum number of participants has been reached")
 
         def execute():
             if self.registration_window and self.claimed is None:
-                return self.claim() or True
+                return self.claim()
 
     elif action == 'denied':
         subject = _("Your registration has been denied")
@@ -370,5 +371,6 @@ def handle_submission_action(
             raise ValueError(request.translate(failure))
         if not no_messages:
             request.alert(failure)
+            return
 
     return request.redirect(request.link(self))

--- a/tests/onegov/form/test_model.py
+++ b/tests/onegov/form/test_model.py
@@ -356,13 +356,11 @@ def test_registration_claims_with_a_limit(session):
         spots=100
     )
 
-    with pytest.raises(AssertionError):
-        submission.claim()
+    assert not submission.claim()
 
-    with pytest.raises(AssertionError):
-        submission.claim(11)
+    assert not submission.claim(11)
 
-    submission.claim(spots=10)
+    assert submission.claim(spots=10)
     session.flush()
 
     assert window.claimed_spots == 10


### PR DESCRIPTION
Form: Notify if registration could not be confirmed because the maximum number of participants has been reached

TYPE: Bugfix
LINK: ogc-1211

