### PR TITLE
Feature/ogc 1219 preserve filter order

### DIFF
--- a/src/onegov/event/models/mixins.py
+++ b/src/onegov/event/models/mixins.py
@@ -1,3 +1,5 @@
+from collections import OrderedDict
+
 from onegov.core.orm.mixins import content_property, ContentMixin
 from onegov.core.orm.types import UTCDateTime
 from sedate import to_timezone
@@ -64,3 +66,10 @@ class OccurrenceMixin(ContentMixin):
         """ The localized version of the end date/time. """
 
         return to_timezone(self.end, self.timezone)
+
+    def filter_keywords_ordered(self, order=None):
+        order = order or []
+        if order:
+            return OrderedDict((k, self.filter_keywords.get(k)) for k in order)
+
+        return OrderedDict(sorted(self.filter_keywords.items()))

--- a/src/onegov/org/templates/macros.pt
+++ b/src/onegov/org/templates/macros.pt
@@ -1115,7 +1115,7 @@
                 <span tal:repeat="tag occurrence.tags" class="blank-label" i18n:translate>${tag}</span>
             </div>
             <div tal:condition="occurrence.filter_keywords and show_filters" class="occurrence-filter">
-                <div tal:repeat="filter occurrence.filter_keywords.items()">
+                <div tal:repeat="filter occurrence.filter_keywords_ordered().items()">
                     <span tal:condition="filter[1]" class="blank-label-description">${filter[0].title()}:</span>
                     <span tal:repeat="tag filter[1]" tal:condition="isinstance(filter[1], list)" class="blank-label">${tag}</span>
                     <span tal:condition="not isinstance(filter[1], list) and filter[1]" class="blank-label">${filter[1]}</span>

--- a/src/onegov/org/templates/macros.pt
+++ b/src/onegov/org/templates/macros.pt
@@ -1118,7 +1118,7 @@
                 <div tal:repeat="filter occurrence.filter_keywords.items()">
                     <span tal:condition="filter[1]" class="blank-label-description">${filter[0].title()}:</span>
                     <span tal:repeat="tag filter[1]" tal:condition="isinstance(filter[1], list)" class="blank-label">${tag}</span>
-                    <span tal:condition="not isinstance(filter[1], list)" class="blank-label">${filter[1]}</span>
+                    <span tal:condition="not isinstance(filter[1], list) and filter[1]" class="blank-label">${filter[1]}</span>
                 </div>
             </div>
         </div>

--- a/src/onegov/org/templates/occurrence.pt
+++ b/src/onegov/org/templates/occurrence.pt
@@ -19,7 +19,7 @@
                 </div>
 
                 <div class="occurrence-filters" tal:condition="occurrence.filter_keywords and show_filters">
-                    <div tal:repeat="filter occurrence.filter_keywords.items()">
+                    <div tal:repeat="filter occurrence.filter_keywords_ordered().items()">
                         <span tal:condition="filter[1]" class="blank-label-description">${filter[0].title()}:</span>
                         <span tal:repeat="tag filter[1]" tal:condition="isinstance(filter[1], list)" class="blank-label">${tag}</span>
                         <span tal:condition="not isinstance(filter[1], list) and filter[1]" class="blank-label">${filter[1]}</span>

--- a/src/onegov/org/templates/occurrence.pt
+++ b/src/onegov/org/templates/occurrence.pt
@@ -22,7 +22,7 @@
                     <div tal:repeat="filter occurrence.filter_keywords.items()">
                         <span tal:condition="filter[1]" class="blank-label-description">${filter[0].title()}:</span>
                         <span tal:repeat="tag filter[1]" tal:condition="isinstance(filter[1], list)" class="blank-label">${tag}</span>
-                        <span tal:condition="not isinstance(filter[1], list)" class="blank-label">${filter[1]}</span>
+                        <span tal:condition="not isinstance(filter[1], list) and filter[1]" class="blank-label">${filter[1]}</span>
                     </div>
                 </div>
 

--- a/src/onegov/town6/templates/macros.pt
+++ b/src/onegov/town6/templates/macros.pt
@@ -1337,7 +1337,7 @@
                                             <div tal:repeat="filter occurrence.filter_keywords.items()">
                                                 <span tal:condition="filter[1]" class="blank-label-description">${filter[0].title()}:</span>
                                                 <span tal:repeat="tag filter[1]" tal:condition="isinstance(filter[1], list)" class="blank-label">${tag}</span>
-                                                <span tal:condition="not isinstance(filter[1], list)" class="blank-label">${filter[1]}</span>
+                                                <span tal:condition="not isinstance(filter[1], list) and filter[1]" class="blank-label">${filter[1]}</span>
                                             </div>
                                         </div>
                                     </div>

--- a/src/onegov/town6/templates/macros.pt
+++ b/src/onegov/town6/templates/macros.pt
@@ -1334,7 +1334,7 @@
                                             <span tal:repeat="tag occurrence.tags" class="blank-label" i18n:translate>${tag}</span>
                                         </div>
                                         <div tal:condition="occurrence.filter_keywords and show_filters">
-                                            <div tal:repeat="filter occurrence.filter_keywords.items()">
+                                            <div tal:repeat="filter occurrence.filter_keywords_ordered().items()">
                                                 <span tal:condition="filter[1]" class="blank-label-description">${filter[0].title()}:</span>
                                                 <span tal:repeat="tag filter[1]" tal:condition="isinstance(filter[1], list)" class="blank-label">${tag}</span>
                                                 <span tal:condition="not isinstance(filter[1], list) and filter[1]" class="blank-label">${filter[1]}</span>

--- a/src/onegov/town6/templates/occurrence.pt
+++ b/src/onegov/town6/templates/occurrence.pt
@@ -18,7 +18,7 @@
                 </div>
 
                 <div class="occurrence-filters" tal:condition="occurrence.filter_keywords and show_filters">
-                    <div tal:repeat="filter occurrence.filter_keywords.items()">
+                    <div tal:repeat="filter occurrence.filter_keywords_ordered().items()">
                         <span tal:condition="filter[1]" class="blank-label-description">${filter[0].title()}:</span>
                         <span tal:repeat="tag filter[1]" tal:condition="isinstance(filter[1], list)" class="blank-label">${tag}</span>
                         <span tal:condition="not isinstance(filter[1], list) and filter[1]" class="blank-label">${filter[1]}</span>

--- a/src/onegov/town6/templates/occurrence.pt
+++ b/src/onegov/town6/templates/occurrence.pt
@@ -21,7 +21,7 @@
                     <div tal:repeat="filter occurrence.filter_keywords.items()">
                         <span tal:condition="filter[1]" class="blank-label-description">${filter[0].title()}:</span>
                         <span tal:repeat="tag filter[1]" tal:condition="isinstance(filter[1], list)" class="blank-label">${tag}</span>
-                        <span tal:condition="not isinstance(filter[1], list)" class="blank-label">${filter[1]}</span>
+                        <span tal:condition="not isinstance(filter[1], list) and filter[1]" class="blank-label">${filter[1]}</span>
                     </div>
                 </div>
 


### PR DESCRIPTION
Events: Preserve filter order (alphabetically by default)

TYPE: Feature
LINK: ogc-1219
