### PR TITLE
Fix wrong identation

### DIFF
--- a/src/onegov/org/forms/event.py
+++ b/src/onegov/org/forms/event.py
@@ -440,8 +440,8 @@ class EventForm(Form):
                 if form_field is None:
                     continue
 
-                    form_field.data = keywords[field.id] if (
-                        field.id in keywords) else None
+                form_field.data = keywords[field.id] if (
+                    field.id in keywords) else None
 
     @cached_property
     def parsed_dates(self):


### PR DESCRIPTION
Events: filter keywords are not pupulated when editing event

TYPE: Bugfix
LINK: ogc-1219
