### PR TITLE
Form: Gets rid of `colour` dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,8 +54,6 @@ module = [
     "bjoern.*",
     "blinker.*",
     "chameleon.*",
-    # FIXME: do we actually make good use of this?
-    "colour.*",
     "cssutils.*",
     "elasticsearch_dsl.*",
     "dectate.*",
@@ -108,6 +106,10 @@ module = [
     "transaction.*",
     "ua_parser.*",
     "urlextract.*",
+    # TEMPORARY: webcolors has type annotations but is missing its
+    #            py.typed marker, once that has been fixed, we should
+    #            remove the module from this list.
+    "webcolors.*",
     "webassets.*",
     "webtest.*",
     "xlrd.*",

--- a/setup.cfg
+++ b/setup.cfg
@@ -69,7 +69,6 @@ install_requires =
     chameleon
     certifi
     click
-    colour
     cssmin
     cssutils
     dill
@@ -155,6 +154,7 @@ install_requires =
     urlextract
     vobject
     watchdog
+    webcolors
     webob
     websockets
     webtest

--- a/src/onegov/agency/views/settings.py
+++ b/src/onegov/agency/views/settings.py
@@ -147,7 +147,7 @@ class AgencySettingsForm(Form):
         obj.agency_path_display_on_people = \
             self.agency_path_display_on_people.data
         obj.pdf_underline_links = self.underline_links.data
-        obj.pdf_link_color = self.link_color.data.get_hex()
+        obj.pdf_link_color = self.link_color.data
 
 
 @AgencyApp.form(

--- a/src/onegov/onboarding/models/town_assistant.py
+++ b/src/onegov/onboarding/models/town_assistant.py
@@ -27,7 +27,7 @@ class TownAssistant(Assistant):
             request.browser_session['user'] = form.data['user']
             request.browser_session['user_name'] = form.data['user_name']
             request.browser_session['phone_number'] = form.data['phone_number']
-            request.browser_session['color'] = form.data['color'].get_hex()
+            request.browser_session['color'] = form.data['color']
 
             return morepath.redirect(request.link(self.for_next_step()))
 

--- a/src/onegov/org/forms/directory.py
+++ b/src/onegov/org/forms/directory.py
@@ -1,5 +1,4 @@
 from functools import cached_property
-from colour import Color
 from onegov.core.utils import safe_format_keys
 from onegov.directory import DirectoryConfiguration
 from onegov.directory import DirectoryZipArchive
@@ -485,13 +484,11 @@ class DirectoryBaseForm(Form):
 
     @property
     def marker_color(self):
-        if self.marker_color_value.data:
-            return self.marker_color_value.data.get_hex()
+        return self.marker_color_value.data
 
     @marker_color.setter
     def marker_color(self, value):
-        self.marker_color_value.data = Color(
-            value or self.default_marker_color)
+        self.marker_color_value.data = value or self.default_marker_color
 
     @property
     def configuration(self):

--- a/src/onegov/org/forms/settings.py
+++ b/src/onegov/org/forms/settings.py
@@ -93,10 +93,10 @@ class GeneralSettingsForm(Form):
     def theme_options(self):
         options = self.model.theme_options
 
-        try:
-            options['primary-color'] = self.primary_color.data.get_hex()
-        except AttributeError:
+        if self.primary_color.data is None:
             options['primary-color'] = user_options['primary-color']
+        else:
+            options['primary-color'] = self.primary_color.data
         font_family = self.font_family_sans_serif.data
         if font_family not in self.theme.font_families.values():
             options['font-family-sans-serif'] = self.default_font_family
@@ -464,13 +464,12 @@ class HeaderSettingsForm(Form):
             'header_links': self.json_to_links(self.header_links.data) or None,
             'left_header_name': self.left_header_name.data or None,
             'left_header_url': self.left_header_url.data or None,
-            'left_header_color': self.left_header_color.data.get_hex(),
+            'left_header_color': self.left_header_color.data,
             'left_header_rem': self.left_header_rem.data,
             'announcement': self.announcement.data,
             'announcement_url': self.announcement_url.data,
-            'announcement_bg_color': self.announcement_bg_color.data.get_hex(),
-            'announcement_font_color':
-            self.announcement_font_color.data.get_hex(),
+            'announcement_bg_color': self.announcement_bg_color.data,
+            'announcement_font_color': self.announcement_font_color.data,
             'announcement_is_private': self.announcement_is_private.data
         }
 

--- a/src/onegov/town6/forms/settings.py
+++ b/src/onegov/town6/forms/settings.py
@@ -32,10 +32,10 @@ class GeneralSettingsForm(OrgGeneralSettingsForm):
     def theme_options(self):
         options = self.model.theme_options
 
-        try:
-            options['primary-color-ui'] = self.primary_color.data.get_hex()
-        except AttributeError:
+        if self.primary_color.data is None:
             options['primary-color-ui'] = user_options['primary-color-ui']
+        else:
+            options['primary-color-ui'] = self.primary_color.data
 
         body_family = self.body_font_family_ui.data
         if body_family not in self.theme.font_families.values():
@@ -134,4 +134,4 @@ class ChatSettingsForm(Form):
 
     def populate_obj(self, obj, *args, **kwargs):
         super().populate_obj(obj, *args, **kwargs)
-        obj.chat_bg_color = self.chat_color.data.get_hex()
+        obj.chat_bg_color = self.chat_color.data


### PR DESCRIPTION
## Commit message

Form: Gets rid of `colour` dependency

Instead uses actively maintained `webcolors` to validate `ColorField`

TYPE: Feature
LINK: OGC-1229

## Checklist

- [ ] I have performed a self-review of my code
