### PR TITLE
Add field for event registration URL

### DIFF
--- a/src/onegov/event/collections/events.py
+++ b/src/onegov/event/collections/events.py
@@ -576,6 +576,10 @@ class EventCollection(Pagination[Event]):
                 url = SubElement(event, 'url_web')
                 url.text = e.external_event_url
 
+            if e.event_registration_url:
+                registration = SubElement(event, 'url_web')
+                registration.text = e.event_registration_url
+
             if e.image:
                 image = SubElement(event, 'url_bild')
                 image.text = request.link(e.image)

--- a/src/onegov/event/models/event.py
+++ b/src/onegov/event/models/event.py
@@ -108,6 +108,9 @@ class Event(Base, OccurrenceMixin, TimestampMixin, SearchableContent,
     #: an external url for the event
     external_event_url: 'dict_property[str | None]' = content_property()
 
+    #: an external url for the event
+    event_registration_url: 'dict_property[str | None]' = content_property()
+
     #: the price of the event (a text field, not an amount)
     price: 'dict_property[str | None]' = content_property()
 

--- a/src/onegov/org/forms/event.py
+++ b/src/onegov/org/forms/event.py
@@ -171,6 +171,11 @@ class EventForm(Form):
         description="https://www.example.ch",
     )
 
+    event_registration_url = StringField(
+        label=_("Event Registration URL"),
+        description="/form/event-registration, https://www.example.ch",
+    )
+
     coordinates = CoordinatesField(
         label=_("Coordinates"),
         description=_("The marker can be moved by dragging it with the mouse"),
@@ -528,6 +533,8 @@ class EventImportForm(Form):
                                                         "number")),
             'external_event_url': self.request.translate(
                 _("External event URL")),
+            'event_registration_url': self.request.translate(
+                _("Event Registration URL")),
             'tags': self.request.translate(_("Tags")),
             'start': self.request.translate(_("From")),
             'end': self.request.translate(_("To")),

--- a/src/onegov/org/locale/de_CH/LC_MESSAGES/onegov.org.po
+++ b/src/onegov/org/locale/de_CH/LC_MESSAGES/onegov.org.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE 1.0\n"
-"POT-Creation-Date: 2024-01-11 10:41+0100\n"
+"POT-Creation-Date: 2024-01-22 10:47+0100\n"
 "PO-Revision-Date: 2022-03-15 10:21+0100\n"
 "Last-Translator: Marc Sommerhalder <marc.sommerhalder@seantis.ch>\n"
 "Language-Team: German\n"
@@ -704,6 +704,9 @@ msgstr "Wird als Kontakttelefonnummer angezeigt"
 
 msgid "External event URL"
 msgstr "Externe Event-URL"
+
+msgid "Event Registration URL"
+msgstr "Event Anmeldung URL"
 
 msgid "The marker can be moved by dragging it with the mouse"
 msgstr "Der Marker kann mit der Maus verschoben werden"
@@ -3868,6 +3871,9 @@ msgstr "Zurück"
 
 msgid "Link to organizers page"
 msgstr "Link zur Veranstalterseite"
+
+msgid "Link to registration"
+msgstr "Link zur Anmeldung"
 
 msgid "Export this event"
 msgstr "Diesen Termin exportieren"

--- a/src/onegov/org/locale/fr_CH/LC_MESSAGES/onegov.org.po
+++ b/src/onegov/org/locale/fr_CH/LC_MESSAGES/onegov.org.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE 1.0\n"
-"POT-Creation-Date: 2024-01-11 10:41+0100\n"
+"POT-Creation-Date: 2024-01-22 10:47+0100\n"
 "PO-Revision-Date: 2022-03-15 10:50+0100\n"
 "Last-Translator: Marc Sommerhalder <marc.sommerhalder@seantis.ch>\n"
 "Language-Team: French\n"
@@ -705,6 +705,9 @@ msgstr "Affiché comme numéro de téléphone de contact"
 
 msgid "External event URL"
 msgstr "URL de l'événement externe"
+
+msgid "Event Registration URL"
+msgstr "URL de l'inscription à l'événement"
 
 msgid "The marker can be moved by dragging it with the mouse"
 msgstr "Le curseur peut être déplacé avec la souris"
@@ -3871,6 +3874,9 @@ msgstr "Retour"
 
 msgid "Link to organizers page"
 msgstr "Lien vers la page de l'organisateur"
+
+msgid "Link to registration"
+msgstr "Lien vers l'inscription"
 
 msgid "Export this event"
 msgstr "Exporter cet événement"

--- a/src/onegov/org/locale/it_CH/LC_MESSAGES/onegov.org.po
+++ b/src/onegov/org/locale/it_CH/LC_MESSAGES/onegov.org.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"POT-Creation-Date: 2024-01-11 10:41+0100\n"
+"POT-Creation-Date: 2024-01-22 10:47+0100\n"
 "PO-Revision-Date: 2022-03-15 10:52+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -706,6 +706,9 @@ msgstr "Indicato come numero di telefono di contatto"
 
 msgid "External event URL"
 msgstr "URL evento esterno"
+
+msgid "Event Registration URL"
+msgstr "URL di registrazione all'evento"
 
 msgid "The marker can be moved by dragging it with the mouse"
 msgstr "L'indicatore può essere spostato trascinandolo con il mouse"
@@ -3863,6 +3866,9 @@ msgstr "Indietro"
 
 msgid "Link to organizers page"
 msgstr "Link alla pagina dell'organizzatore"
+
+msgid "Link to registration"
+msgstr "Link alla registrazione"
 
 msgid "Export this event"
 msgstr "Esporta questo evento"

--- a/src/onegov/org/templates/occurrence.pt
+++ b/src/onegov/org/templates/occurrence.pt
@@ -30,6 +30,10 @@
                     <a tal:condition="event_link" class="button" href="${event_link}" i18n:translate="">Link to organizers page</a>
                 </div>
 
+                <div class="occurence-link" tal:define="registration_link occurrence.event.content.get('event_registration_url')">
+                    <a tal:condition="registration_link" class="button" href="${registration_link}" i18n:translate="">Link to registration</a>
+                </div>
+
                 <div class="occurrence-description">
                     <p tal:content="structure description"></p>
                 </div>

--- a/src/onegov/town6/locale/de_CH/LC_MESSAGES/onegov.town6.po
+++ b/src/onegov/town6/locale/de_CH/LC_MESSAGES/onegov.town6.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: OneGov Cloud 1.0\n"
-"POT-Creation-Date: 2023-11-29 11:18+0100\n"
+"POT-Creation-Date: 2024-01-22 10:58+0100\n"
 "PO-Revision-Date: 2021-03-03 16:24+0100\n"
 "Last-Translator: Lukas Burkhard <lukas.burkhard@seantis.ch>\n"
 "Language-Team: German\n"
@@ -36,11 +36,9 @@ msgid "Confirmation"
 msgstr "Bestätigung"
 
 msgid ""
-"I confirm that I am aware that this chat will be saved and the history will "
-"be sent to me by email."
-msgstr ""
 "Ich bestätige, dass mir bewusst ist, dass dieser Chat gespeichert und der "
 "Verlauf an mich per Mail gesendet wird."
+msgstr ""
 
 msgid "Chat ID"
 msgstr "Chat ID"
@@ -635,6 +633,9 @@ msgid "Something missing? Propose a new entry."
 msgstr ""
 "Fehlt ein Eintrag im Verzeichnis? Schlagen Sie einen neuen Eintrag vor."
 
+msgid "Internal Notes"
+msgstr ""
+
 msgid "External link"
 msgstr "Externe Verknüpfung"
 
@@ -956,9 +957,6 @@ msgstr "Initiiert"
 
 msgid "Submitted"
 msgstr "Gemeldet"
-
-msgid "submitted"
-msgstr "angemeldet"
 
 msgid "Withdrawn"
 msgstr "Zurückgezogen"
@@ -1740,6 +1738,9 @@ msgstr ""
 msgid "Link to organizers page"
 msgstr "Link zur Veranstalterseite"
 
+msgid "Link to registration"
+msgstr "Link zur Anmeldung"
+
 msgid "Export this event"
 msgstr "Diesen Termin exportieren"
 
@@ -1829,6 +1830,9 @@ msgstr ""
 
 msgid "Unsubscribe"
 msgstr "Abmelden"
+
+msgid "submitted"
+msgstr "angemeldet"
 
 msgid "No dates found, please select dates in the calendar first"
 msgstr "Keine Termine gefunden, bitte wählen Sie erst Termine im Kalender aus"
@@ -2278,6 +2282,13 @@ msgid ""
 msgstr ""
 "Gehen Sie mit Vorsicht vor. Tickets und die darin enthaltenen Daten können "
 "unwiderruflich gelöscht werden."
+
+#~ msgid ""
+#~ "I confirm that I am aware that this chat will be saved and the history "
+#~ "will be sent to me by email."
+#~ msgstr ""
+#~ "Ich bestätige, dass mir bewusst ist, dass dieser Chat gespeichert und der "
+#~ "Verlauf an mich per Mail gesendet wird."
 
 #~ msgid "Chat title"
 #~ msgstr "Chat Titel"

--- a/src/onegov/town6/locale/fr_CH/LC_MESSAGES/onegov.town6.po
+++ b/src/onegov/town6/locale/fr_CH/LC_MESSAGES/onegov.town6.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: OneGov Cloud 1.0\n"
-"POT-Creation-Date: 2023-11-29 11:18+0100\n"
+"POT-Creation-Date: 2024-01-22 10:58+0100\n"
 "PO-Revision-Date: 2021-03-03 14:04+0100\n"
 "Last-Translator: Lukas Burkhard <lukas.burkhard@seantis.ch>\n"
 "Language-Team: French\n"
@@ -36,11 +36,9 @@ msgid "Confirmation"
 msgstr "Confirmation"
 
 msgid ""
-"I confirm that I am aware that this chat will be saved and the history will "
-"be sent to me by email."
+"Ich bestätige, dass mir bewusst ist, dass dieser Chat gespeichert und der "
+"Verlauf an mich per Mail gesendet wird."
 msgstr ""
-"Je confirme que je suis conscient(e) que ce chat est enregistré et que "
-"l'historique m'est envoyé par e-mail."
 
 msgid "Chat ID"
 msgstr "Chat ID"
@@ -629,6 +627,9 @@ msgstr "Proposer une entrée"
 msgid "Something missing? Propose a new entry."
 msgstr "Il manque quelque chose? Proposez une nouvelle entrée."
 
+msgid "Internal Notes"
+msgstr ""
+
 msgid "External link"
 msgstr "Lien externe"
 
@@ -952,9 +953,6 @@ msgstr "Initié"
 
 msgid "Submitted"
 msgstr "Soumis"
-
-msgid "submitted"
-msgstr "soumis"
 
 msgid "Withdrawn"
 msgstr "Retiré"
@@ -1735,6 +1733,9 @@ msgstr ""
 msgid "Link to organizers page"
 msgstr "Lien vers la page de l'organisateur"
 
+msgid "Link to registration"
+msgstr "Lien vers l'inscription"
+
 msgid "Export this event"
 msgstr "Exporter cet événement"
 
@@ -1825,6 +1826,9 @@ msgstr ""
 
 msgid "Unsubscribe"
 msgstr "Se désabonner"
+
+msgid "submitted"
+msgstr "soumis"
 
 msgid "No dates found, please select dates in the calendar first"
 msgstr "Aucune date trouvée, sélectionnez les dates dans le calendrier d'abord"
@@ -2281,6 +2285,13 @@ msgid ""
 msgstr ""
 "Procédez avec prudence. Les billets et les données qu'ils contiennent "
 "peuvent être irrévocablement supprimés."
+
+#~ msgid ""
+#~ "I confirm that I am aware that this chat will be saved and the history "
+#~ "will be sent to me by email."
+#~ msgstr ""
+#~ "Je confirme que je suis conscient(e) que ce chat est enregistré et que "
+#~ "l'historique m'est envoyé par e-mail."
 
 #~ msgid "Chat title"
 #~ msgstr "Title du Chat"

--- a/src/onegov/town6/locale/it_CH/LC_MESSAGES/onegov.town6.po
+++ b/src/onegov/town6/locale/it_CH/LC_MESSAGES/onegov.town6.po
@@ -1,7 +1,7 @@
 # This file was generated from translations.town6.xlsx
 msgid ""
 msgstr ""
-"POT-Creation-Date: 2023-11-29 11:18+0100\n"
+"POT-Creation-Date: 2024-01-22 10:58+0100\n"
 "PO-Revision-Date: 2021-09-27 16:02+0200\n"
 "Language: it_CH\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -27,11 +27,9 @@ msgid "Confirmation"
 msgstr "Conferma"
 
 msgid ""
-"I confirm that I am aware that this chat will be saved and the history will "
-"be sent to me by email."
+"Ich bestätige, dass mir bewusst ist, dass dieser Chat gespeichert und der "
+"Verlauf an mich per Mail gesendet wird."
 msgstr ""
-"Confermo di essere consapevole che questa chat sarà salvata e che la "
-"cronologia mi sarà inviata via e-mail."
 
 msgid "Chat ID"
 msgstr "Chat ID "
@@ -41,8 +39,7 @@ msgstr "Immagini"
 
 msgid "Choose the position of the page images on the content pages"
 msgstr ""
-"Scegliere la posizione delle immagini di pagina nelle pagine di "
-"contenuto"
+"Scegliere la posizione delle immagini di pagina nelle pagine di contenuto"
 
 msgid "Page image position"
 msgstr "Posizione dell'immagine della pagina"
@@ -628,6 +625,9 @@ msgstr "Proponi un elemento"
 msgid "Something missing? Propose a new entry."
 msgstr "Manca qualcosa? Proponi un nuovo elemento."
 
+msgid "Internal Notes"
+msgstr ""
+
 msgid "External link"
 msgstr "Collegamento esterno"
 
@@ -950,9 +950,6 @@ msgstr "Avviato"
 
 msgid "Submitted"
 msgstr "Inviato"
-
-msgid "submitted"
-msgstr "inviato"
 
 msgid "Withdrawn"
 msgstr "Ritirato"
@@ -1727,6 +1724,9 @@ msgstr ""
 msgid "Link to organizers page"
 msgstr "Link alla pagina dell'organizzatore"
 
+msgid "Link to registration"
+msgstr "Link alla registrazione"
+
 msgid "Export this event"
 msgstr "Esporta questo evento"
 
@@ -1818,6 +1818,9 @@ msgstr ""
 
 msgid "Unsubscribe"
 msgstr "Annulla iscrizione"
+
+msgid "submitted"
+msgstr "inviato"
 
 msgid "No dates found, please select dates in the calendar first"
 msgstr "Nessuna data trovata, seleziona prima le date nel calendario"
@@ -2275,6 +2278,13 @@ msgid ""
 msgstr ""
 "Procedere con cautela. I biglietti e i dati in essi contenuti possono essere "
 "irrevocabilmente cancellati."
+
+#~ msgid ""
+#~ "I confirm that I am aware that this chat will be saved and the history "
+#~ "will be sent to me by email."
+#~ msgstr ""
+#~ "Confermo di essere consapevole che questa chat sarà salvata e che la "
+#~ "cronologia mi sarà inviata via e-mail."
 
 #~ msgid "Chat title"
 #~ msgstr "Titolo della chat"

--- a/src/onegov/town6/templates/occurrence.pt
+++ b/src/onegov/town6/templates/occurrence.pt
@@ -29,6 +29,10 @@
                     <a tal:condition="event_link" class="button" href="${event_link}" i18n:translate="">Link to organizers page</a>
                 </div>
 
+                <div class="occurence-link" tal:define="registration_link occurrence.event.content.get('event_registration_url')">
+                    <a tal:condition="registration_link" class="button" href="${registration_link}" i18n:translate="">Link to registration</a>
+                </div>
+
                 <div class="occurrence-description">
                     <p tal:content="structure description"></p>
                 </div>


### PR DESCRIPTION
Please fill in the commit message below and work through the checklist. You can delete parts that are not needed, e.g. the optional description, the link to a ticket or irrelevant options of the checklist.

## Commit message

Town6: Add field for event registration URL

TYPE: Feature
LINK: OGC-1420

## Checklist

- [x] I have performed a self-review of my code
- [x] I have updated the PO files
- [x] I made changes/features for both org and town6
- [x] I have updated the election_day API docs
- [x] I have tested my code thoroughly by hand