### PR TITLE
Org: Protect `DirectoryFile` when linked to an entry with mTAN access

### DIFF
--- a/src/onegov/directory/models/directory.py
+++ b/src/onegov/directory/models/directory.py
@@ -75,6 +75,20 @@ INHERIT = _Sentinel.INHERIT
 class DirectoryFile(File):
     __mapper_args__ = {'polymorphic_identity': 'directory'}
 
+    if TYPE_CHECKING:
+        # NOTE: this should always be exactly one entry, since we use
+        #       a one-to-many relationship on DirectoryEntry. Technically
+        #       it's possible to create a DirectoryFile, that isn't linked
+        #       to any directory entry, but generally this shouldn't happen
+        linked_directory_entries: relationship[list[DirectoryEntry]]
+
+    @property
+    def directory_entry(self) -> 'DirectoryEntry | None':
+        # we gracefully handle if there are no linked entries, even though
+        # there should always be exactly one
+        entries = self.linked_directory_entries
+        return entries[0] if entries else None
+
     @property
     def access(self) -> str:
         # we don't want these files to show up in search engines

--- a/src/onegov/file/integration.py
+++ b/src/onegov/file/integration.py
@@ -530,6 +530,10 @@ def view_file_head(self: File, request: 'CoreRequest') -> 'StoredFile':
 
 @DepotApp.view(model=File, name='thumbnail', render=render_depot_file,
                permission=Public, request_method='HEAD')
+@DepotApp.view(model=File, name='small', render=render_depot_file,
+               permission=Public, request_method='HEAD')
+@DepotApp.view(model=File, name='medium', render=render_depot_file,
+               permission=Public, request_method='HEAD')
 def view_thumbnail_head(
     self: File,
     request: 'CoreRequest'

--- a/tests/onegov/directory/test_orm.py
+++ b/tests/onegov/directory/test_orm.py
@@ -323,7 +323,9 @@ def test_files(session):
     assert iphone_found.values['file']['filename'] == 'press-release.txt'
     assert session.query(File).count() == 1
 
-    file_id = session.query(File).one().id
+    file = session.query(File).one()
+    assert file.directory_entry == iphone_found
+    file_id = file.id
     press_releases.update(iphone_found, dict(
         title="iPhone Found in Ancient Ruins in the Andes",
         file=Bunch(data=None, action='keep')  # keep the file -> onegov.form


### PR DESCRIPTION
## Commit message

Org: Protect `DirectoryFile` when linked to an entry with mTAN access

Previously we relied on file links being impossible to predict, but since someone still may maliciously share a link, we're better off actually protecting the file in simple cases like this.

TYPE: Feature
LINK: OGC-1428

## Checklist

- [x] I have performed a self-review of my code
- [x] I have tested my code thoroughly by hand
- [x] I have added tests for my changes/features
