### PR TITLE
Feature/ogc 1243 extension person data

### DIFF
--- a/src/onegov/org/forms/settings.py
+++ b/src/onegov/org/forms/settings.py
@@ -659,7 +659,11 @@ class ModuleSettingsForm(Form):
             ('phone', _("Phone")),
             ('phone_direct', _("Direct Phone Number or Mobile")),
             ('website', _("Website")),
-            ('address', _("Address")),
+            ('website_2', _("Website 2")),
+            ('location_address', _("Location Address")),
+            ('location_code_city', _("Location Code and City")),
+            ('postal_address', _("Postal Address")),
+            ('postal_code_city', _("Postal Code and City")),
             ('notes', _("Notes")),
         ])
 

--- a/src/onegov/org/templates/macros.pt
+++ b/src/onegov/org/templates/macros.pt
@@ -732,8 +732,17 @@
                         <span tal:condition="person.political_party and 'political_party' not in exclude">${person.political_party}</span>
                         <span tal:condition="person.parliamentary_group and 'parliamentary_group' not in exclude">${person.parliamentary_group}</span>
                     </li>
-                    <li tal:condition="person.address and 'address' not in exclude" class="person-card-address">
-                        <span>${person.address}</span>
+                    <li tal:condition="person.location_address and 'location_address' not in exclude" class="person-card-address">
+                        <span>${person.location_address}</span>
+                    </li>
+                    <li tal:condition="person.location_code_city and 'location_code_city' not in exclude" class="person-card-address">
+                        <span>${person.location_code_city}</span>
+                    </li>
+                    <li tal:condition="person.postal_address and 'postal_address' not in exclude" class="person-card-address">
+                        <span>${person.postal_address}</span>
+                    </li>
+                    <li tal:condition="person.postal_code_city and 'postal_code_city' not in exclude" class="person-card-address">
+                        <span>${person.postal_code_city}</span>
                     </li>
                     <li tal:condition="person.email and 'email' not in exclude" class="person-card-email">
                         <a href="mailto:${person.email}">${person.email}</a>
@@ -746,6 +755,9 @@
                     </li>
                     <li tal:condition="person.website and 'website' not in exclude" class="person-card-website">
                         <a href="${person.website}">${person.website}</a>
+                    </li>
+                    <li tal:condition="person.website_2 and 'website_2' not in exclude" class="person-card-website">
+                        <a href="${person.website_2}">${person.website_2}</a>
                     </li>
                     <li class="person-card-notes" tal:condition="person.notes and 'notes' not in exclude">
                         <span>${person.notes}</span>

--- a/src/onegov/people/cli.py
+++ b/src/onegov/people/cli.py
@@ -151,8 +151,6 @@ p4 = re.compile(r'(.*), (.*), (.*)')
 p1 = re.compile(r'(.*), (.*)')
 p6 = re.compile(r'(.*)\n(.*)')
 p5 = re.compile(r'([A-Za-z ]*) ?(\d+[a-z]?)?')  # street name and optional
-
-
 # building number
 
 
@@ -200,9 +198,8 @@ def parse_and_split_address_field(address):
         postal_pcc = m.group(2)
         return location_addr, location_pcc, postal_addr, postal_pcc
 
-    if m := p6.match(address):
-        postal_addr = m.group(1)
-        postal_pcc = m.group(2)
+    if p6.match(address):
+        postal_addr, postal_pcc = address.rsplit('\n', 1)
         return location_addr, location_pcc, postal_addr, postal_pcc
 
     if m := p5.match(address):

--- a/src/onegov/people/cli.py
+++ b/src/onegov/people/cli.py
@@ -276,10 +276,11 @@ def onegov_migrate_people_address_field(dry_run):
 
     Example:
 
-        onegov-people --select /onegov_town6/ebikon onegov-migrate-people-address-field
+        onegov-people --select /onegov_town6/ebikon
+        onegov-migrate-people-address-field
 
-        onegov-people --select /onegov_org/risch onegov-migrate-people-address-field
-        --dry-run
+        onegov-people --select /onegov_org/risch
+        onegov-migrate-people-address-field --dry-run
 
     """
 

--- a/src/onegov/people/cli.py
+++ b/src/onegov/people/cli.py
@@ -264,6 +264,57 @@ def migrate_people_address_field(dry_run):
     return _migrate
 
 
+@cli.command('onegov-migrate-people-address-field')
+@click.option('--dry-run/--no-dry-run', default=False)
+def onegov_migrate_people_address_field(dry_run):
+    """ Migrates people address field everywhere in onegov.
+
+    Migrate data from 'people' column 'address' field to
+    'location_address', 'location_code_city', 'postal_address' and
+    'postal_code_city' fields.
+
+
+    Example:
+
+        onegov-people --select /onegov_town6/ebikon onegov-migrate-people-address-field
+
+        onegov-people --select /onegov_org/risch onegov-migrate-people-address-field
+        --dry-run
+
+    """
+
+    def _migrate(request, app):
+        click.secho(f'Request url: {request.url}..')
+        session = app.session()
+        click.secho("Onegov migrate data from table 'people' column "
+                    "'address' field to 'location_address', "
+                    "'location_code_city', 'postal_address' and "
+                    "'postal_code_city ..",
+                    fg='yellow')
+        migration_count = 0
+        total_count = 0
+        for person in session.query(Person):
+            total_count += 1
+
+            if not person.address:
+                continue
+
+            person.location_address, person.location_code_city, \
+                person.postal_address, person.postal_code_city = \
+                parse_and_split_address_field(person.address)
+
+            migration_count += 1
+
+        if dry_run:
+            transaction.abort()
+            click.secho('Aborting transaction', fg='yellow')
+
+        click.secho(f'Migrated all {migration_count} address(es) of totally '
+                    f'{total_count} people', fg='green')
+
+    return _migrate
+
+
 re_postal_code_city_ch = re.compile(r'\d{4} .*')  # e.g. '1234 Mein Ort'
 re_postal_code_city_de = re.compile(r'D-\d{5} .*')  # e.g. 'D-12345 Mein Ort'
 

--- a/src/onegov/people/cli.py
+++ b/src/onegov/people/cli.py
@@ -149,6 +149,7 @@ p2 = re.compile(r'(.*), (.*)Postadresse: (.*), (.*)')
 p3 = re.compile(r'(.*), (Postfach), (.*)')
 p4 = re.compile(r'(.*), (.*), (.*)')
 p1 = re.compile(r'(.*), (.*)')
+p6 = re.compile(r'(.*)\n(.*)')
 p5 = re.compile(r'([A-Za-z ]*) ?(\d+[a-z]?)?')  # street name and optional
 
 
@@ -195,6 +196,11 @@ def parse_and_split_address_field(address):
         return location_addr, location_pcc, postal_addr, postal_pcc
 
     if m := p1.match(address):
+        postal_addr = m.group(1)
+        postal_pcc = m.group(2)
+        return location_addr, location_pcc, postal_addr, postal_pcc
+
+    if m := p6.match(address):
         postal_addr = m.group(1)
         postal_pcc = m.group(2)
         return location_addr, location_pcc, postal_addr, postal_pcc

--- a/src/onegov/people/upgrade.py
+++ b/src/onegov/people/upgrade.py
@@ -238,3 +238,18 @@ def extend_agency_and_person_with_more_fields(context):
                 Column(column, Text, nullable=True),
                 default=lambda x: ''
             )
+
+
+@upgrade_task('ogc-1243 replace person address field')
+def onegov_replace_person_address_field(context):
+    people_columns = ['location_address', 'location_code_city',
+                      'postal_address', 'postal_code_city', 'website_2']
+    table = 'people'
+
+    for column in people_columns:
+        if not context.has_column(table, column):
+            context.add_column_with_defaults(
+                table,
+                Column(column, Text, nullable=True),
+                default=lambda x: ''
+            )

--- a/src/onegov/people/upgrade.py
+++ b/src/onegov/people/upgrade.py
@@ -238,18 +238,3 @@ def extend_agency_and_person_with_more_fields(context):
                 Column(column, Text, nullable=True),
                 default=lambda x: ''
             )
-
-
-@upgrade_task('ogc-1243 replace person address field')
-def onegov_replace_person_address_field(context):
-    people_columns = ['location_address', 'location_code_city',
-                      'postal_address', 'postal_code_city', 'website_2']
-    table = 'people'
-
-    for column in people_columns:
-        if not context.has_column(table, column):
-            context.add_column_with_defaults(
-                table,
-                Column(column, Text, nullable=True),
-                default=lambda x: ''
-            )

--- a/src/onegov/town6/templates/macros.pt
+++ b/src/onegov/town6/templates/macros.pt
@@ -915,8 +915,18 @@
                         <span tal:condition="person.political_party and 'political_party' not in exclude">${person.political_party}</span>
                         <span tal:condition="person.parliamentary_group and 'parliamentary_group' not in exclude">${person.parliamentary_group}</span>
                     </li>
-                    <li tal:condition="person.address and 'address' not in exclude" class="person-card-address">
-                        <span>${person.address}</span>
+                    <li tal:condition="person.location_address and 'location_address' not in exclude" class="person-card-address">
+                        <span title="_('Location address')">${person .location_address}</span>
+                    </li>
+                    <li tal:condition="person.location_code_city and 'location_code_city' not in exclude" class="person-card-address">
+                        <span title="Hover text für location code and
+                        city">${person.location_code_city}</span>
+                    </li>
+                    <li tal:condition="person.postal_address and 'postal_address' not in exclude" class="person-card-address">
+                        <span>${person.postal_address}</span>
+                    </li>
+                    <li tal:condition="person.postal_code_city and 'postal_code_city' not in exclude" class="person-card-address">
+                        <span>${person.postal_code_city}</span>
                     </li>
                     <li tal:condition="person.email and 'email' not in exclude" class="person-card-email">
                         <a href="mailto:${person.email}">${person.email}</a>
@@ -929,6 +939,9 @@
                     </li>
                     <li tal:condition="person.website and 'website' not in exclude" class="person-card-website">
                         <a href="${person.website}">${person.website}</a>
+                    </li>
+                    <li tal:condition="person.website_2 and 'website_2' not in exclude" class="person-card-website">
+                        <a href="${person.website_2}">${person.website_2}</a>
                     </li>
                     <div class="person-card-context-specific-functions" tal:condition="python: organization_to_function">
                         <span i18n:translate="">Functions:</span>

--- a/tests/onegov/people/test_upgrade.py
+++ b/tests/onegov/people/test_upgrade.py
@@ -10,6 +10,12 @@ def test_parse_person_address_field():
          ('', '', 'Leimenstrasse 1', '4001 Basel')),
         ('Pilatusstrasse 3\n6003 Luzern',
          ('', '', 'Pilatusstrasse 3', '6003 Luzern')),
+        ('Bauverwaltung Lauerz\nHusmatt 1\n6424 Lauerz',
+         ('', '', 'Bauverwaltung Lauerz\nHusmatt 1', '6424 Lauerz')),
+        ('Meier AG\nBüro für Softis\nMit viel Spass bei der Arbeit\nPostfach '
+         '41\n1234 Govikon',
+         ('', '', 'Meier AG\nBüro für Softis\nMit viel Spass bei der '
+                  'Arbeit\nPostfach 41', '1234 Govikon')),
         ('Strassburgerallee 12-18, 4055 Basel',
          ('', '', 'Strassburgerallee ' '12-18', '4055 Basel')),
         ('St. Alban-Graben 5, 4010 Basel',

--- a/tests/onegov/people/test_upgrade.py
+++ b/tests/onegov/people/test_upgrade.py
@@ -8,6 +8,8 @@ def test_parse_person_address_field():
         ('', ('', '', '', '')),
         ('Leimenstrasse 1, 4001 Basel',
          ('', '', 'Leimenstrasse 1', '4001 Basel')),
+        ('Pilatusstrasse 3\n6003 Luzern',
+         ('', '', 'Pilatusstrasse 3', '6003 Luzern')),
         ('Strassburgerallee 12-18, 4055 Basel',
          ('', '', 'Strassburgerallee ' '12-18', '4055 Basel')),
         ('St. Alban-Graben 5, 4010 Basel',


### PR DESCRIPTION
People: Replaces the address field for people for org and town6

TYPE: Feature
LINK: ogc-1243
HINT: onegov-core --select /onegov_org/* upgrade
HINT: onegov-core --select /onegov_tow6/* upgrade
HINT: onegov-people --select /onegov_org/* onegov-migrate-people-address-field
HINT: onegov-people --select /onegov_town6/* onegov-migrate-people-address-field



## Checklist

- [x] I have performed a self-review of my code
- [x] I considered adding a reviewer
- [x] I have added an upgrade hint such as data migration commands to be run
- [x] I made changes/features for both org and town6
- [x] I have tested my code thoroughly by hand
    - [x] I have tested database upgrades
- [x] I have added tests for my changes/features
