### PR TITLE
Add missing translations and use for organizer email

### DIFF
--- a/src/onegov/org/templates/macros.pt
+++ b/src/onegov/org/templates/macros.pt
@@ -972,7 +972,7 @@
 
         <tal:b condition="event.organizer_phone">
             <dt i18n:translate>Organizer phone number</dt>
-            <dd><a href="mailto:${event.organizer_phone}" tal:content="event.organizer_phone" />
+            <dd><a href="${event.organizer_phone}" tal:content="event.organizer_phone" />
             </dd>
         </tal:b>
 

--- a/src/onegov/org/templates/occurrence.pt
+++ b/src/onegov/org/templates/occurrence.pt
@@ -53,11 +53,11 @@
                             <dd>${organizer}</dd>
                         </div>
                         <div tal:condition="organizer_email">
-                            <dt i18n:translate>E-Mail</dt>
+                            <dt i18n:translate>Organizer E-Mail address</dt>
                             <dd><a href="mailto:${organizer_email}" tal:content="organizer_email" /></dd>
                         </div>
                         <div tal:condition="organizer_phone">
-                            <dt i18n:translate></dt>
+                            <dt i18n:translate>Organizer phone number</dt>
                             <dd>${organizer_phone}</dd>
                         </div>
                     </dl>

--- a/src/onegov/town6/templates/macros.pt
+++ b/src/onegov/town6/templates/macros.pt
@@ -1133,7 +1133,7 @@
         </tal:b>
         <tal:b condition="event.organizer_phone">
             <dt i18n:translate>Organizer phone number</dt>
-            <dd><a href="mailto:${event.organizer_phone}" tal:content="event.organizer_phone" /></dd>
+            <dd><a href="${event.organizer_phone}" tal:content="event.organizer_phone" /></dd>
         </tal:b>
 
         <tal:b condition="event.tags">

--- a/src/onegov/town6/templates/occurrence.pt
+++ b/src/onegov/town6/templates/occurrence.pt
@@ -52,11 +52,11 @@
                             <dd>${organizer}</dd>
                         </div>
                         <div tal:condition="organizer_email">
-                            <dt i18n:translate>E-Mail</dt>
+                            <dt i18n:translate>Organizer E-Mail address</dt>
                             <dd><a href="mailto:${organizer_email}" tal:content="organizer_email" /></dd>
                         </div>
                         <div tal:condition="organizer_phone">
-                            <dt i18n:translate>Phone number</dt>
+                            <dt i18n:translate>Organizer phone number</dt>
                             <dd>${organizer_phone}</dd>
                         </div>
                     </dl>


### PR DESCRIPTION
Events: Organizer phone number not always shown and translated

TYPE: Bugfix
LINK: ogc-1222
