### PR TITLE
Org: Sorts rendered `UploadMultipleField` in template macros

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -66,7 +66,7 @@ install_requires =
     bleach
     blinker
     bs4
-    chameleon<4.4.2
+    chameleon
     certifi
     click
     cssmin

--- a/src/onegov/form/display.py
+++ b/src/onegov/form/display.py
@@ -164,12 +164,12 @@ class UploadFieldRenderer(BaseRenderer):
 class UploadMultipleFieldRenderer(BaseRenderer):
 
     def __call__(self, field: 'Field') -> Markup:
-        return Markup('<br>').join(sorted(
+        return Markup('<br>').join(
             Markup('{filename} ({size})').format(
                 filename=data['filename'],
                 size=humanize.naturalsize(data['size'])
             ) for data in field.data if data
-        ))
+        )
 
 
 @registry.register_for('RadioField')

--- a/src/onegov/org/templates/macros.pt
+++ b/src/onegov/org/templates/macros.pt
@@ -628,7 +628,7 @@
 
                     </tal:b>
                 </tal:b>
-                <tal:b tal:case="'UploadMultipleField'" tal:repeat="iter zip(field, rendered.split(layout.Markup('<br>')))">
+                <tal:b tal:case="'UploadMultipleField'" tal:repeat="iter sorted(zip(field, rendered.split(layout.Markup('<br>'))), key=lambda i: i[0])">
                     <tal:b tal:define="subfield iter[0];
                                        rendered iter[1];
                                        url layout.field_download_link(subfield);

--- a/src/onegov/org/templates/macros.pt
+++ b/src/onegov/org/templates/macros.pt
@@ -628,7 +628,7 @@
 
                     </tal:b>
                 </tal:b>
-                <tal:b tal:case="'UploadMultipleField'" tal:repeat="iter sorted(zip(field, rendered.split(layout.Markup('<br>'))), key=lambda i: i[0])">
+                <tal:b tal:case="'UploadMultipleField'" tal:repeat="iter sorted(zip(field, rendered.split(layout.Markup('<br>'))), key=lambda i: i[1])">
                     <tal:b tal:define="subfield iter[0];
                                        rendered iter[1];
                                        url layout.field_download_link(subfield);

--- a/src/onegov/swissvotes/models/file.py
+++ b/src/onegov/swissvotes/models/file.py
@@ -94,7 +94,8 @@ class LocalizedFile:
     def __delete_by_locale__(self, instance, locale=None):
         if instance:
             name = self.__get_localized_name__(instance, locale)
-            for file in instance.files:
+            # create a copy of the list since we remove elements
+            for file in tuple(instance.files):
                 if file.name == name:
                     instance.files.remove(file)
 

--- a/src/onegov/town6/templates/macros.pt
+++ b/src/onegov/town6/templates/macros.pt
@@ -836,7 +836,7 @@
                         </div>
                     </tal:b>
                 </tal:b>
-                <tal:b tal:case="'UploadMultipleField'" tal:repeat="iter sorted(zip(field, rendered.split(layout.Markup('<br>'))), key=lambda i: i[0])">
+                <tal:b tal:case="'UploadMultipleField'" tal:repeat="iter sorted(zip(field, rendered.split(layout.Markup('<br>'))), key=lambda i: i[1])">
                     <tal:b tal:define="subfield iter[0];
                                        rendered iter[1];
                                        url layout.field_download_link(subfield);

--- a/src/onegov/town6/templates/macros.pt
+++ b/src/onegov/town6/templates/macros.pt
@@ -836,7 +836,7 @@
                         </div>
                     </tal:b>
                 </tal:b>
-                <tal:b tal:case="'UploadMultipleField'" tal:repeat="iter zip(field, rendered.split(layout.Markup('<br>')))">
+                <tal:b tal:case="'UploadMultipleField'" tal:repeat="iter sorted(zip(field, rendered.split(layout.Markup('<br>'))), key=lambda i: i[0])">
                     <tal:b tal:define="subfield iter[0];
                                        rendered iter[1];
                                        url layout.field_download_link(subfield);

--- a/tests/onegov/api/conftest.py
+++ b/tests/onegov/api/conftest.py
@@ -31,7 +31,7 @@ class Endpoint(ApiEndpoint):
 
     def __init__(self, app, extra_parameters=None, page=None):
         self._collection = Collection()
-        return super().__init__(app, extra_parameters, page)
+        super().__init__(app, extra_parameters, page)
 
     @property
     def collection(self):

--- a/tests/onegov/form/test_display.py
+++ b/tests/onegov/form/test_display.py
@@ -54,9 +54,9 @@ def test_render_upload_multiple_field():
     assert render_field(MockField('UploadMultipleField', [
         {'filename': 'a.txt', 'size': 3000},
         {},  # deleted file will not be rendered
-        {'filename': 'c.txt', 'size': 2000},  # should sort after b>.txt
+        {'filename': 'c.txt', 'size': 2000},
         {'filename': 'b>.txt', 'size': 1000},
-    ])) == 'a.txt (3.0 kB)<br>b&gt;.txt (1.0 kB)<br>c.txt (2.0 kB)'
+    ])) == 'a.txt (3.0 kB)<br>c.txt (2.0 kB)<br>b&gt;.txt (1.0 kB)'
 
 
 def test_render_radio_field():


### PR DESCRIPTION
## Commit message

Org: Sorts rendered `UploadMultipleField` in template macros

Previous solution caused labels and links to go out of sync

TYPE: Bugfix
LINK: OGC-1410

## Checklist

- [x] I have performed a self-review of my code
- [x] I have tested my code thoroughly by hand
