### PR TITLE
Ogc 1202 header

### DIFF
--- a/src/onegov/org/forms/settings.py
+++ b/src/onegov/org/forms/settings.py
@@ -60,11 +60,6 @@ class GeneralSettingsForm(Form):
         description=_("URL pointing to the logo"),
         render_kw={'class_': 'image-url'})
 
-    standard_image = StringField(
-        label=_("Standard Image"),
-        render_kw={'class_': 'image-url'}
-    )
-
     reply_to = EmailField(
         _("E-Mail Reply Address (Reply-To)"), [InputRequired()],
         description=_("Replies to automated e-mails go to this address."))
@@ -91,6 +86,12 @@ class GeneralSettingsForm(Form):
     custom_css = CssField(
         label=_('Additional CSS'),
         render_kw={'rows': 8},
+    )
+
+    standard_image = StringField(
+        fieldset=_('Images'),
+        label=_("Standard Image"),
+        render_kw={'class_': 'image-url'}
     )
 
     @property

--- a/src/onegov/org/locale/de_CH/LC_MESSAGES/onegov.org.po
+++ b/src/onegov/org/locale/de_CH/LC_MESSAGES/onegov.org.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE 1.0\n"
-"POT-Creation-Date: 2023-11-17 11:54+0100\n"
+"POT-Creation-Date: 2023-11-29 11:14+0100\n"
 "PO-Revision-Date: 2022-03-15 10:21+0100\n"
 "Last-Translator: Marc Sommerhalder <marc.sommerhalder@seantis.ch>\n"
 "Language-Team: German\n"
@@ -1273,9 +1273,6 @@ msgstr "Link zum Logo"
 msgid "Logo (Square)"
 msgstr "Logo (Quadratisch)"
 
-msgid "Standard Image"
-msgstr "Standardbild"
-
 msgid "E-Mail Reply Address (Reply-To)"
 msgstr "E-Mail Antwort Adresse (Reply-To)"
 
@@ -1302,6 +1299,9 @@ msgstr "Italienisch"
 
 msgid "Additional CSS"
 msgstr "Zusätzliches CSS"
+
+msgid "Standard Image"
+msgstr "Standardbild"
 
 msgid "Column width left side"
 msgstr "Breite linke Seite"
@@ -2354,6 +2354,12 @@ msgstr "Bild in der Vorschau auf der Seitenübersicht anzeigen"
 
 msgid "Show image on page"
 msgstr "Bild auf der Seite anzeigen"
+
+msgid "As first element of the content"
+msgstr "Als erstes Element des Inhalts"
+
+msgid "As a full width header"
+msgstr "Als ein Header-Bild mit voller Breite"
 
 msgid "Documents"
 msgstr "Dokumente"
@@ -4102,8 +4108,12 @@ msgstr "Ticket Updates via E-Mail"
 msgid "Disable E-Mails"
 msgstr "E-Mails deaktivieren"
 
-msgid "No ticket updates via e-mail. An e-mail is still sent when a ticket is assigned."
-msgstr "Keine Ticket Updates via E-Mail. Es wird weiterhin eine E-Mail gesendet, wenn ein Ticket zugewiesen wird."
+msgid ""
+"No ticket updates via e-mail. An e-mail is still sent when a ticket is "
+"assigned."
+msgstr ""
+"Keine Ticket Updates via E-Mail. Es wird weiterhin eine E-Mail gesendet, "
+"wenn ein Ticket zugewiesen wird."
 
 msgid "Enable E-Mails"
 msgstr "E-Mails aktivieren"

--- a/src/onegov/org/locale/fr_CH/LC_MESSAGES/onegov.org.po
+++ b/src/onegov/org/locale/fr_CH/LC_MESSAGES/onegov.org.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE 1.0\n"
-"POT-Creation-Date: 2023-11-17 11:54+0100\n"
+"POT-Creation-Date: 2023-11-29 11:14+0100\n"
 "PO-Revision-Date: 2022-03-15 10:50+0100\n"
 "Last-Translator: Marc Sommerhalder <marc.sommerhalder@seantis.ch>\n"
 "Language-Team: French\n"
@@ -1272,9 +1272,6 @@ msgstr "URL pointant vers le logo"
 msgid "Logo (Square)"
 msgstr "Logo (carré)"
 
-msgid "Standard Image"
-msgstr "Image standard"
-
 msgid "E-Mail Reply Address (Reply-To)"
 msgstr "Adresse e-mail de réponse (Reply-To)"
 
@@ -1301,6 +1298,9 @@ msgstr "Italien"
 
 msgid "Additional CSS"
 msgstr "CSS additionnel"
+
+msgid "Standard Image"
+msgstr "Image standard"
 
 msgid "Column width left side"
 msgstr "Largeur de la colonne côté gauche"
@@ -2355,6 +2355,12 @@ msgstr "Afficher l'image sur l'aperçu de la page parent"
 
 msgid "Show image on page"
 msgstr "Afficher l'image sur la page"
+
+msgid "As first element of the content"
+msgstr "Come primo elemento del contenuto"
+
+msgid "As a full width header"
+msgstr "Come immagine di intestazione a tutta larghezza"
 
 msgid "Documents"
 msgstr "Documents"
@@ -4111,8 +4117,12 @@ msgstr "Mises à jour de tickets par e-mail"
 msgid "Disable E-Mails"
 msgstr "Désactiver les e-mails"
 
-msgid "No ticket updates via e-mail. An e-mail is still sent when a ticket is assigned."
-msgstr "Aucune mise à jour de tickets par e-mail. Un e-mail continue d'être envoyé lorsqu'un ticket est attribué."
+msgid ""
+"No ticket updates via e-mail. An e-mail is still sent when a ticket is "
+"assigned."
+msgstr ""
+"Aucune mise à jour de tickets par e-mail. Un e-mail continue d'être envoyé "
+"lorsqu'un ticket est attribué."
 
 msgid "Enable E-Mails"
 msgstr "Activer les e-mails"

--- a/src/onegov/org/locale/it_CH/LC_MESSAGES/onegov.org.po
+++ b/src/onegov/org/locale/it_CH/LC_MESSAGES/onegov.org.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"POT-Creation-Date: 2023-11-17 11:54+0100\n"
+"POT-Creation-Date: 2023-11-29 11:14+0100\n"
 "PO-Revision-Date: 2022-03-15 10:52+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -1274,9 +1274,6 @@ msgstr "URL che punta al logo"
 msgid "Logo (Square)"
 msgstr "Logo (quadrato)"
 
-msgid "Standard Image"
-msgstr "Immagine standard"
-
 msgid "E-Mail Reply Address (Reply-To)"
 msgstr "Indirizzo di risposta dell'e-mail (Rispondi a)"
 
@@ -1303,6 +1300,9 @@ msgstr "Italiano"
 
 msgid "Additional CSS"
 msgstr "CSS aggiuntivo"
+
+msgid "Standard Image"
+msgstr "Immagine standard"
 
 msgid "Column width left side"
 msgstr "Larghezza colonna lato sinistro"
@@ -2363,6 +2363,12 @@ msgstr "Mostra l'immagine in anteprima nella pagina madre"
 
 msgid "Show image on page"
 msgstr "Mostra l'immagine nella pagina"
+
+msgid "As first element of the content"
+msgstr "En tant que premier élément du contenu"
+
+msgid "As a full width header"
+msgstr "En tant qu'image d'en-tête pleine largeur"
 
 msgid "Documents"
 msgstr "Documenti"
@@ -4103,8 +4109,12 @@ msgstr "Il biglietto si aggiorna tramite e-mail"
 msgid "Disable E-Mails"
 msgstr "Disabilita i messaggi e-mail"
 
-msgid "No ticket updates via e-mail. An e-mail is still sent when a ticket is assigned."
-msgstr "Nessun aggiornamento dei biglietti tramite e-mail. Viene comunque inviata un'e-mail quando viene assegnato un ticket."
+msgid ""
+"No ticket updates via e-mail. An e-mail is still sent when a ticket is "
+"assigned."
+msgstr ""
+"Nessun aggiornamento dei biglietti tramite e-mail. Viene comunque inviata "
+"un'e-mail quando viene assegnato un ticket."
 
 msgid "Enable E-Mails"
 msgstr "Abilita i messaggi e-mail"

--- a/src/onegov/org/models/extensions.py
+++ b/src/onegov/org/models/extensions.py
@@ -553,6 +553,17 @@ class ImageExtension(ContentExtension):
                 default=True,
             )
 
+            position_choices = [
+                ('in_content', _("As first element of the content")),
+                ('header', _("As a full width header")),
+            ]
+
+            page_image_position = RadioField(
+                label=_('Show image on page'),
+                choices=position_choices,
+                default='in_content',
+            )
+
         return PageImageForm
 
 

--- a/src/onegov/town6/assets/js/common.js
+++ b/src/onegov/town6/assets/js/common.js
@@ -306,3 +306,19 @@ $('.reveal[data-reveal-width]').on('open.zf.reveal', function() {
     let divWrapper = formField.parentElement.parentElement;
     divWrapper.style.marginLeft = '1.55rem';
 });
+
+// Height of header images
+var w = window.matchMedia("(max-width: 700px)");
+var header_height = $('#header').height();
+console.log(header_height)
+
+if ($('.header-image .page-image').length) {
+    var page_image = $('.header-image .page-image');
+    if (w.matches) {
+            var new_height = 'calc(90vw - ' + header_height + 'px)';
+    } else {
+            var new_height = 'calc(80vh - ' + header_height + 'px)';
+    }
+    page_image.css('padding-bottom', new_height);
+}
+

--- a/src/onegov/town6/forms/settings.py
+++ b/src/onegov/town6/forms/settings.py
@@ -1,4 +1,4 @@
-from wtforms.fields import BooleanField
+from wtforms.fields import BooleanField, RadioField
 from wtforms.validators import InputRequired
 
 from onegov.form import Form
@@ -13,7 +13,18 @@ from onegov.town6.theme import user_options
 class GeneralSettingsForm(OrgGeneralSettingsForm):
     """ Defines the settings form for onegov org. """
 
+    page_image_position = RadioField(
+        fieldset=_('Images'),
+        description=_("Choose the position of the page images"),
+        label=_("Page image position"),
+        choices=(
+            ('as_content', _("As content image")),
+            ('header', _("As header"))
+        ),
+    )
+
     body_font_family_ui = ChosenSelectField(
+        fieldset=_('Fonts'),
         label=_('Font family serif'),
         description=_('Used for text in html body'),
         choices=[],
@@ -21,6 +32,7 @@ class GeneralSettingsForm(OrgGeneralSettingsForm):
     )
 
     header_font_family_ui = ChosenSelectField(
+        fieldset=_('Fonts'),
         label=_('Font family sans-serif'),
         description=_('Used for all the headings'),
         choices=[],
@@ -35,6 +47,12 @@ class GeneralSettingsForm(OrgGeneralSettingsForm):
             options['primary-color-ui'] = user_options['primary-color-ui']
         else:
             options['primary-color-ui'] = self.primary_color.data
+
+        if self.page_image_position.data is None:
+            options['page-image-position'] = user_options[
+                'page-image-position']
+        else:
+            options['page-image-position'] = self.page_image_position.data
 
         body_family = self.body_font_family_ui.data
         if body_family not in self.theme.font_families.values():
@@ -57,6 +75,7 @@ class GeneralSettingsForm(OrgGeneralSettingsForm):
     @theme_options.setter
     def theme_options(self, options):
         self.primary_color.data = options.get('primary-color-ui')
+        self.page_image_position.data = options.get('page-image-position')
         self.body_font_family_ui.data = options.get(
             'body-font-family-ui') or self.default_font_family
         self.header_font_family_ui.data = options.get(

--- a/src/onegov/town6/locale/de_CH/LC_MESSAGES/onegov.town6.po
+++ b/src/onegov/town6/locale/de_CH/LC_MESSAGES/onegov.town6.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: OneGov Cloud 1.0\n"
-"POT-Creation-Date: 2023-11-17 11:54+0100\n"
+"POT-Creation-Date: 2023-11-29 11:18+0100\n"
 "PO-Revision-Date: 2021-03-03 16:24+0100\n"
 "Last-Translator: Lukas Burkhard <lukas.burkhard@seantis.ch>\n"
 "Language-Team: German\n"
@@ -22,6 +22,46 @@ msgstr "Chats"
 
 msgid "My Chats"
 msgstr "Meine Chats"
+
+msgid "Name"
+msgstr "Name"
+
+msgid "E-mail"
+msgstr "E-mail"
+
+msgid "Topic"
+msgstr "Thema"
+
+msgid "Confirmation"
+msgstr "Bestätigung"
+
+msgid ""
+"I confirm that I am aware that this chat will be saved and the history will "
+"be sent to me by email."
+msgstr ""
+"Ich bestätige, dass mir bewusst ist, dass dieser Chat gespeichert und der "
+"Verlauf an mich per Mail gesendet wird."
+
+msgid "Chat ID"
+msgstr "Chat ID"
+
+msgid "Images"
+msgstr "Bilder"
+
+msgid "Choose the position of the page images"
+msgstr "Position der Seiten-Bilder"
+
+msgid "Page image position"
+msgstr "Position der Seiten-Bilder"
+
+msgid "As content image"
+msgstr "Als Inhaltsbild"
+
+msgid "As header"
+msgstr "Als Headerbild"
+
+msgid "Fonts"
+msgstr "Schriften"
 
 msgid "Font family serif"
 msgstr "Schriftart mit Serifen"
@@ -43,8 +83,8 @@ msgstr "Chat aktivieren"
 
 msgid "The chat is currently in an test-phase. Activate at your own risk."
 msgstr ""
-"Der Chat befindet sich aktuel in einer Test-Phase. "
-"Auf eigenes Risiko aktivieren."
+"Der Chat befindet sich aktuel in einer Test-Phase. Auf eigenes Risiko "
+"aktivieren."
 
 msgid "Events"
 msgstr "Veranstaltungen"
@@ -234,9 +274,6 @@ msgstr ""
 
 msgid "Upload Ticket"
 msgstr "Ticket hochladen"
-
-msgid "Confirmation"
-msgstr "Bestätigung"
 
 msgid "New Message"
 msgstr "Neue Nachricht"
@@ -688,9 +725,6 @@ msgstr "Hochladen"
 
 msgid "Just Uploaded"
 msgstr "Soeben hochgeladen"
-
-msgid "Name"
-msgstr "Name"
 
 msgid "Extension"
 msgstr "Erweiterung"
@@ -1964,8 +1998,12 @@ msgstr "Ticket Updates via E-Mail"
 msgid "Disable E-Mails"
 msgstr "E-Mails deaktivieren"
 
-msgid "No ticket updates via e-mail. An e-mail is still sent when a ticket is assigned."
-msgstr "Keine Ticket Updates via E-Mail. Es wird weiterhin eine E-Mail gesendet, wenn ein Ticket zugewiesen wird."
+msgid ""
+"No ticket updates via e-mail. An e-mail is still sent when a ticket is "
+"assigned."
+msgstr ""
+"Keine Ticket Updates via E-Mail. Es wird weiterhin eine E-Mail gesendet, "
+"wenn ein Ticket zugewiesen wird."
 
 msgid "Enable E-Mails"
 msgstr "E-Mails aktivieren"

--- a/src/onegov/town6/locale/fr_CH/LC_MESSAGES/onegov.town6.po
+++ b/src/onegov/town6/locale/fr_CH/LC_MESSAGES/onegov.town6.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: OneGov Cloud 1.0\n"
-"POT-Creation-Date: 2023-11-17 11:54+0100\n"
+"POT-Creation-Date: 2023-11-29 11:18+0100\n"
 "PO-Revision-Date: 2021-03-03 14:04+0100\n"
 "Last-Translator: Lukas Burkhard <lukas.burkhard@seantis.ch>\n"
 "Language-Team: French\n"
@@ -22,6 +22,46 @@ msgstr "Chats"
 
 msgid "My Chats"
 msgstr "Mes chats"
+
+msgid "Name"
+msgstr "Nom"
+
+msgid "E-mail"
+msgstr "E-mail"
+
+msgid "Topic"
+msgstr "Rubrique"
+
+msgid "Confirmation"
+msgstr "Confirmation"
+
+msgid ""
+"I confirm that I am aware that this chat will be saved and the history will "
+"be sent to me by email."
+msgstr ""
+"Je confirme que je suis conscient(e) que ce chat est enregistré et que "
+"l'historique m'est envoyé par e-mail."
+
+msgid "Chat ID"
+msgstr "Chat ID"
+
+msgid "Images"
+msgstr "Images"
+
+msgid "Choose the position of the page images"
+msgstr "Choisir la position des images de la page"
+
+msgid "Page image position"
+msgstr "Position de l'image de la page"
+
+msgid "As content image"
+msgstr "En tant qu'image de contenu"
+
+msgid "As header"
+msgstr "Comme image d'en-tête"
+
+msgid "Fonts"
+msgstr "Polices de caractères"
 
 msgid "Font family serif"
 msgstr "Police serif"
@@ -230,9 +270,6 @@ msgstr ""
 
 msgid "Upload Ticket"
 msgstr "Télécharger le ticket"
-
-msgid "Confirmation"
-msgstr "Confirmation"
 
 msgid "New Message"
 msgstr "Nouveau message"
@@ -683,9 +720,6 @@ msgstr "Télécharger"
 
 msgid "Just Uploaded"
 msgstr "Mis en ligne à l'instant"
-
-msgid "Name"
-msgstr "Nom"
 
 msgid "Extension"
 msgstr "Extension"
@@ -1963,8 +1997,12 @@ msgstr "Mises à jour de tickets par e-mail"
 msgid "Disable E-Mails"
 msgstr "Désactiver les e-mails"
 
-msgid "No ticket updates via e-mail. An e-mail is still sent when a ticket is assigned."
-msgstr "Aucune mise à jour de tickets par e-mail. Un e-mail continue d'être envoyé lorsqu'un ticket est attribué."
+msgid ""
+"No ticket updates via e-mail. An e-mail is still sent when a ticket is "
+"assigned."
+msgstr ""
+"Aucune mise à jour de tickets par e-mail. Un e-mail continue d'être envoyé "
+"lorsqu'un ticket est attribué."
 
 msgid "Enable E-Mails"
 msgstr "Activer les e-mails"

--- a/src/onegov/town6/locale/it_CH/LC_MESSAGES/onegov.town6.po
+++ b/src/onegov/town6/locale/it_CH/LC_MESSAGES/onegov.town6.po
@@ -1,7 +1,7 @@
 # This file was generated from translations.town6.xlsx
 msgid ""
 msgstr ""
-"POT-Creation-Date: 2023-11-17 11:54+0100\n"
+"POT-Creation-Date: 2023-11-29 11:18+0100\n"
 "PO-Revision-Date: 2021-09-27 16:02+0200\n"
 "Language: it_CH\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -13,6 +13,46 @@ msgstr "Chat"
 
 msgid "My Chats"
 msgstr "Le mie chat"
+
+msgid "Name"
+msgstr "Nome"
+
+msgid "E-mail"
+msgstr "E-mail"
+
+msgid "Topic"
+msgstr "Argomento"
+
+msgid "Confirmation"
+msgstr "Conferma"
+
+msgid ""
+"I confirm that I am aware that this chat will be saved and the history will "
+"be sent to me by email."
+msgstr ""
+"Confermo di essere consapevole che questa chat sarà salvata e che la "
+"cronologia mi sarà inviata via e-mail."
+
+msgid "Chat ID"
+msgstr "Chat ID "
+
+msgid "Images"
+msgstr "Immagini"
+
+msgid "Choose the position of the page images"
+msgstr "Scegliere la posizione delle immagini della pagina"
+
+msgid "Page image position"
+msgstr "Posizione dell'immagine della pagina"
+
+msgid "As content image"
+msgstr "Come immagine di contenuto"
+
+msgid "As header"
+msgstr "Come immagine di intestazione"
+
+msgid "Fonts"
+msgstr "Caratteri"
 
 msgid "Font family serif"
 msgstr "Font famiglia serif"
@@ -34,8 +74,7 @@ msgstr "Attivare la chat"
 
 msgid "The chat is currently in an test-phase. Activate at your own risk."
 msgstr ""
-"a chat è attualmente in fase di test. Attivare a proprio rischio e "
-"pericolo"
+"a chat è attualmente in fase di test. Attivare a proprio rischio e pericolo"
 
 #, fuzzy
 msgid "Events"
@@ -225,9 +264,6 @@ msgstr "Questo caricherà il ticket nell'istanza di Gever, se configurata."
 
 msgid "Upload Ticket"
 msgstr "Caricare il biglietto"
-
-msgid "Confirmation"
-msgstr "Conferma"
 
 msgid "New Message"
 msgstr "Nuovo messaggio"
@@ -679,9 +715,6 @@ msgstr "Carica"
 
 msgid "Just Uploaded"
 msgstr "Appena caricato"
-
-msgid "Name"
-msgstr "Nome"
 
 msgid "Extension"
 msgstr "Estensione"
@@ -1955,8 +1988,12 @@ msgstr "Il biglietto si aggiorna tramite e-mail"
 msgid "Disable E-Mails"
 msgstr "Disabilita i messaggi e-mail"
 
-msgid "No ticket updates via e-mail. An e-mail is still sent when a ticket is assigned."
-msgstr "Nessun aggiornamento dei biglietti tramite e-mail. Viene comunque inviata un'e-mail quando viene assegnato un ticket."
+msgid ""
+"No ticket updates via e-mail. An e-mail is still sent when a ticket is "
+"assigned."
+msgstr ""
+"Nessun aggiornamento dei biglietti tramite e-mail. Viene comunque inviata "
+"un'e-mail quando viene assegnato un ticket."
 
 msgid "Enable E-Mails"
 msgstr "Abilita i messaggi e-mail"

--- a/src/onegov/town6/templates/layout.pt
+++ b/src/onegov/town6/templates/layout.pt
@@ -173,13 +173,7 @@
                             </div>
                         </div>
                     </div>
-
                     <div class="grid-container">
-                        <div class="grid-x">
-                            <div class="small-12 cell">
-                                <div tal:condition="not: layout.on_homepage" metal:use-macro="layout.macros['breadcrumbs']"></div>
-                            </div>
-                        </div>
                         <div class="grid-x alerts">
                             <div id="alert-boxes" class="cell small-12">
                                 <div tal:condition="form.errors|nothing" data-alert class="callout alert" data-closable>
@@ -195,6 +189,17 @@
                 </header>
 
                 <tal:b tal:define="on_homepage layout.on_homepage; sidebar_links layout.sidebar_links">
+                    <div class="header-image" tal:condition="not on_homepage and layout.org.theme_options.get('page-image-position', False) ==  'header'">
+                        <div class="dark-overlay"></div> 
+                        <div metal:define-slot="header-image"></div>
+                        <div class="grid-container">
+                            <div class="grid-x grid-padding-x">
+                                <div class="cell small-12">
+                                    <div class="text"><tal:b metal:define-slot="hi-title"></tal:b></div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
                     <article class="content without-sidebar-links" tal:condition="on_homepage">
                         <section role="main" id="content">
                             <div metal:define-slot="content"></div>
@@ -204,6 +209,7 @@
                         <div class="grid-container">
                             <div class="grid-x grid-padding-x">
                                 <div class="cell small-12">
+                                    <div tal:condition="not: layout.on_homepage" metal:use-macro="layout.macros['breadcrumbs']"></div>
                                     <section role="main" id="content">
                                         <h1 class="main-title">
                                             <div metal:define-slot="main-title">

--- a/src/onegov/town6/templates/macros.pt
+++ b/src/onegov/town6/templates/macros.pt
@@ -737,7 +737,7 @@
     <div class="grid-x grid-padding-x" tal:define="show_side_panel show_side_panel|False; location location|False; show_page_image page.show_page_image|None; files files|None;">
         <tal:b condition="not: people or files or contact or coordinates or location or show_side_panel or more_entries|False">
             <div class="small-12 cell page-content-main">
-                <img class="page-image" tal:condition="show_page_image" src="${page.page_image}">
+                <img class="page-image" tal:condition="show_page_image and layout.org.theme_options.get('page-image-position', 'as_content') ==  'as_content' and page.page_image" src="${page.page_image}">
                 <div metal:define-slot="before-lead"></div>
                 <div class="limit-line-width">
                     <span class="page-lead h5" tal:condition="lead" tal:content="structure lead" />
@@ -750,7 +750,7 @@
         </tal:b>
         <tal:b condition="people or files or contact or coordinates or show_side_panel or more_entries|False">
             <div class="small-12 medium-7 cell page-content-main">
-                <img class="page-image" tal:condition="show_page_image" src="${page.page_image}">
+                <img class="page-image" tal:condition="show_page_image and layout.org.theme_options.get('page-image-position', 'as_content') ==  'as_content' and page.page_image" src="${page.page_image}">
                 <div class="limit-line-width">
                     <span class="page-lead h5" tal:condition="lead" tal:content="structure lead" />
                 </div>

--- a/src/onegov/town6/templates/topic.pt
+++ b/src/onegov/town6/templates/topic.pt
@@ -1,5 +1,13 @@
-<div metal:use-macro="layout.base" i18n:domain="onegov.town6">
-    <tal:b metal:fill-slot="title">
+<div metal:use-macro="layout.base" i18n:domain="onegov.town6" tal:define="header layout.org.theme_options.get('page-image-position', False) ==  'header' and page.show_page_image and (page.page_image or layout.org.meta.get('standard_image', False))">
+    <tal:b metal:fill-slot="header-image" tal:condition="header">
+        <div tal:condition="header" class="page-image" style="background-image: url(${page.page_image if (page.show_page_image and page.page_image) else layout.org.meta.get('standard_image', None)}); background-size: cover; padding-bottom: 30%;"></div>
+    </tal:b>
+    <tal:b tal:condition="header" metal:fill-slot="hi-title">
+        <h1 class="main-title with-header-image">
+            ${title}
+        </h1>
+    </tal:b>
+    <tal:b tal:condition="not header" metal:fill-slot="title">
         ${title}
     </tal:b>
 

--- a/src/onegov/town6/theme/styles/homepage.scss
+++ b/src/onegov/town6/theme/styles/homepage.scss
@@ -46,15 +46,6 @@
 
         }
 
-        .dark-overlay {
-            background: rgb(0, 0, 0);
-            background: linear-gradient(0deg, rgba(0,0,0,0.4) 0%, rgba(0,0,0,0.4) 26%, rgba(0,0,0,0) 54%, rgba(0,0,0,0) 100%);
-            bottom: 0;
-            left: 0;
-            position: absolute;
-            right: 0;
-            top: 0;
-        }
     }
 
     .homepage-video,
@@ -63,7 +54,7 @@
         .text {
             bottom: 5rem;
             color: $white;
-            height: auto;
+            height: fit-content !important;
             position: absolute;
             text-shadow: 0 0 2em $black;
 
@@ -78,16 +69,6 @@
                 bottom: 2rem;
             }
 
-        }
-
-        .dark-overlay {
-            background: rgb(0, 0, 0);
-            background: linear-gradient(0deg, rgba(0,0,0,0.4) 0%, rgba(0,0,0,0.4) 26%, rgba(0,0,0,0) 54%, rgba(0,0,0,0) 100%);
-            bottom: 0;
-            left: 0;
-            position: absolute;
-            right: 0;
-            top: 0;
         }
 
         .orbit-image {

--- a/src/onegov/town6/theme/styles/org.scss
+++ b/src/onegov/town6/theme/styles/org.scss
@@ -147,7 +147,7 @@ footer {
 
 .main-title {
     line-height: 1.2;
-    margin-bottom: 1rem;
+    margin-bottom: 2rem;
     max-width: 30ex;
 }
 
@@ -1006,4 +1006,29 @@ ul.recipients {
     -moz-transform: rotate(180deg);
     -webkit-transform: rotate(180deg);
     transform: rotate(180deg);
+}
+
+.header-image {
+    margin-bottom: .5rem;
+    position: relative;
+
+    .text {
+        bottom: .5rem;
+        color: $white;
+        height: fit-content !important;
+        position: absolute;
+        text-shadow: 0 0 2em $black;
+    }
+}
+
+.dark-overlay {
+    background: rgb(0, 0, 0);
+    background: linear-gradient(0deg, rgba(0,0,0,0.4) 0%, rgba(0,0,0,0.4) 26%, rgba(0,0,0,0) 54%, rgba(0,0,0,0) 100%);
+    bottom: 0;
+    height: 100%;
+    left: 0;
+    max-height: 100%;
+    position: absolute;
+    right: 0;
+    top: 0;
 }


### PR DESCRIPTION
Please fill in the commit message below and work through the checklist. You can delete parts that are not needed, e.g. the optional description, the link to a ticket or irrelevant options of the checklist.

## Commit message

Town6: Add option for header images

Adds option to set the page images as fullscreen header images instead of content images.

TYPE: Feature
LINK: OGC-1202

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I considered adding a reviewer
- [ ] I have updated the PO files
- [ ] I have tested my code thoroughly by hand
    - [ ] I have tested styling changes/features on different browsers
    - [ ] I have tested javascript changes/features on different browsers
- [ ] I have added tests for my changes/features