### PR TITLE
Validate if filter keywords not used in EventForm

### DIFF
--- a/src/onegov/org/forms/event.py
+++ b/src/onegov/org/forms/event.py
@@ -345,6 +345,7 @@ class EventForm(Form):
             'end_time',
             'weekly',
             'email',
+            # tschupre ?
         })
 
         # clear the recurrence to avoid updating all occurrences too much
@@ -653,3 +654,20 @@ class EventConfigurationForm(Form):
             'class_': 'formcode-select',
             'data-fields-include': 'radio,checkbox'
         })
+
+    def validate(self):
+        """
+        Ensures none of the active keywords is used in the `EventForm` to
+        prevent overriding data accidentally by defining filters.
+        """
+        result = super().validate()
+
+        for keyword in [k.lower() for k
+                        in self.keyword_fields.data.splitlines()]:
+            if keyword in dir(EventForm):
+                error = f'Keyword \'{keyword}\' is already in use!'
+                self.definition.errors.append(error)
+                self.keyword_fields.errors.append(error)
+                result = False
+
+        return result

--- a/src/onegov/org/forms/event.py
+++ b/src/onegov/org/forms/event.py
@@ -345,7 +345,6 @@ class EventForm(Form):
             'end_time',
             'weekly',
             'email',
-            # tschupre ?
         })
 
         # clear the recurrence to avoid updating all occurrences too much

--- a/src/onegov/org/forms/event.py
+++ b/src/onegov/org/forms/event.py
@@ -642,6 +642,8 @@ class EventConfigurationForm(Form):
             ValidFilterFormDefinition(
                 require_email_field=False,
                 require_title_fields=False,
+                reserved_fields={name for name, _ in
+                                 EventForm()._unbound_fields}
             )
         ],
         render_kw={'rows': 32, 'data-editor': 'form'})
@@ -653,20 +655,3 @@ class EventConfigurationForm(Form):
             'class_': 'formcode-select',
             'data-fields-include': 'radio,checkbox'
         })
-
-    def validate(self):
-        """
-        Ensures none of the active keywords is used in the `EventForm` to
-        prevent overriding data accidentally by defining filters.
-        """
-        result = super().validate()
-
-        for keyword in [k.lower() for k
-                        in self.keyword_fields.data.splitlines()]:
-            if keyword in EventForm:
-                error = f'Keyword \'{keyword}\' is already in use!'
-                self.definition.errors.append(error)
-                self.keyword_fields.errors.append(error)
-                result = False
-
-        return result

--- a/src/onegov/org/forms/event.py
+++ b/src/onegov/org/forms/event.py
@@ -663,7 +663,7 @@ class EventConfigurationForm(Form):
 
         for keyword in [k.lower() for k
                         in self.keyword_fields.data.splitlines()]:
-            if keyword in dir(EventForm):
+            if keyword in EventForm:
                 error = f'Keyword \'{keyword}\' is already in use!'
                 self.definition.errors.append(error)
                 self.keyword_fields.errors.append(error)

--- a/src/onegov/org/forms/event.py
+++ b/src/onegov/org/forms/event.py
@@ -17,6 +17,7 @@ from onegov.form.fields import MultiCheckboxField
 from onegov.form.fields import TimeField
 from onegov.form.fields import UploadField
 from onegov.form.fields import UploadFileWithORMSupport
+from onegov.form.utils import get_fields_from_class
 from onegov.form.validators import (
     FileSizeLimit, ValidPhoneNumber, ValidFilterFormDefinition)
 from onegov.form.validators import WhitelistedMimeType
@@ -643,7 +644,7 @@ class EventConfigurationForm(Form):
                 require_email_field=False,
                 require_title_fields=False,
                 reserved_fields={name for name, _ in
-                                 EventForm()._unbound_fields}
+                                 get_fields_from_class(EventForm)}
             )
         ],
         render_kw={'rows': 32, 'data-editor': 'form'})


### PR DESCRIPTION
Events: Validate event filter definition does not use names used in `EventForm`

TYPE: Feature
LINK: ogc-1219