### PR TITLE
Scrollbar on open navigation

### DIFF
--- a/src/onegov/town6/templates/layout.pt
+++ b/src/onegov/town6/templates/layout.pt
@@ -38,7 +38,7 @@
 <body id="${layout.page_id}" class="${' '.join(cls for cls in layout.body_classes)} town-6" data-default-marker-color="${layout.primary_color}" data-default-lat="${layout.default_map_view.lat|nothing}" data-default-lon="${layout.default_map_view.lon|nothing}" data-default-zoom="${layout.default_map_view.zoom|nothing}" tal:attributes="layout.custom_body_attributes">
     <!--! Adds a 'framed' class to the body if this document is shown inside an iframe -->
     <script>if (window !== window.parent) { document.querySelector('body').className += " framed"; }</script>
-        <div class="off-canvas position-left" id="offCanvas" data-off-canvas data-auto-focus="false" >
+        <div class="off-canvas position-left" data-transition="overlap" id="offCanvas" data-off-canvas data-auto-focus="false" >
             <!-- Close button -->
             <div class="button-area">
                 <button class="off-canvas-close-button" aria-label="Close menu" type="button" data-close>
@@ -60,7 +60,7 @@
             <!-- Gets filled by sidebar_mobile.js -->
         </div>
 
-        <div class="off-canvas position-right"  tal:condition="not:hide_search_header|nothing" id="offCanvasSearch" data-auto-focus="false" data-off-canvas>
+        <div class="off-canvas position-right"  tal:condition="not:hide_search_header|nothing" data-transition="overlap" id="offCanvasSearch" data-auto-focus="false" data-off-canvas>
             <button class="off-canvas-close-button" aria-label="Close menu" type="button" data-close>
                 <i class="fa fa-times"></i>
             </button>

--- a/src/onegov/town6/theme/styles/header.scss
+++ b/src/onegov/town6/theme/styles/header.scss
@@ -553,6 +553,7 @@ $editbar-fg-color-active: $white;
 
 #offCanvasSearch {
     background-color: $white;
+    z-index: 1000;
 
     .off-canvas-close-button {
         color: $primary-color;
@@ -561,6 +562,7 @@ $editbar-fg-color-active: $white;
 
 #offCanvas {
     background: $primary-color;
+    z-index: 1000;
 
     .button-area {
         display: flex;
@@ -571,6 +573,21 @@ $editbar-fg-color-active: $white;
         display: flex;
         justify-content: center;
         padding-top: 10vh;
+    }
+
+    &::-webkit-scrollbar {
+        width: 8px;
+    }
+
+    &::-webkit-scrollbar-track {
+        border-radius: 8px;
+        background-color: $primary-color;
+        border: 2px solid $primary-color;
+    }
+    
+    &::-webkit-scrollbar-thumb {
+        border-radius: 8px;
+        background-color: $white;
     }
 
     .side-navigation {


### PR DESCRIPTION
Please fill in the commit message below and work through the checklist. You can delete parts that are not needed, e.g. the optional description, the link to a ticket or irrelevant options of the checklist.

## Commit message

Town6: Scrollbar on open navigation

Scrollbar in Safari and Chrome now looks nicer when you open the navigation and it gets longer than the page. Also there is no vertical scrollbar anymore if you open the menu.

TYPE: Feature
LINK: OGC-1258

## Checklist

- [X] I have performed a self-review of my code
- [X] I have tested my code thoroughly by hand
    - [X] I have tested styling changes/features on different browsers
