### PR TITLE
mypy: Gets rid of runtime check for `dict_property` for now.

### DIFF
--- a/src/onegov/agency/models/agency.py
+++ b/src/onegov/agency/models/agency.py
@@ -2,6 +2,7 @@ from onegov.agency.models.membership import ExtendedAgencyMembership
 from onegov.agency.utils import get_html_paragraph_with_line_breaks
 from onegov.core.crypto import random_token
 from onegov.core.orm.abstract import associated
+from onegov.core.orm.mixins import dict_property
 from onegov.core.orm.mixins import meta_property
 from onegov.core.utils import normalize_for_url
 from onegov.file import File
@@ -35,7 +36,7 @@ class ExtendedAgency(Agency, AccessExtension, PublicationExtension):
     #: the PDF. The fields are expected to contain two parts seperated by a
     #: point. The first part is either `membership` or `person`, the second
     #: the name of the attribute (e.g. `membership.title`).
-    export_fields = meta_property(default=list)
+    export_fields: dict_property[list[str]] = meta_property(default=list)
 
     #: The PDF for the agency and all its suborganizations.
     pdf = associated(AgencyPdf, 'pdf', 'one-to-one')

--- a/src/onegov/org/models/organisation.py
+++ b/src/onegov/org/models/organisation.py
@@ -4,7 +4,7 @@ from datetime import date, timedelta
 from functools import lru_cache
 from hashlib import sha256
 from onegov.core.orm import Base
-from onegov.core.orm.mixins import meta_property, TimestampMixin
+from onegov.core.orm.mixins import dict_property, meta_property, TimestampMixin
 from onegov.core.orm.types import JSON, UUID
 from onegov.core.utils import linkify, paragraphify
 from onegov.form import flatten_fieldsets, parse_formcode
@@ -13,6 +13,11 @@ from onegov.org.models.tan import DEFAULT_ACCESS_WINDOW
 from onegov.org.models.swiss_holidays import SwissHolidays
 from sqlalchemy import Column, Text
 from uuid import uuid4
+
+
+from typing import Any, TYPE_CHECKING
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 
 class Organisation(Base, TimestampMixin):
@@ -66,10 +71,14 @@ class Organisation(Base, TimestampMixin):
     locales = meta_property()
     redirect_homepage_to = meta_property()
     redirect_path = meta_property()
-    hidden_people_fields = meta_property(default=list)
-    event_locations = meta_property(default=list)
+    hidden_people_fields: dict_property[list[str]] = meta_property(
+        default=list
+    )
+    event_locations: dict_property[list[str]] = meta_property(default=list)
     geo_provider = meta_property(default='geo-mapbox')
-    holiday_settings = meta_property(default=dict)
+    holiday_settings: dict_property[dict[str, Any]] = meta_property(
+        default=dict
+    )
     hide_onegov_footer = meta_property(default=False)
     standard_image = meta_property()
     submit_events_visible = meta_property(default=True)
@@ -139,7 +148,7 @@ class Organisation(Base, TimestampMixin):
     agency_display_levels = meta_property()
 
     # Header settings that go into the div.globals
-    header_options = meta_property(default=dict)
+    header_options: dict_property[dict[str, Any]] = meta_property(default=dict)
 
     # Setting if show full agency path on people detail view
     agency_path_display_on_people = meta_property(default=False)
@@ -172,7 +181,9 @@ class Organisation(Base, TimestampMixin):
     chat_title = meta_property()
     chat_bg_color = meta_property()
     chat_customer_id = meta_property()
-    hide_chat_for_roles = meta_property(default=tuple)
+    hide_chat_for_roles: dict_property['Sequence[str]'] = meta_property(
+        default=tuple
+    )
     disable_chat = meta_property(default=False)
 
     # Required information to upload documents to a Gever instance

--- a/src/onegov/org/models/page.py
+++ b/src/onegov/org/models/page.py
@@ -1,5 +1,6 @@
 from datetime import datetime
-from onegov.core.orm.mixins import content_property, meta_property
+from onegov.core.orm.mixins import (
+    content_property, dict_property, meta_property)
 from onegov.file import MultiAssociatedFiles
 from onegov.form import Form, move_fields
 from onegov.org import _
@@ -124,7 +125,7 @@ class News(Page, TraitInfo, SearchableContent, NewsletterExtension,
     filter_years: list[int] = []
     filter_tags: list[str] = []
 
-    hashtags = meta_property(default=list)
+    hashtags: dict_property[list[str]] = meta_property(default=list)
 
     @property
     def es_public(self):

--- a/src/onegov/swissvotes/models/vote.py
+++ b/src/onegov/swissvotes/models/vote.py
@@ -2,6 +2,7 @@ from collections import OrderedDict
 from functools import cached_property
 from onegov.core.orm import Base
 from onegov.core.orm.mixins import content_property
+from onegov.core.orm.mixins import dict_property
 from onegov.core.orm.mixins import ContentMixin
 from onegov.core.orm.mixins import TimestampMixin
 from onegov.core.orm.types import JSON
@@ -26,6 +27,9 @@ from sqlalchemy.dialects.postgresql import TSVECTOR
 from sqlalchemy.orm import deferred
 from urllib.parse import urlparse
 from urllib.parse import urlunparse
+
+
+from typing import Any
 
 
 class encoded_property:
@@ -279,12 +283,20 @@ class SwissVote(Base, TimestampMixin, LocalizedFiles, ContentMixin):
     posters_sa_nay = Column(Text)
 
     # Fetched list of image urls using MfG API
-    posters_mfg_yea_imgs = content_property(default=dict)
-    posters_mfg_nay_imgs = content_property(default=dict)
+    posters_mfg_yea_imgs: dict_property[dict[str, Any]] = content_property(
+        default=dict
+    )
+    posters_mfg_nay_imgs: dict_property[dict[str, Any]] = content_property(
+        default=dict
+    )
 
     # Fetched list of image urls using SA API
-    posters_sa_yea_imgs = content_property(default=dict)
-    posters_sa_nay_imgs = content_property(default=dict)
+    posters_sa_yea_imgs: dict_property[dict[str, Any]] = content_property(
+        default=dict
+    )
+    posters_sa_nay_imgs: dict_property[dict[str, Any]] = content_property(
+        default=dict
+    )
 
     def posters(self, request):
         result = {'yea': [], 'nay': []}

--- a/src/onegov/translator_directory/models/translator.py
+++ b/src/onegov/translator_directory/models/translator.py
@@ -5,7 +5,7 @@ from sqlalchemy import Column, Text, Enum, Date, Integer, Boolean, Float
 from sqlalchemy.orm import backref, relationship
 
 from onegov.core.orm import Base
-from onegov.core.orm.mixins import ContentMixin, meta_property
+from onegov.core.orm.mixins import ContentMixin, dict_property, meta_property
 from onegov.core.orm.types import UUID
 from onegov.file import AssociatedFiles
 from onegov.gis import CoordinatesMixin
@@ -22,6 +22,7 @@ from onegov.translator_directory.models.language import (
 
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:
+    from collections.abc import Sequence
     from onegov.user import User
     from .certificate import LanguageCertificate
     from .language import Language
@@ -172,10 +173,13 @@ class Translator(Base, TimestampMixin, AssociatedFiles, ContentMixin,
     operation_comments = Column(Text)
 
     # List of types of interpreting the interpreter can do
+    expertise_interpreting_types: 'dict_property[Sequence[str]]'
     expertise_interpreting_types = meta_property(default=tuple)
 
     # List of types of professional guilds
+    expertise_professional_guilds: 'dict_property[Sequence[str]]'
     expertise_professional_guilds = meta_property(default=tuple)
+    expertise_professional_guilds_other: 'dict_property[Sequence[str]]'
     expertise_professional_guilds_other = meta_property(default=tuple)
 
     @property


### PR DESCRIPTION
## Commit message

mypy: Gets rid of runtime check for `dict_property` for now

Instead adds proper overloads and adds annotations for the properties
that could not be inferred based on their arguments.

## Checklist

- [x] I have performed a self-review of my code
