### PR TITLE
Fsi: Adds missing file extension for vCalendar.

### DIFF
--- a/src/onegov/fsi/models/course_event.py
+++ b/src/onegov/fsi/models/course_event.py
@@ -361,7 +361,7 @@ class CourseEvent(Base, TimestampMixin, ORMSearchable):
 
     def as_ical_attachment(self, url=None):
         return Attachment(
-            filename=self.name.lower().replace(' ', '_'),
+            filename=self.name.lower().replace(' ', '_') + '.ics',
             content=self.as_ical(url),
             content_type='text/calendar'
         )


### PR DESCRIPTION
## Commit message

Fsi: Adds missing file extension for vCalendar.


TYPE: Bugfix
LINK: OGC-1319


## Checklist

- [x] I have performed a self-review of my code

