### PR TITLE
Org: Allows uploaded files to appear in public search results more often

### DIFF
--- a/src/onegov/activity/models/activity.py
+++ b/src/onegov/activity/models/activity.py
@@ -1,7 +1,7 @@
 from onegov.activity.models.occasion import Occasion
 from onegov.activity.models.period import Period
 from onegov.activity.utils import extract_thumbnail, extract_municipality
-from onegov.core.orm import Base
+from onegov.core.orm import Base, observes
 from onegov.core.orm.mixins import (
     content_property,
     ContentMixin,
@@ -16,7 +16,6 @@ from sqlalchemy import exists, and_, desc
 from sqlalchemy.dialects.postgresql import HSTORE
 from sqlalchemy.ext.mutable import MutableDict
 from sqlalchemy.orm import object_session, relationship
-from sqlalchemy_utils import observes
 from uuid import uuid4
 
 

--- a/src/onegov/activity/models/occasion.py
+++ b/src/onegov/activity/models/occasion.py
@@ -3,7 +3,7 @@ import sedate
 from datetime import date, datetime, timedelta
 from decimal import Decimal
 from onegov.activity.models.occasion_date import DAYS
-from onegov.core.orm import Base
+from onegov.core.orm import Base, observes
 from onegov.core.orm.mixins import TimestampMixin
 from onegov.core.orm.types import UUID
 from psycopg2.extras import NumericRange
@@ -19,7 +19,7 @@ from sqlalchemy.dialects.postgresql import ARRAY, INT4RANGE
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.sql.functions import coalesce
 from sqlalchemy.orm import relationship, object_session, validates
-from sqlalchemy_utils import aggregated, observes
+from sqlalchemy_utils import aggregated
 from uuid import uuid4
 
 

--- a/src/onegov/ballot/models/election/election.py
+++ b/src/onegov/ballot/models/election/election.py
@@ -8,7 +8,7 @@ from onegov.ballot.models.mixins import StatusMixin
 from onegov.ballot.models.mixins import summarized_property
 from onegov.ballot.models.mixins import TitleTranslationsMixin
 from onegov.ballot.models.party_result.mixins import PartyResultsOptionsMixin
-from onegov.core.orm import Base
+from onegov.core.orm import Base, observes
 from onegov.core.orm import translation_hybrid
 from onegov.core.orm.mixins import ContentMixin
 from onegov.core.orm.mixins import dict_property
@@ -20,7 +20,6 @@ from sqlalchemy import func
 from sqlalchemy import Integer
 from sqlalchemy import select
 from sqlalchemy import Text
-from sqlalchemy_utils import observes
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import backref
 from sqlalchemy.orm import object_session

--- a/src/onegov/ballot/models/election_compound/election_compound.py
+++ b/src/onegov/ballot/models/election_compound/election_compound.py
@@ -10,7 +10,7 @@ from onegov.ballot.models.party_result.mixins import (
     HistoricalPartyResultsMixin)
 from onegov.ballot.models.party_result.mixins import PartyResultsCheckMixin
 from onegov.ballot.models.party_result.mixins import PartyResultsOptionsMixin
-from onegov.core.orm import Base
+from onegov.core.orm import Base, observes
 from onegov.core.orm import translation_hybrid
 from onegov.core.orm.mixins import ContentMixin
 from onegov.core.orm.mixins import dict_property
@@ -21,7 +21,6 @@ from onegov.file import NamedFile
 from sqlalchemy import Column, Boolean
 from sqlalchemy import Date
 from sqlalchemy import Text
-from sqlalchemy_utils import observes
 from sqlalchemy.orm import backref
 from sqlalchemy.orm import object_session
 from sqlalchemy.orm import relationship

--- a/src/onegov/ballot/models/vote/vote.py
+++ b/src/onegov/ballot/models/vote/vote.py
@@ -7,7 +7,7 @@ from onegov.ballot.models.mixins import TitleTranslationsMixin
 from onegov.ballot.models.vote.ballot import Ballot
 from onegov.ballot.models.vote.ballot_result import BallotResult
 from onegov.ballot.models.vote.mixins import DerivedBallotsCountMixin
-from onegov.core.orm import Base
+from onegov.core.orm import Base, observes
 from onegov.core.orm import translation_hybrid
 from onegov.core.orm.mixins import ContentMixin
 from onegov.core.orm.mixins import dict_property
@@ -18,7 +18,6 @@ from sqlalchemy import Date
 from sqlalchemy import func
 from sqlalchemy import select
 from sqlalchemy import Text
-from sqlalchemy_utils import observes
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import backref
 from sqlalchemy.orm import object_session

--- a/src/onegov/core/orm/__init__.py
+++ b/src/onegov/core/orm/__init__.py
@@ -1,6 +1,7 @@
 import psycopg2
 
 from onegov.core.orm.cache import orm_cached
+from onegov.core.orm.observer import observes
 from onegov.core.orm.session_manager import SessionManager, query_schemas
 from onegov.core.orm.sql import as_selectable, as_selectable_from_path
 from sqlalchemy import event, inspect
@@ -160,6 +161,7 @@ __all__ = [
     'as_selectable_from_path',
     'translation_hybrid',
     'find_models',
+    'observes',
     'orm_cached',
     'query_schemas'
 ]

--- a/src/onegov/core/orm/abstract/adjacency_list.py
+++ b/src/onegov/core/orm/abstract/adjacency_list.py
@@ -1,7 +1,7 @@
 from enum import Enum
 from itertools import chain
 from lazy_object_proxy import Proxy
-from onegov.core.orm import Base
+from onegov.core.orm import Base, observes
 from onegov.core.utils import normalize_for_url, increment_name, is_sorted
 from sqlalchemy import Column, ForeignKey, Integer, Text
 from sqlalchemy.ext.declarative import declared_attr
@@ -15,7 +15,6 @@ from sqlalchemy.orm import (
 from sqlalchemy.orm.attributes import get_history
 from sqlalchemy.schema import Index
 from sqlalchemy.sql.expression import column, nullsfirst
-from sqlalchemy_utils import observes
 
 
 from typing import Any, Generic, TypeVar, TYPE_CHECKING

--- a/src/onegov/core/orm/abstract/associable.py
+++ b/src/onegov/core/orm/abstract/associable.py
@@ -202,19 +202,33 @@ def associated(
         uselist = not cardinality.endswith('to-one')
 
     def descriptor(cls: type['Base']) -> 'rel[list[_M]] | rel[_M | None]':
+        # we can't use sqlalchemy.inspect, since our type isn't finalized
+        # so we have to jump through some hoops to find out what is our
+        # primary key
+        table = cls.metadata.tables.get(cls.__tablename__)
+        if table is not None:
+            # in this case we already know what the primary key is
+            pk_name = next(iter(table.primary_key)).name
+        else:
+            # we could try to look at our __dict__ to find the primary key
+            # but for now let's keep things simple
+            pk_name = 'id'
+
         name = '{}_for_{}_{}'.format(
             associated_cls.__tablename__,
             cls.__tablename__,
             attribute_name
         )
-        key = '{}_id'.format(cls.__tablename__)
-        target = '{}.id'.format(cls.__tablename__)
+        key = f'{cls.__tablename__}_{pk_name}'
+        target = f'{cls.__tablename__}.{pk_name}'
 
         if backref_suffix == '__tablename__':
             backref_name = 'linked_{}'.format(cls.__tablename__)
         else:
             backref_name = 'linked_{}'.format(backref_suffix)
 
+        # FIXME: we probably should inspect associated_cls to find out
+        #        its actual primary key
         association_key = associated_cls.__name__.lower() + '_id'
         association_id = associated_cls.id
 

--- a/src/onegov/core/orm/abstract/associable.py
+++ b/src/onegov/core/orm/abstract/associable.py
@@ -222,7 +222,10 @@ def associated(
         # has to get inserted we only create a new instance for the
         # association table, if we haven't already created it, we
         # also only need to create the backref once, since we punt
-        # on polymorphism anyways
+        # on polymorphism anyways, but in the case were we don't create
+        # a backref we need to set back_populates so introspection
+        # is aware that the two relationships are inverses of one
+        # another, otherwise things like @observes won't work.
         association_table = cls.metadata.tables.get(name)
         if association_table is None:
             association_table = Table(
@@ -243,8 +246,10 @@ def associated(
                 backref_name,
                 enable_typechecks=False
             )
+            back_populates = None
         else:
             file_backref = None
+            back_populates = backref_name
 
         assert issubclass(associated_cls, Associable)
 
@@ -275,6 +280,7 @@ def associated(
             # Have a look at onegov.chat.models.Message to see how that has
             # been done.
             backref=file_backref,
+            back_populates=back_populates,
             single_parent=single_parent,
             cascade=cascade,
             uselist=uselist,

--- a/src/onegov/core/orm/observer.py
+++ b/src/onegov/core/orm/observer.py
@@ -1,0 +1,152 @@
+import sqlalchemy_utils.observer
+from dectate.tool import resolve_dotted_name
+from functools import wraps
+from sqlalchemy.event import contains, listen, remove
+
+
+from typing import Any, ClassVar, TypeVar, TYPE_CHECKING
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from onegov.core.framework import Framework
+    from sqlalchemy.orm import Mapper
+
+    _F = TypeVar('_F', bound=Callable[..., Any])
+
+
+MISSING = object()
+
+
+class ScopedPropertyObserver(sqlalchemy_utils.observer.PropertyObserver):
+    """
+    This subclass of `PropertyObserver` doesn't register itself globally.
+
+    Having all observers listen for each application is both wasteful and
+    can lead to bugs if some tables only exist for some applications.
+
+    We should never use the base class, since that will always cause all
+    observers to trigger regardless of whether we used the scoped observer
+    or not.
+    """
+
+    _global_observer: ClassVar['ScopedPropertyObserver']
+    _scoped_observers: ClassVar[dict[str, 'ScopedPropertyObserver']]
+    _scoped_observers = {}
+
+    def __new__(cls, dotted_name: str | None) -> 'ScopedPropertyObserver':
+
+        # special case global scope
+        if dotted_name is None:
+            if not hasattr(cls, '_global_observer'):
+                cls._global_observer = super().__new__(cls)
+            return cls._global_observer
+
+        if dotted_name not in cls._scoped_observers:
+            cls._scoped_observers[dotted_name] = super().__new__(cls)
+        return cls._scoped_observers[dotted_name]
+
+    def __init__(self, dotted_name: str | None) -> None:
+        """
+        In order to get ourselves out of circular dependency hell we
+        accept a dotted_name in place of the application class that
+        defines the scope of the observer.
+
+        The dotted_name will be resolved once enter_scope is called.
+        """
+        super().__init__()
+        self.dotted_name = dotted_name
+        if dotted_name is None:
+            # global scope is always active
+            self.activate()
+
+    @property
+    def scope(self) -> type[object]:
+        assert self.dotted_name is not None
+        application_cls = resolve_dotted_name(self.dotted_name)
+        assert isinstance(application_cls, type)
+
+        # reify this so we only look the scope up once
+        self.__dict__['scope'] = application_cls
+        return application_cls
+
+    def register_listeners(self) -> None:
+        for cls, event, func in self.listener_args:
+            # don't register before_flush
+            if event == 'before_flush':
+                continue
+
+            if not contains(cls, event, func):
+                listen(cls, event, func)
+
+    def activate(self) -> None:
+        for cls, event, func in self.listener_args:
+            # only register before_flush
+            if event != 'before_flush':
+                continue
+
+            if not contains(cls, event, func):
+                listen(cls, event, func)
+
+    def deactivate(self) -> None:
+        for cls, event, func in self.listener_args:
+            # only deregister before_flush
+            if event != 'before_flush':
+                continue
+
+            if contains(cls, event, func):
+                remove(cls, event, func)
+
+    def update_generator_registry(
+        self,
+        mapper: 'Mapper',
+        class_: type[Any]
+    ) -> None:
+
+        for generator in class_.__dict__.values():
+            if getattr(
+                generator,
+                '__observes_scope__',
+                MISSING
+            ) == self.dotted_name:
+
+                self.generator_registry[class_].append(
+                    generator
+                )
+
+    @classmethod
+    def enter_scope(cls, application: 'Framework') -> None:
+        for observer in cls._scoped_observers.values():
+            if isinstance(application, observer.scope):
+                observer.activate()
+            else:
+                observer.deactivate()
+
+    def __repr__(self) -> str:
+        return '<ScopedPropertyObserver>'
+
+
+def observes(
+    *paths: str,
+    scope: str | None = None
+) -> 'Callable[[_F], _F]':
+
+    observer = ScopedPropertyObserver(scope)
+    observer.register_listeners()
+
+    def decorator(func: '_F') -> '_F':
+        @wraps(func)
+        def wrapper(self: Any, *args: Any, **kwargs: Any) -> Any:
+            return func(self, *args, **kwargs)
+
+        wrapper.__observes__ = paths  # type:ignore[attr-defined]
+        wrapper.__observes_scope__ = scope  # type:ignore[attr-defined]
+        return wrapper  # type:ignore[return-value]
+    return decorator
+
+
+if hasattr(sqlalchemy_utils.observer, 'observer'):
+    # make sure this observer doesn't mess with us
+    # remove_listeners doesn't check if the listeners are there
+    # so we call register_listeners to make sure we can remove them
+    sqlalchemy_utils.observer.observer.register_listeners()
+    sqlalchemy_utils.observer.observer.remove_listeners()
+    delattr(sqlalchemy_utils.observer, 'observer')

--- a/src/onegov/directory/models/directory.py
+++ b/src/onegov/directory/models/directory.py
@@ -4,7 +4,7 @@ from enum import Enum
 from onegov.core.cache import instance_lru_cache
 from onegov.core.cache import lru_cache
 from onegov.core.crypto import random_token
-from onegov.core.orm import Base
+from onegov.core.orm import Base, observes
 from onegov.core.orm.mixins import ContentMixin
 from onegov.core.orm.mixins import TimestampMixin
 from onegov.core.orm.types import UUID
@@ -12,7 +12,7 @@ from onegov.core.utils import normalize_for_url
 from onegov.directory.errors import ValidationError, DuplicateEntryError
 from onegov.directory.migration import DirectoryMigration
 from onegov.directory.types import DirectoryConfigurationStorage
-from onegov.file import File
+from onegov.file import File, MultiAssociatedFiles
 from onegov.file.utils import as_fileintent
 from onegov.form import flatten_fieldsets, parse_formcode, parse_form
 from onegov.search import SearchableContent
@@ -24,7 +24,7 @@ from sqlalchemy import Text
 from sqlalchemy.orm import object_session
 from sqlalchemy.orm import relationship
 from sqlalchemy.orm.attributes import InstrumentedAttribute
-from sqlalchemy_utils import aggregated, observes
+from sqlalchemy_utils import aggregated
 from uuid import uuid4
 from wtforms import FieldList
 
@@ -95,7 +95,8 @@ class DirectoryFile(File):
         return 'secret' if self.published else 'private'
 
 
-class Directory(Base, ContentMixin, TimestampMixin, SearchableContent):
+class Directory(Base, ContentMixin, TimestampMixin,
+                SearchableContent, MultiAssociatedFiles):
     """ A directory of entries that share a common data structure. For example,
     a directory of people, of emergency services or playgrounds.
 

--- a/src/onegov/file/models/file.py
+++ b/src/onegov/file/models/file.py
@@ -7,7 +7,7 @@ from contextlib import contextmanager
 from collections import defaultdict
 from depot.fields.sqlalchemy import UploadedFileField as UploadedFileFieldBase
 from onegov.core.crypto import random_token
-from onegov.core.orm import Base
+from onegov.core.orm import Base, observes
 from onegov.core.orm.abstract import Associable
 from onegov.core.orm.mixins import TimestampMixin
 from onegov.core.orm.types import JSON, UTCDateTime
@@ -28,7 +28,6 @@ from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import deferred
 from sqlalchemy.orm import object_session, Session
 from sqlalchemy.orm.attributes import flag_modified
-from sqlalchemy_utils import observes
 from time import monotonic
 
 
@@ -292,6 +291,9 @@ class File(Base, Associable, TimestampMixin):
             else_=text('NULL')
         ), UTCDateTime)
 
+    # NOTE: Technically we could scope these observes to DepotApp, but
+    #       then we would need to instantiate a DepotApp for testing
+    #       which could get annoying
     @observes('reference')
     def reference_observer(self, reference: 'UploadedFile') -> None:
         if 'checksum' in self.reference:

--- a/src/onegov/file/models/file.py
+++ b/src/onegov/file/models/file.py
@@ -249,6 +249,10 @@ class File(Base, Associable, TimestampMixin):
     #: lost afterwards)
     stats: 'Column[FileStats | None]' = deferred(Column(JSON, nullable=True))
 
+    #: arbitrary additional meta data, which can be used by subclasses to
+    #: store additional information using e.g. `meta_property`
+    meta: 'Column[dict[str, Any]]' = Column(JSON, nullable=False, default=dict)
+
     if TYPE_CHECKING:
         # forward declare backref
         filesets: 'relationship[list[FileSet]]'

--- a/src/onegov/form/collection.py
+++ b/src/onegov/form/collection.py
@@ -192,8 +192,15 @@ class FormDefinitionCollection:
             self.session.flush()
 
         # this will fail if there are any submissions left
-        self.query().filter(FormDefinition.name == name).delete('fetch')
-        self.session.flush()
+        definition = self.by_name(name)
+        if definition:
+            if definition.files:
+                # unlink any linked files before deleting
+                definition.files = []
+                self.session.flush()
+
+            self.session.delete(definition)
+            self.session.flush()
 
     def by_name(self, name: str) -> FormDefinition | None:
         """ Returns the given form by name or None. """

--- a/src/onegov/form/collection.py
+++ b/src/onegov/form/collection.py
@@ -191,7 +191,6 @@ class FormDefinitionCollection:
             registration_windows.delete()
             self.session.flush()
 
-        # this will fail if there are any submissions left
         definition = self.by_name(name)
         if definition:
             if definition.files:
@@ -199,8 +198,9 @@ class FormDefinitionCollection:
                 definition.files = []
                 self.session.flush()
 
-            self.session.delete(definition)
-            self.session.flush()
+        # this will fail if there are any submissions left
+        self.query().filter(FormDefinition.name == name).delete('fetch')
+        self.session.flush()
 
     def by_name(self, name: str) -> FormDefinition | None:
         """ Returns the given form by name or None. """

--- a/src/onegov/form/models/definition.py
+++ b/src/onegov/form/models/definition.py
@@ -9,6 +9,7 @@ from onegov.form.parser import parse_form
 from onegov.form.utils import hash_definition
 from onegov.form.extensions import Extendable
 from sqlalchemy import Column, Text
+from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import object_session, relationship
 from sqlalchemy_utils import observes
 
@@ -27,6 +28,12 @@ class FormDefinition(Base, ContentMixin, TimestampMixin, Extendable):
     """ Defines a form stored in the database. """
 
     __tablename__ = 'forms'
+
+    # for better compatibility with generic code that expects an id
+    # this is just an alias for `name`, which is our primary key
+    @hybrid_property
+    def id(self) -> str:
+        return self.name
 
     #: the name of the form (key, part of the url)
     name: 'Column[str]' = Column(Text, nullable=False, primary_key=True)

--- a/src/onegov/form/models/definition.py
+++ b/src/onegov/form/models/definition.py
@@ -156,11 +156,11 @@ class FormDefinition(Base, ContentMixin, TimestampMixin,
             self.extensions or [],
         )
 
-    @observes('definition', scope='onegov.form.integration.FormApp')
+    @observes('definition')
     def definition_observer(self, definition: str) -> None:
         self.checksum = hash_definition(definition)
 
-    @observes('title', scope='onegov.form.integration.FormApp')
+    @observes('title')
     def title_observer(self, title: str) -> None:
         self.order = normalize_for_url(title)
 

--- a/src/onegov/form/models/submission.py
+++ b/src/onegov/form/models/submission.py
@@ -211,11 +211,11 @@ class FormSubmission(Base, TimestampMixin, Payable, AssociatedFiles,
             return form._fields[email_fields[0]].data
         return None
 
-    @observes('definition', scope='onegov.form.integration.FormApp')
+    @observes('definition')
     def definition_observer(self, definition: str) -> None:
         self.checksum = hash_definition(definition)
 
-    @observes('state', scope='onegov.form.integration.FormApp')
+    @observes('state')
     def state_observer(self, state: 'SubmissionState') -> None:
         if self.state == 'complete':
             form = self.form_class(data=self.data)

--- a/src/onegov/form/models/submission.py
+++ b/src/onegov/form/models/submission.py
@@ -1,6 +1,6 @@
 import html
 
-from onegov.core.orm import Base
+from onegov.core.orm import Base, observes
 from onegov.core.orm.mixins import TimestampMixin, dict_property, meta_property
 from onegov.core.orm.types import JSON, UUID
 from onegov.core.orm.types import UTCDateTime
@@ -20,7 +20,6 @@ from sqlalchemy import ForeignKey
 from sqlalchemy import Integer
 from sqlalchemy import Text
 from sqlalchemy.ext.hybrid import hybrid_property
-from sqlalchemy_utils import observes
 from uuid import uuid4
 from wtforms.fields import EmailField
 
@@ -212,11 +211,11 @@ class FormSubmission(Base, TimestampMixin, Payable, AssociatedFiles,
             return form._fields[email_fields[0]].data
         return None
 
-    @observes('definition')
+    @observes('definition', scope='onegov.form.integration.FormApp')
     def definition_observer(self, definition: str) -> None:
         self.checksum = hash_definition(definition)
 
-    @observes('state')
+    @observes('state', scope='onegov.form.integration.FormApp')
     def state_observer(self, state: 'SubmissionState') -> None:
         if self.state == 'complete':
             form = self.form_class(data=self.data)

--- a/src/onegov/gazette/models/category.py
+++ b/src/onegov/gazette/models/category.py
@@ -1,10 +1,10 @@
 from onegov.core.orm.abstract import AdjacencyList
 from onegov.core.orm.mixins import ContentMixin
 from onegov.core.orm.mixins import TimestampMixin
+from onegov.gazette.observer import observes
 from sqlalchemy import Boolean
 from sqlalchemy import Column
 from sqlalchemy import or_
-from sqlalchemy_utils import observes
 from sqlalchemy.orm import object_session
 
 

--- a/src/onegov/gazette/models/issue.py
+++ b/src/onegov/gazette/models/issue.py
@@ -5,6 +5,7 @@ from onegov.core.orm.types import UTCDateTime
 from onegov.file import AssociatedFiles
 from onegov.file import File
 from onegov.file.utils import as_fileintent
+from onegov.gazette.observer import observes
 from sedate import as_datetime
 from sedate import standardize_date
 from sqlalchemy import Column
@@ -12,7 +13,6 @@ from sqlalchemy import Date
 from sqlalchemy import extract
 from sqlalchemy import Integer
 from sqlalchemy import Text
-from sqlalchemy_utils import observes
 from sqlalchemy.orm import object_session
 
 

--- a/src/onegov/gazette/models/notice.py
+++ b/src/onegov/gazette/models/notice.py
@@ -11,13 +11,13 @@ from onegov.gazette.models.category import Category
 from onegov.gazette.models.issue import Issue
 from onegov.gazette.models.issue import IssueName
 from onegov.gazette.models.organization import Organization
+from onegov.gazette.observer import observes
 from onegov.notice import OfficialNotice
 from onegov.user import User
 from onegov.user import UserCollection
 from sedate import as_datetime
 from sedate import standardize_date
 from sedate import utcnow
-from sqlalchemy_utils import observes
 from sqlalchemy.orm import backref
 from sqlalchemy.orm import object_session
 from sqlalchemy.orm import relationship

--- a/src/onegov/gazette/models/organization.py
+++ b/src/onegov/gazette/models/organization.py
@@ -4,10 +4,10 @@ from onegov.core.orm.mixins import ContentMixin
 from onegov.core.orm.mixins import dict_property
 from onegov.core.orm.mixins import meta_property
 from onegov.core.orm.mixins import TimestampMixin
+from onegov.gazette.observer import observes
 from sqlalchemy import Boolean
 from sqlalchemy import Column
 from sqlalchemy import or_
-from sqlalchemy_utils import observes
 from sqlalchemy.orm import object_session
 
 

--- a/src/onegov/gazette/observer.py
+++ b/src/onegov/gazette/observer.py
@@ -1,0 +1,12 @@
+from onegov.core.orm import observes as base_observes
+
+
+from typing import Any, TypeVar, TYPE_CHECKING
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    _F = TypeVar('_F', bound=Callable[..., Any])
+
+
+def observes(*paths: str) -> 'Callable[[_F], _F]':
+    return base_observes(*paths, scope='onegov.gazette.app.GazetteApp')

--- a/src/onegov/org/cronjobs.py
+++ b/src/onegov/org/cronjobs.py
@@ -16,7 +16,7 @@ from onegov.org import _, OrgApp
 from onegov.org.layout import DefaultMailLayout
 from onegov.org.models import (
     ResourceRecipient, ResourceRecipientCollection, TAN, TANAccess)
-from onegov.org.models.page import LinkedFileAccessMixin
+from onegov.org.models.extensions import GeneralFileLinkExtension
 from onegov.org.models.ticket import ReservationHandler
 from onegov.org.views.allocation import handle_rules_cronjob
 from onegov.org.views.newsletter import send_newsletter
@@ -124,9 +124,9 @@ def reindex_published_models(request: 'OrgRequest') -> None:
             objects.extend(query.all())
 
     for obj in objects:
-        if isinstance(obj, LinkedFileAccessMixin):
+        if isinstance(obj, GeneralFileLinkExtension):
             # manually invoke the files observer which updates access
-            obj.files_observer(obj.files, {}, None, None)  # type:ignore
+            obj.files_observer(obj.files, set(), None, None)
 
         request.app.es_orm_events.index(request.app.schema, obj)
 

--- a/src/onegov/org/models/directory.py
+++ b/src/onegov/org/models/directory.py
@@ -10,11 +10,12 @@ from onegov.directory import (
     Directory, DirectoryEntry, DirectoryEntryCollection)
 from onegov.directory.errors import DuplicateEntryError, ValidationError
 from onegov.directory.migration import DirectoryMigration
+from onegov.file import MultiAssociatedFiles
 from onegov.form import as_internal_id, Extendable, FormSubmission
 from onegov.form.submissions import prepare_for_submission
 from onegov.org import _
 from onegov.org.models.extensions import (
-    CoordinatesExtension, PublicationExtension)
+    CoordinatesExtension, GeneralFileLinkExtension, PublicationExtension)
 from onegov.org.models.extensions import AccessExtension
 from onegov.org.models.message import DirectoryMessage
 from onegov.pay import Price
@@ -312,10 +313,17 @@ class DirectorySubmissionAction:
             self.directory, self.ticket, request, 'rejected')
 
 
-class ExtendedDirectory(Directory, AccessExtension, Extendable):
+class ExtendedDirectory(Directory, AccessExtension, Extendable,
+                        MultiAssociatedFiles, GeneralFileLinkExtension):
     __mapper_args__ = {'polymorphic_identity': 'extended'}
 
     es_type_name = 'extended_directories'
+
+    content_fields_containing_links_to_files = {
+        'text',
+        'submissions_guideline',
+        'change_requests_guideline'
+    }
 
     enable_map: dict_property[str | None] = meta_property()
     enable_submissions: dict_property[bool | None] = meta_property()

--- a/src/onegov/org/models/directory.py
+++ b/src/onegov/org/models/directory.py
@@ -10,7 +10,6 @@ from onegov.directory import (
     Directory, DirectoryEntry, DirectoryEntryCollection)
 from onegov.directory.errors import DuplicateEntryError, ValidationError
 from onegov.directory.migration import DirectoryMigration
-from onegov.file import MultiAssociatedFiles
 from onegov.form import as_internal_id, Extendable, FormSubmission
 from onegov.form.submissions import prepare_for_submission
 from onegov.org import _
@@ -314,7 +313,7 @@ class DirectorySubmissionAction:
 
 
 class ExtendedDirectory(Directory, AccessExtension, Extendable,
-                        MultiAssociatedFiles, GeneralFileLinkExtension):
+                        GeneralFileLinkExtension):
     __mapper_args__ = {'polymorphic_identity': 'extended'}
 
     es_type_name = 'extended_directories'

--- a/src/onegov/org/models/extensions.py
+++ b/src/onegov/org/models/extensions.py
@@ -12,7 +12,6 @@ from onegov.org.forms.extensions import PublicationFormExtension
 from onegov.org.forms.fields import UploadOrSelectExistingMultipleFilesField
 from onegov.people import Person, PersonCollection
 from onegov.reservation import Resource
-from sedate import to_timezone, utcnow
 from sqlalchemy.orm import object_session
 from wtforms.fields import BooleanField
 from wtforms.fields import RadioField
@@ -698,47 +697,5 @@ class GeneralFileLinkExtension(ContentExtension):
             files = UploadOrSelectExistingMultipleFilesField(
                 label=_("Documents"),
             )
-
-            def populate_obj(
-                self,
-                obj: object,
-                *args: Any,
-                **kwargs: Any
-            ) -> None:
-                super().populate_obj(obj, *args, **kwargs)
-
-                # transfer the publication settings to newly added files
-                # TODO: maybe we should take access into account as well?
-                if (
-                    self.files.added_files
-                    and 'publication_start' in self
-                    and 'publication_end' in self
-                ):
-                    start = self['publication_start'].data
-                    end = self['publication_end'].data
-                    if start is None and end is None:
-                        # nothing to do
-                        return
-
-                    now = utcnow()
-                    published = True
-                    if end is not None and to_timezone(end, 'UTC') < now:
-                        # clear both dates and set published to False
-                        published = False
-                        start = None
-                        end = None
-
-                    elif start is not None:
-                        if to_timezone(start, 'UTC') < now:
-                            # clear the date since we're already published
-                            start = None
-                        else:
-                            # otherwise set published to False
-                            published = False
-
-                    for file in self.files.added_files:
-                        file.published = published
-                        file.publish_date = start
-                        file.publish_end_date = end
 
         return GeneralFileForm

--- a/src/onegov/org/models/extensions.py
+++ b/src/onegov/org/models/extensions.py
@@ -754,6 +754,14 @@ def _content_file_link_observer(
     if not file_ids:
         return
 
+    # HACK: On insert the id may have not been generated yet, so we need
+    #       to generate it now, this assumes that the default argument
+    #       provided is a single callable without a context argument
+    if self.id is None:
+        # for now we assume all of our default callables don't require
+        # the execution context
+        self.id = type(self).id.default.arg(None)
+
     key = str(self.id)
     session = object_session(self)
     collection = FileCollection['GeneralFile'](session, type='general')

--- a/src/onegov/org/models/extensions.py
+++ b/src/onegov/org/models/extensions.py
@@ -12,12 +12,12 @@ from onegov.org.forms import ResourceForm
 from onegov.org.forms.extensions import CoordinatesFormExtension
 from onegov.org.forms.extensions import PublicationFormExtension
 from onegov.org.forms.fields import UploadOrSelectExistingMultipleFilesField
+from onegov.org.observer import observes
 from onegov.people import Person, PersonCollection
 from onegov.reservation import Resource
 from sqlalchemy import inspect
 from sqlalchemy.ext.declarative import declared_attr
 from sqlalchemy.orm import object_session
-from sqlalchemy_utils import observes
 from urlextract import URLExtract
 from wtforms.fields import BooleanField
 from wtforms.fields import RadioField

--- a/src/onegov/org/models/external_link.py
+++ b/src/onegov/org/models/external_link.py
@@ -9,9 +9,9 @@ from onegov.core.utils import normalize_for_url
 from onegov.form import FormCollection
 from onegov.reservation import ResourceCollection
 from onegov.org.models import AccessExtension
+from onegov.org.observer import observes
 from onegov.search import SearchableContent
 from sqlalchemy import Column, Text
-from sqlalchemy_utils import observes
 
 
 from typing import Any, TYPE_CHECKING

--- a/src/onegov/org/models/form.py
+++ b/src/onegov/org/models/form.py
@@ -1,7 +1,9 @@
+from onegov.file import MultiAssociatedFiles
 from onegov.form.models import FormDefinition
 from onegov.org.models.extensions import AccessExtension
 from onegov.org.models.extensions import ContactExtension
 from onegov.org.models.extensions import CoordinatesExtension
+from onegov.org.models.extensions import GeneralFileLinkExtension
 from onegov.org.models.extensions import HoneyPotExtension
 from onegov.org.models.extensions import PersonLinkExtension
 from onegov.search import SearchableContent
@@ -18,7 +20,8 @@ if TYPE_CHECKING:
 class BuiltinFormDefinition(FormDefinition, AccessExtension,
                             ContactExtension, PersonLinkExtension,
                             CoordinatesExtension, SearchableContent,
-                            HoneyPotExtension):
+                            HoneyPotExtension, MultiAssociatedFiles,
+                            GeneralFileLinkExtension):
     __mapper_args__ = {'polymorphic_identity': 'builtin'}
 
     es_type_name = 'builtin_forms'
@@ -33,7 +36,8 @@ class BuiltinFormDefinition(FormDefinition, AccessExtension,
 class CustomFormDefinition(FormDefinition, AccessExtension,
                            ContactExtension, PersonLinkExtension,
                            CoordinatesExtension, SearchableContent,
-                           HoneyPotExtension):
+                           HoneyPotExtension, MultiAssociatedFiles,
+                           GeneralFileLinkExtension):
     __mapper_args__ = {'polymorphic_identity': 'custom'}
 
     es_type_name = 'custom_forms'

--- a/src/onegov/org/models/form.py
+++ b/src/onegov/org/models/form.py
@@ -1,4 +1,3 @@
-from onegov.file import MultiAssociatedFiles
 from onegov.form.models import FormDefinition
 from onegov.org.models.extensions import AccessExtension
 from onegov.org.models.extensions import ContactExtension
@@ -20,8 +19,7 @@ if TYPE_CHECKING:
 class BuiltinFormDefinition(FormDefinition, AccessExtension,
                             ContactExtension, PersonLinkExtension,
                             CoordinatesExtension, SearchableContent,
-                            HoneyPotExtension, MultiAssociatedFiles,
-                            GeneralFileLinkExtension):
+                            HoneyPotExtension, GeneralFileLinkExtension):
     __mapper_args__ = {'polymorphic_identity': 'builtin'}
 
     es_type_name = 'builtin_forms'
@@ -36,8 +34,7 @@ class BuiltinFormDefinition(FormDefinition, AccessExtension,
 class CustomFormDefinition(FormDefinition, AccessExtension,
                            ContactExtension, PersonLinkExtension,
                            CoordinatesExtension, SearchableContent,
-                           HoneyPotExtension, MultiAssociatedFiles,
-                           GeneralFileLinkExtension):
+                           HoneyPotExtension, GeneralFileLinkExtension):
     __mapper_args__ = {'polymorphic_identity': 'custom'}
 
     es_type_name = 'custom_forms'

--- a/src/onegov/org/models/page.py
+++ b/src/onegov/org/models/page.py
@@ -81,7 +81,7 @@ class LinkedFileAccessMixin:
 
         # remove ourselves if the link has been deleted
         state = inspect(self)
-        for file in state.attrs.files.deleted:
+        for file in state.attrs.files.history.deleted:
             if key in file.linked_accesses:
                 del file.linked_accesses[key]
 

--- a/src/onegov/org/models/page.py
+++ b/src/onegov/org/models/page.py
@@ -24,22 +24,87 @@ from sedate import replace_timezone
 from sqlalchemy import desc, func, or_, and_, inspect
 from sqlalchemy.dialects.postgresql import array, JSON
 from sqlalchemy.orm import undefer, object_session
+from sqlalchemy.ext.declarative import declared_attr
 from sqlalchemy_utils import observes
 from urlextract import URLExtract
 
 
 from typing import Any, TYPE_CHECKING
 if TYPE_CHECKING:
-    from onegov.file import File
     from onegov.org.request import OrgRequest
-    from sqlalchemy import Column
-    from sqlalchemy.orm import Query, relationship
+    from sqlalchemy.orm import Query
 
 
 # FIXME: This is a bit of a hack because we don't have easy access to the
 #        current request inside @observes methods, so we just assume any
 #        urls that end with /storage/[0-9a-f]{64} are links to *our* files
 FILE_URL_RE = re.compile(r'/storage/([0-9a-f]{64})$')
+
+
+def _files_observer(
+    self: 'Topic | News',
+    files: list[GeneralFile],
+    meta: set[str],
+    publication_start: datetime | None,
+    publication_end: datetime | None
+) -> None:
+    # mainly we want to observe changes to the linked files
+    # but when the publication or access changes we may need
+    # to change the access we propagated to the linked files
+    # so we're observing those attributes too
+
+    key = str(self.id)
+
+    # we could try to determine which accesses if any need to
+    # be updated using the SQLAlchemy inspect API, but it's
+    # probably faster to just update all the files.
+    current_access = self.access if self.published else 'private'
+    for file in files:
+        file.linked_accesses[key] = current_access
+
+    # remove ourselves if the link has been deleted
+    state = inspect(self)
+    for file in state.attrs.files.history.deleted:
+        if key in file.linked_accesses:
+            del file.linked_accesses[key]
+
+
+def _text_observer(self: 'Topic | News', content: set[str]) -> None:
+    # we don't automatically unlink files, since in Topic/News
+    # we are also using GeneralFileLinkExtension, in a more
+    # general case, where we don't use that we probably want
+    # to unlink files, since there's otherwise no way to remove
+    # the link.
+    if not content or 'text' not in content:
+        return
+
+    text = self.content.get('text', None)
+    if not text:
+        return
+
+    extractor = URLExtract()
+    file_ids = [
+        match.group(1)
+        for url in extractor.find_urls(text, only_unique=True)
+        if (match := FILE_URL_RE.search(url))
+    ]
+    if not file_ids:
+        return
+
+    session = object_session(self)
+    collection = GeneralFileCollection(session)
+    files = collection.query().filter(GeneralFile.id.in_(file_ids))
+    current_access = self.access if self.published else 'private'
+    for file in files:
+        # we may do this redundantly for some files if both observers
+        # trigger, but it's easier to take the hit than to try to
+        # figure out whether or not both observers triggered and in
+        # which order
+        file.linked_accesses[str(self.id)] = current_access
+
+        # link any files that haven't already been linked
+        if file not in self.files:
+            self.files.append(file)
 
 
 # TODO: We should probably make a more general mixin which uses an
@@ -49,79 +114,26 @@ FILE_URL_RE = re.compile(r'/storage/([0-9a-f]{64})$')
 class LinkedFileAccessMixin:
 
     if TYPE_CHECKING:
-        # forward declare what we need
-        id: Any
-        files: relationship[list[File]]
-        publication_start: Column[datetime | None]
-        publication_end: Column[datetime | None]
-        published: Column[bool]
-        access: dict_property[str]
+        def files_observer(
+            self,
+            files: list[GeneralFile],
+            meta: set[str],
+            publication_start: datetime | None,
+            publication_end: datetime | None
+        ) -> None: ...
 
-    # mainly we want to observe changes to the linked files
-    # but when the publication or access changes we may need
-    # to change the access we propagated to the linked files
-    # so we're observing those attributes too
-    @observes('files', 'meta', 'publication_start', 'publication_end')
-    def files_observer(
-        self,
-        files: list[GeneralFile],
-        meta: dict[str, Any],
-        publication_start: datetime | None,
-        publication_end: datetime | None
-    ) -> None:
+        def text_observer(self, content: set[str]) -> None: ...
+    else:
+        # in order for observes to trigger we need to use declared_attr
+        @declared_attr
+        def files_observer(cls):
+            return observes(
+                'files', 'meta', 'publication_start', 'publication_end'
+            )(_files_observer)
 
-        key = str(self.id)
-
-        # we could try to determine which accesses if any need to
-        # be updated using the SQLAlchemy inspect API, but it's
-        # probably faster to just update all the files.
-        current_access = self.access if self.published else 'private'
-        for file in files:
-            file.linked_accesses[key] = current_access
-
-        # remove ourselves if the link has been deleted
-        state = inspect(self)
-        for file in state.attrs.files.history.deleted:
-            if key in file.linked_accesses:
-                del file.linked_accesses[key]
-
-    @observes('content')
-    def text_observer(self, content: dict[str, Any]) -> None:
-        # we don't automatically unlink files, since in Topic/News
-        # we are also using GeneralFileLinkExtension, in a more
-        # general case, where we don't use that we probably want
-        # to unlink files, since there's otherwise no way to remove
-        # the link.
-        if not content:
-            return
-
-        text = content.get('text')
-        if not text:
-            return
-
-        extractor = URLExtract()
-        file_ids = [
-            match.group(1)
-            for url in extractor.find_urls(text, only_unique=True)
-            if (match := FILE_URL_RE.search(url))
-        ]
-        if not file_ids:
-            return
-
-        session = object_session(self)
-        collection = GeneralFileCollection(session)
-        files = collection.query().filter(GeneralFile.id.in_(file_ids))
-        current_access = self.access if self.published else 'private'
-        for file in files:
-            # we may do this redundantly for some files if both observers
-            # trigger, but it's easier to take the hit than to try to
-            # figure out whether or not both observers triggered and in
-            # which order
-            file.linked_accesses[str(self.id)] = current_access
-
-            # link any files that haven't already been linked
-            if file not in self.files:
-                self.files.append(file)
+        @declared_attr
+        def text_observer(cls):
+            return observes('content')(_text_observer)
 
 
 class Topic(Page, TraitInfo, SearchableContent, AccessExtension,

--- a/src/onegov/org/models/page.py
+++ b/src/onegov/org/models/page.py
@@ -1,7 +1,6 @@
 from datetime import datetime
 from onegov.core.orm.mixins import (
     content_property, dict_property, meta_property)
-from onegov.file import MultiAssociatedFiles
 from onegov.form import Form, move_fields
 from onegov.org import _
 from onegov.org.forms import LinkForm, PageForm
@@ -16,13 +15,13 @@ from onegov.org.models.extensions import GeneralFileLinkExtension
 from onegov.org.models.extensions import PersonLinkExtension
 from onegov.org.models.extensions import VisibleOnHomepageExtension
 from onegov.org.models.traitinfo import TraitInfo
+from onegov.org.observer import observes
 from onegov.page import Page
 from onegov.search import SearchableContent
 from sedate import replace_timezone
 from sqlalchemy import desc, func, or_, and_
 from sqlalchemy.dialects.postgresql import array, JSON
 from sqlalchemy.orm import undefer, object_session
-from sqlalchemy_utils import observes
 
 
 from typing import Any, TYPE_CHECKING
@@ -35,7 +34,7 @@ class Topic(Page, TraitInfo, SearchableContent, AccessExtension,
             PublicationExtension, VisibleOnHomepageExtension,
             ContactExtension, ContactHiddenOnPageExtension,
             PersonLinkExtension, CoordinatesExtension, ImageExtension,
-            MultiAssociatedFiles, GeneralFileLinkExtension):
+            GeneralFileLinkExtension):
 
     __mapper_args__ = {'polymorphic_identity': 'topic'}
 
@@ -123,8 +122,7 @@ class Topic(Page, TraitInfo, SearchableContent, AccessExtension,
 class News(Page, TraitInfo, SearchableContent, NewsletterExtension,
            AccessExtension, PublicationExtension, VisibleOnHomepageExtension,
            ContactExtension, ContactHiddenOnPageExtension, PersonLinkExtension,
-           CoordinatesExtension, ImageExtension, MultiAssociatedFiles,
-           GeneralFileLinkExtension):
+           CoordinatesExtension, ImageExtension, GeneralFileLinkExtension):
 
     __mapper_args__ = {'polymorphic_identity': 'news'}
 

--- a/src/onegov/org/models/page.py
+++ b/src/onegov/org/models/page.py
@@ -1,3 +1,4 @@
+import re
 from datetime import datetime
 from onegov.core.orm.mixins import (
     content_property, dict_property, meta_property)
@@ -6,6 +7,7 @@ from onegov.form import Form, move_fields
 from onegov.org import _
 from onegov.org.forms import LinkForm, PageForm
 from onegov.org.models.atoz import AtoZ
+from onegov.org.models.file import GeneralFile, GeneralFileCollection
 from onegov.org.models.extensions import (
     ContactExtension, ContactHiddenOnPageExtension, ImageExtension,
     NewsletterExtension, PublicationExtension
@@ -19,23 +21,115 @@ from onegov.org.models.traitinfo import TraitInfo
 from onegov.page import Page
 from onegov.search import SearchableContent
 from sedate import replace_timezone
-from sqlalchemy import desc, func, or_, and_
+from sqlalchemy import desc, func, or_, and_, inspect
 from sqlalchemy.dialects.postgresql import array, JSON
 from sqlalchemy.orm import undefer, object_session
 from sqlalchemy_utils import observes
+from urlextract import URLExtract
 
 
 from typing import Any, TYPE_CHECKING
 if TYPE_CHECKING:
+    from onegov.file import File
     from onegov.org.request import OrgRequest
-    from sqlalchemy.orm import Query
+    from sqlalchemy import Column
+    from sqlalchemy.orm import Query, relationship
+
+
+# FIXME: This is a bit of a hack because we don't have easy access to the
+#        current request inside @observes methods, so we just assume any
+#        urls that end with /storage/[0-9a-f]{64} are links to *our* files
+FILE_URL_RE = re.compile(r'/storage/([0-9a-f]{64})$')
+
+
+# TODO: We should probably make a more general mixin which uses an
+#       attribute to lookup which content/meta properties can contain
+#       links to files, for now this is hardcoded for Topic/News where
+#       the only attribute is `text`
+class LinkedFileAccessMixin:
+
+    if TYPE_CHECKING:
+        # forward declare what we need
+        id: Any
+        files: relationship[list[File]]
+        publication_start: Column[datetime | None]
+        publication_end: Column[datetime | None]
+        published: Column[bool]
+        access: dict_property[str]
+
+    # mainly we want to observe changes to the linked files
+    # but when the publication or access changes we may need
+    # to change the access we propagated to the linked files
+    # so we're observing those attributes too
+    @observes('files', 'meta', 'publication_start', 'publication_end')
+    def files_observer(
+        self,
+        files: list[GeneralFile],
+        meta: dict[str, Any],
+        publication_start: datetime | None,
+        publication_end: datetime | None
+    ) -> None:
+
+        key = str(self.id)
+
+        # we could try to determine which accesses if any need to
+        # be updated using the SQLAlchemy inspect API, but it's
+        # probably faster to just update all the files.
+        current_access = self.access if self.published else 'private'
+        for file in files:
+            file.linked_accesses[key] = current_access
+
+        # remove ourselves if the link has been deleted
+        state = inspect(self)
+        for file in state.attrs.files.deleted:
+            if key in file.linked_accesses:
+                del file.linked_accesses[key]
+
+    @observes('content')
+    def text_observer(self, content: dict[str, Any]) -> None:
+        # we don't automatically unlink files, since in Topic/News
+        # we are also using GeneralFileLinkExtension, in a more
+        # general case, where we don't use that we probably want
+        # to unlink files, since there's otherwise no way to remove
+        # the link.
+        if not content:
+            return
+
+        text = content.get('text')
+        if not text:
+            return
+
+        extractor = URLExtract()
+        file_ids = [
+            match.group(1)
+            for url in extractor.find_urls(text, only_unique=True)
+            if (match := FILE_URL_RE.search(url))
+        ]
+        if not file_ids:
+            return
+
+        session = object_session(self)
+        collection = GeneralFileCollection(session)
+        files = collection.query().filter(GeneralFile.id.in_(file_ids))
+        current_access = self.access if self.published else 'private'
+        for file in files:
+            # we may do this redundantly for some files if both observers
+            # trigger, but it's easier to take the hit than to try to
+            # figure out whether or not both observers triggered and in
+            # which order
+            file.linked_accesses[str(self.id)] = current_access
+
+            # link any files that haven't already been linked
+            if file not in self.files:
+                self.files.append(file)
 
 
 class Topic(Page, TraitInfo, SearchableContent, AccessExtension,
             PublicationExtension, VisibleOnHomepageExtension,
             ContactExtension, ContactHiddenOnPageExtension,
             PersonLinkExtension, CoordinatesExtension, ImageExtension,
-            MultiAssociatedFiles, GeneralFileLinkExtension):
+            MultiAssociatedFiles, GeneralFileLinkExtension,
+            LinkedFileAccessMixin):
 
     __mapper_args__ = {'polymorphic_identity': 'topic'}
 
@@ -124,7 +218,7 @@ class News(Page, TraitInfo, SearchableContent, NewsletterExtension,
            AccessExtension, PublicationExtension, VisibleOnHomepageExtension,
            ContactExtension, ContactHiddenOnPageExtension, PersonLinkExtension,
            CoordinatesExtension, ImageExtension, MultiAssociatedFiles,
-           GeneralFileLinkExtension):
+           GeneralFileLinkExtension, LinkedFileAccessMixin):
 
     __mapper_args__ = {'polymorphic_identity': 'news'}
 

--- a/src/onegov/org/models/resource.py
+++ b/src/onegov/org/models/resource.py
@@ -7,7 +7,6 @@ from libres.db.models import ReservedSlot
 from onegov.core.orm.mixins import (
     content_property, dict_property, meta_property)
 from onegov.core.orm.types import UUID
-from onegov.file import MultiAssociatedFiles
 from onegov.form.models import FormSubmission
 from onegov.org import _
 from onegov.org.models.extensions import (
@@ -207,8 +206,7 @@ class SharedMethods:
 class DaypassResource(Resource, AccessExtension, SearchableContent,
                       ContactExtension, PersonLinkExtension,
                       CoordinatesExtension, SharedMethods,
-                      ResourceValidationExtension, MultiAssociatedFiles,
-                      GeneralFileLinkExtension):
+                      ResourceValidationExtension, GeneralFileLinkExtension):
     __mapper_args__ = {'polymorphic_identity': 'daypass'}
 
     es_type_name = 'daypasses'
@@ -226,8 +224,7 @@ class DaypassResource(Resource, AccessExtension, SearchableContent,
 class RoomResource(Resource, AccessExtension, SearchableContent,
                    ContactExtension, PersonLinkExtension,
                    CoordinatesExtension, SharedMethods,
-                   ResourceValidationExtension, MultiAssociatedFiles,
-                   GeneralFileLinkExtension):
+                   ResourceValidationExtension, GeneralFileLinkExtension):
     __mapper_args__ = {'polymorphic_identity': 'room'}
 
     es_type_name = 'rooms'
@@ -255,8 +252,7 @@ class RoomResource(Resource, AccessExtension, SearchableContent,
 class ItemResource(Resource, AccessExtension, SearchableContent,
                    ContactExtension, PersonLinkExtension,
                    CoordinatesExtension, SharedMethods,
-                   ResourceValidationExtension, MultiAssociatedFiles,
-                   GeneralFileLinkExtension):
+                   ResourceValidationExtension, GeneralFileLinkExtension):
 
     __mapper_args__ = {'polymorphic_identity': 'daily-item'}
 

--- a/src/onegov/org/models/resource.py
+++ b/src/onegov/org/models/resource.py
@@ -7,10 +7,11 @@ from libres.db.models import ReservedSlot
 from onegov.core.orm.mixins import (
     content_property, dict_property, meta_property)
 from onegov.core.orm.types import UUID
+from onegov.file import MultiAssociatedFiles
 from onegov.form.models import FormSubmission
 from onegov.org import _
 from onegov.org.models.extensions import (
-    ContactExtension, ResourceValidationExtension)
+    ContactExtension, GeneralFileLinkExtension, ResourceValidationExtension)
 from onegov.org.models.extensions import CoordinatesExtension
 from onegov.org.models.extensions import AccessExtension
 from onegov.org.models.extensions import PersonLinkExtension
@@ -206,7 +207,8 @@ class SharedMethods:
 class DaypassResource(Resource, AccessExtension, SearchableContent,
                       ContactExtension, PersonLinkExtension,
                       CoordinatesExtension, SharedMethods,
-                      ResourceValidationExtension):
+                      ResourceValidationExtension, MultiAssociatedFiles,
+                      GeneralFileLinkExtension):
     __mapper_args__ = {'polymorphic_identity': 'daypass'}
 
     es_type_name = 'daypasses'
@@ -224,7 +226,8 @@ class DaypassResource(Resource, AccessExtension, SearchableContent,
 class RoomResource(Resource, AccessExtension, SearchableContent,
                    ContactExtension, PersonLinkExtension,
                    CoordinatesExtension, SharedMethods,
-                   ResourceValidationExtension):
+                   ResourceValidationExtension, MultiAssociatedFiles,
+                   GeneralFileLinkExtension):
     __mapper_args__ = {'polymorphic_identity': 'room'}
 
     es_type_name = 'rooms'
@@ -252,7 +255,8 @@ class RoomResource(Resource, AccessExtension, SearchableContent,
 class ItemResource(Resource, AccessExtension, SearchableContent,
                    ContactExtension, PersonLinkExtension,
                    CoordinatesExtension, SharedMethods,
-                   ResourceValidationExtension):
+                   ResourceValidationExtension, MultiAssociatedFiles,
+                   GeneralFileLinkExtension):
 
     __mapper_args__ = {'polymorphic_identity': 'daily-item'}
 

--- a/src/onegov/org/observer.py
+++ b/src/onegov/org/observer.py
@@ -1,0 +1,12 @@
+from onegov.core.orm import observes as base_observes
+
+
+from typing import Any, TypeVar, TYPE_CHECKING
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    _F = TypeVar('_F', bound=Callable[..., Any])
+
+
+def observes(*paths: str) -> 'Callable[[_F], _F]':
+    return base_observes(*paths, scope='onegov.org.app.OrgApp')

--- a/src/onegov/org/upgrade.py
+++ b/src/onegov/org/upgrade.py
@@ -321,4 +321,4 @@ def add_files_linked_in_page_text(context: UpgradeContext) -> None:
             continue
 
         # this should automatically link any unlinked files
-        page.text_observer(page.content)
+        page.text_observer({'text'})

--- a/src/onegov/org/upgrade.py
+++ b/src/onegov/org/upgrade.py
@@ -309,3 +309,16 @@ def fix_nested_list_in_content_people(context: UpgradeContext) -> None:
             else:
                 updated_people.append(person)
         obj.content['people'] = updated_people
+
+
+@upgrade_task('Add explicit link for files linked in page text2')
+def add_files_linked_in_page_text(context: UpgradeContext) -> None:
+    if not context.has_table('pages'):
+        return
+
+    for page in context.session.query(Page):
+        if not hasattr(page, 'text_observer'):
+            continue
+
+        # this should automatically link any unlinked files
+        page.text_observer(page.content)

--- a/src/onegov/org/utils.py
+++ b/src/onegov/org/utils.py
@@ -1162,3 +1162,26 @@ def user_group_emails_for_new_ticket(
         and (dirs := user.group.meta.get('directories')) is not None
         and ticket.group in dirs
     }
+
+
+# from most narrow to widest
+ORDERED_ACCESS = (
+    'private',
+    'member',
+    'secret_mtan',
+    'mtan',
+    'secret',
+    'public'
+)
+
+
+def widest_access(*accesses: str) -> str:
+    index = 0
+    for access in accesses:
+        try:
+            # we only want to look at indexes starting with the one
+            # we're already at, otherwise we're lowering the access
+            index = ORDERED_ACCESS.index(access, index)
+        except ValueError:
+            pass
+    return ORDERED_ACCESS[index]

--- a/src/onegov/org/views/directory.py
+++ b/src/onegov/org/views/directory.py
@@ -289,6 +289,11 @@ def delete_directory(
 
     session = request.session
 
+    if hasattr(self.directory, 'files'):
+        # unlink any linked files
+        self.directory.files = []
+        session.flush()
+
     for entry in self.directory.entries:
         session.delete(entry)
 

--- a/src/onegov/page/model.py
+++ b/src/onegov/page/model.py
@@ -11,6 +11,7 @@ from onegov.core.orm.abstract import AdjacencyList
 from onegov.core.orm.mixins import ContentMixin
 from onegov.core.orm.mixins import TimestampMixin
 from onegov.core.orm.mixins import UTCPublicationMixin
+from onegov.file import MultiAssociatedFiles
 
 
 from typing import TYPE_CHECKING
@@ -20,7 +21,8 @@ if TYPE_CHECKING:
     from sqlalchemy.orm import relationship
 
 
-class Page(AdjacencyList, ContentMixin, TimestampMixin, UTCPublicationMixin):
+class Page(AdjacencyList, ContentMixin, TimestampMixin,
+           UTCPublicationMixin, MultiAssociatedFiles):
     """ Defines a generic page. """
 
     __tablename__ = 'pages'

--- a/src/onegov/recipient/model.py
+++ b/src/onegov/recipient/model.py
@@ -1,9 +1,8 @@
-from onegov.core.orm import Base
+from onegov.core.orm import Base, observes
 from onegov.core.orm.mixins import ContentMixin, TimestampMixin
 from onegov.core.orm.types import UUID
 from onegov.core.utils import normalize_for_url
 from sqlalchemy import Column, Enum, Text
-from sqlalchemy_utils import observes
 from uuid import uuid4
 
 

--- a/src/onegov/reservation/collection.py
+++ b/src/onegov/reservation/collection.py
@@ -138,5 +138,10 @@ class ResourceCollection:
                     handle_reservation(res)
             scheduler.extinguish_managed_records()
 
+        if resource.files:
+            # unlink any linked files
+            resource.files = []
+            self.session.flush()
+
         self.session.delete(resource)
         self.session.flush()

--- a/src/onegov/reservation/core.py
+++ b/src/onegov/reservation/core.py
@@ -50,8 +50,8 @@ class LibresIntegration:
 
         """
 
-        assert self.session_manager.bases, "Must be run after configure_dsn"
-        self.session_manager.bases.append(ORMBase)
+        assert ORMBase in self.session_manager.bases, (
+            "Must be run after configure_dsn")
 
         self.libres_registry = create_default_registry()
         self.libres_context = self.libres_context_from_session_manager(

--- a/src/onegov/reservation/models/resource.py
+++ b/src/onegov/reservation/models/resource.py
@@ -9,6 +9,7 @@ from onegov.core.orm import ModelBase
 from onegov.core.orm.mixins import content_property, dict_property
 from onegov.core.orm.mixins import ContentMixin, TimestampMixin
 from onegov.core.orm.types import UUID
+from onegov.file import MultiAssociatedFiles
 from onegov.form import parse_form
 from onegov.pay import Price, process_payment
 from sedate import align_date_to_day, utcnow
@@ -52,7 +53,8 @@ def extra_scheduler_arguments() -> dict[str, Any]:
     }
 
 
-class Resource(ORMBase, ModelBase, ContentMixin, TimestampMixin):
+class Resource(ORMBase, ModelBase, ContentMixin,
+               TimestampMixin, MultiAssociatedFiles):
     """ A resource holds a single calendar with allocations and reservations.
 
     Note that this resource is not defined on the onegov.core declarative base.

--- a/src/onegov/swissvotes/models/vote.py
+++ b/src/onegov/swissvotes/models/vote.py
@@ -1,5 +1,6 @@
 from collections import OrderedDict
 from functools import cached_property
+from onegov.core.orm import observes
 from onegov.core.orm import Base
 from onegov.core.orm.mixins import content_property
 from onegov.core.orm.mixins import dict_property
@@ -22,7 +23,6 @@ from sqlalchemy import func
 from sqlalchemy import Integer
 from sqlalchemy import Numeric
 from sqlalchemy import Text
-from sqlalchemy_utils import observes
 from sqlalchemy.dialects.postgresql import TSVECTOR
 from sqlalchemy.orm import deferred
 from urllib.parse import urlparse
@@ -898,7 +898,7 @@ class SwissVote(Base, TimestampMixin, LocalizedFiles, ContentMixin):
                 func.to_tsvector(locales[locale], text)
             )
 
-    @observes('files')
+    @observes('files', scope='onegov.swissvotes.app.SwissvotesApp')
     def files_observer(self, files):
         self.reindex_files()
 

--- a/stubs/dectate/tool.pyi
+++ b/stubs/dectate/tool.pyi
@@ -1,0 +1,4 @@
+from types import ModuleType
+from typing import Any
+
+def resolve_dotted_name(name: str, module: ModuleType | None = None) -> Any: ...

--- a/stubs/sqlalchemy_utils/observer.pyi
+++ b/stubs/sqlalchemy_utils/observer.pyi
@@ -1,10 +1,32 @@
-from collections.abc import Callable
-from typing import NewType, TypeVar
-from typing_extensions import ParamSpec
+from _typeshed import Incomplete
+from collections.abc import Callable, Collection, Iterable, Iterator
+from sqlalchemy.orm import Mapper, Session
+from sqlalchemy.orm.session import UOWTransaction  # type:ignore[attr-defined]
+from typing import Any, NamedTuple, TypeVar
+from typing_extensions import ParamSpec, Never, TypeAlias
 
-_T = TypeVar('_T')
-_P = ParamSpec('_P')
-_DontUse = NewType('_DontUse', object)
+_CallbackArgs: TypeAlias = tuple[Any, Callable[..., Any], list[Any]]
 
-# for simplicity we disallow passing in a custom observer
-def observes(*paths: str, **observer_kw: _DontUse) -> Callable[[Callable[_P, _T]], Callable[_P, _T]]: ...
+
+class Callback(NamedTuple):
+    func: Callable[..., Any]
+    backref: Incomplete | None
+    fullpath: list[Incomplete]
+
+
+class PropertyObserver:
+    listener_args: list[tuple[type[Any], str, Callable[..., Any]]]
+    callback_map: dict[type[Any], list[Callback]]
+    generator_registry: dict[type[Any], list[Callable[..., Any]]]
+    def __init__(self) -> None: ...
+    def remove_listeners(self) -> None: ...
+    def register_listeners(self) -> None: ...
+    def update_generator_registry(self, mapper: Mapper, class_: type[object]) -> None: ...
+    def gather_paths(self) -> None: ...
+    def gather_callback_args(self, obj: Any, callbacks: Iterable[Callback]) -> Iterator[_CallbackArgs]: ...
+    def get_callback_args(self, root_obj: Any, callback: Callback) -> _CallbackArgs: ...
+    def iterate_objects_and_callbacks(self, session: Session) -> Iterator[tuple[Any, list[Callback]]]: ...
+    def invoke_callbacks(self, session: Session, ctx: UOWTransaction, instances: Collection[Any] | None) -> None: ...
+
+# we don't want anyone to call this, call the scoped observers' observes instead
+def observes(*paths: Never, **observer_kw: Never) -> Never: ...

--- a/tests/onegov/core/test_cronjobs.py
+++ b/tests/onegov/core/test_cronjobs.py
@@ -40,6 +40,8 @@ def test_run_cronjob(postgres_dsn, redis_url):
         redis_url=redis_url
     )
     app.namespace = 'municipalities'
+    # don't initialize ORMBase
+    app.session_manager.bases.pop()
     app.set_application_id('municipalities/new-york')
 
     # to test we need an actual webserver, webtest doesn't cut it here because

--- a/tests/onegov/core/test_orm.py
+++ b/tests/onegov/core/test_orm.py
@@ -272,6 +272,8 @@ def test_orm_scenario(postgres_dsn, redis_url):
     app = App()
     app.configure_application(dsn=postgres_dsn, base=Base, redis_url=redis_url)
     app.namespace = 'municipalities'
+    # remove ORMBase
+    app.session_manager.bases.pop()
 
     c = Client(app)
 
@@ -342,6 +344,8 @@ def test_i18n_with_request(postgres_dsn, redis_url):
     app = App()
     app.configure_application(dsn=postgres_dsn, base=Base, redis_url=redis_url)
     app.namespace = 'municipalities'
+    # remove ORMBase
+    app.session_manager.bases.pop()
     app.set_application_id('municipalities/new-york')
     app.locales = ['de_CH', 'en_US']
 
@@ -818,6 +822,8 @@ def test_application_retries(postgres_dsn, number_of_retries, redis_url):
         identity_secure=False,
         redis_url=redis_url
     )
+    # remove ORMBase
+    app.session_manager.bases.pop()
     app.namespace = 'municipalities'
 
     # make sure the schema exists already
@@ -1415,6 +1421,8 @@ def test_orm_cache(postgres_dsn, redis_url):
         base=Base,
         redis_url=redis_url
     )
+    # remove ORMBase
+    app.session_manager.bases.pop()
     app.namespace = 'foo'
     app.set_application_id('foo/bar')
 
@@ -1516,6 +1524,8 @@ def test_orm_cache_flush(postgres_dsn, redis_url):
         base=Base,
         redis_url=redis_url
     )
+    # remove ORMBase
+    app.session_manager.bases.pop()
     app.namespace = 'foo'
     app.set_application_id('foo/bar')
     app.clear_request_cache()
@@ -1927,6 +1937,8 @@ def test_i18n_translation_hybrid_independence(postgres_dsn, redis_url):
         base=Base,
         redis_url=redis_url
     )
+    # remove ORMBase
+    freiburg.session_manager.bases.pop()
     freiburg.namespace = 'app'
     freiburg.set_application_id('app/freiburg')
     freiburg.locales = ['de_CH', 'fr_CH']
@@ -1937,6 +1949,8 @@ def test_i18n_translation_hybrid_independence(postgres_dsn, redis_url):
         base=Base,
         redis_url=redis_url
     )
+    # remove ORMBase
+    biel.session_manager.bases.pop()
     biel.namespace = 'app'
     biel.set_application_id('app/biel')
     biel.locales = ['de_CH', 'fr_CH']

--- a/tests/onegov/org/test_extensions.py
+++ b/tests/onegov/org/test_extensions.py
@@ -1,6 +1,5 @@
 import pytest
 
-from dateutil.relativedelta import relativedelta
 from depot.manager import DepotManager
 from io import BytesIO
 from onegov.core.utils import Bunch
@@ -8,9 +7,8 @@ from onegov.form import Form
 from onegov.form.extensions import Extendable
 from onegov.org.models.extensions import (
     PersonLinkExtension, ContactExtension, AccessExtension, HoneyPotExtension,
-    GeneralFileLinkExtension, PublicationExtension
+    GeneralFileLinkExtension
 )
-from sedate import utcnow
 from uuid import UUID
 
 
@@ -536,95 +534,3 @@ def test_general_file_link_extension(depot, session):
     form.populate_obj(topic)
 
     assert topic.files == []
-
-
-def test_general_file_link_extension_with_publication(depot, session):
-
-    class Topic(GeneralFileLinkExtension, PublicationExtension):
-        files = []
-        publication_start = None
-        publication_end = None
-
-    class TopicForm(Form):
-        pass
-
-    topic = Topic()
-    assert topic.files == []
-
-    request = Bunch(**{
-        'app.settings.org.disabled_extensions': [],
-        'session': session
-    })
-    form_class = topic.with_content_extensions(TopicForm, request=request)
-    form = form_class(meta={'request': request})
-
-    assert 'files' in form._fields
-    assert form.files.data == []
-
-    publish_date = utcnow() + relativedelta(days=+1)
-    form.publication_start.data = publish_date
-    form.files.append_entry()
-    form.files[0].file = BytesIO(b'hello world')
-    form.files[0].filename = 'test.txt'
-    form.files[0].action = 'replace'
-    form.populate_obj(topic)
-
-    assert len(topic.files) == 1
-    assert topic.files[0].name == 'test.txt'
-    assert topic.files[0].published is False
-    assert topic.files[0].publish_date == publish_date
-    assert topic.files[0].publish_end_date is None
-
-    # this should not change anything on already uploaded files
-    # even if it replaces an existing file
-    publish_end_date = publish_date + relativedelta(months=+1)
-    form.publication_end.data = publish_end_date
-    form.populate_obj(topic)
-    assert form.files.added_files == []
-    assert len(topic.files) == 1
-    assert topic.files[0].name == 'test.txt'
-    assert topic.files[0].published is False
-    assert topic.files[0].publish_date == publish_date
-    assert topic.files[0].publish_end_date is None
-
-    # but should on newly uploaded files
-    form.files.append_entry()
-    form.files[1].file = BytesIO(b'hello world 2')
-    form.files[1].filename = 'test2.txt'
-    form.files[1].action = 'replace'
-    form.populate_obj(topic)
-    assert len(topic.files) == 2
-    assert topic.files[1].name == 'test2.txt'
-    assert topic.files[1].published is False
-    assert topic.files[1].publish_date == publish_date
-    assert topic.files[1].publish_end_date == publish_end_date
-
-    # publish date in past
-    publish_date = utcnow() + relativedelta(days=-1)
-    form.publication_start.data = publish_date
-    # add another new entry
-    form.files.append_entry()
-    form.files[2].file = BytesIO(b'hello world 3')
-    form.files[2].filename = 'test3.txt'
-    form.files[2].action = 'replace'
-    form.populate_obj(topic)
-    assert len(topic.files) == 3
-    assert topic.files[2].name == 'test3.txt'
-    assert topic.files[2].published is True
-    assert topic.files[2].publish_date is None
-    assert topic.files[2].publish_end_date == publish_end_date
-
-    # publish end date in past
-    publish_end_date = utcnow()
-    form.publication_end.data = publish_end_date
-    # add another new entry
-    form.files.append_entry()
-    form.files[3].file = BytesIO(b'hello world 4')
-    form.files[3].filename = 'test4.txt'
-    form.files[3].action = 'replace'
-    form.populate_obj(topic)
-    assert len(topic.files) == 4
-    assert topic.files[3].name == 'test4.txt'
-    assert topic.files[3].published is False
-    assert topic.files[3].publish_date is None
-    assert topic.files[3].publish_end_date is None

--- a/tests/onegov/org/test_views_directory.py
+++ b/tests/onegov/org/test_views_directory.py
@@ -10,8 +10,10 @@ from pytz import UTC
 from sedate import standardize_date, utcnow, to_timezone, replace_timezone
 from webtest import Upload
 
+from onegov.core.utils import module_path
+from onegov.file import FileCollection
 from onegov.directory import (
-    DirectoryEntry, DirectoryCollection,
+    Directory, DirectoryEntry, DirectoryCollection,
     DirectoryConfiguration, DirectoryZipArchive)
 from onegov.directory.errors import DuplicateEntryError
 from onegov.directory.models.directory import DirectoryFile
@@ -46,15 +48,18 @@ def strip_s(dt, timezone=None):
     return standardize_date(dt, timezone)
 
 
-def create_directory(client, publication=True, required_publication=False,
-                     change_reqs=True, submission=True,
-                     extended_submitter=False, title='Meetings', lead=None
-                     ):
+def create_directory(
+    client, publication=True, required_publication=False,
+    change_reqs=True, submission=True, extended_submitter=False,
+    title='Meetings', lead=None, text=None
+):
     client.login_admin()
     page = client.get('/directories').click('Verzeichnis')
     page.form['title'] = title
     if lead:
         page.form['lead'] = lead
+    if text:
+        page.form['text'] = text
     page.form['structure'] = """
                     Name *= ___
                     Pic *= *.jpg|*.png|*.gif
@@ -817,6 +822,44 @@ def test_directory_numbering(client):
     page = client.get('/directories/trainers')
     numbers = page.pyquery('.entry-number')
     assert [t.text for t in numbers] == ['4. ', '5. ']
+
+
+def test_directory_explicitly_link_referenced_files(client):
+    client.login_admin()
+
+    path = module_path('tests.onegov.org', 'fixtures/sample.pdf')
+    with open(path, 'rb') as f:
+        page = client.get('/files')
+        page.form['file'] = Upload('Sample.pdf', f.read(), 'application/pdf')
+        page.form.submit()
+
+    pdf_url = (
+        client.get('/files')
+        .pyquery('[ic-trigger-from="#button-1"]')
+        .attr('ic-get-from')
+        .removesuffix('/details')
+    )
+    pdf_link = f'<a href="{pdf_url}">Sample.pdf</a>'
+
+    create_directory(client, text=pdf_link)
+
+    session = client.app.session()
+    pdf = FileCollection(session).query().one()
+    directory = (
+        DirectoryCollection(session).query()
+        .filter(Directory.title == 'Meetings').one()
+    )
+    assert directory.files == [pdf]
+    assert pdf.access == 'public'
+
+    directory.access = 'mtan'
+    session.flush()
+    assert pdf.access == 'mtan'
+
+    # link removed
+    directory.files = []
+    session.flush()
+    assert pdf.access == 'secret'
 
 
 def test_newline_in_directory_header(client):

--- a/tests/onegov/org/test_views_pages.py
+++ b/tests/onegov/org/test_views_pages.py
@@ -1,4 +1,6 @@
+from datetime import timedelta
 from freezegun import freeze_time
+from sedate import utcnow
 
 from onegov.core.utils import module_path
 from onegov.file import FileCollection
@@ -171,6 +173,21 @@ def test_pages_explicitly_link_referenced_files(client):
         .filter(Page.title == 'Linking files').one()
     )
     assert page.files == [pdf]
+    session.flush()
+
+    pdf = FileCollection(session).query().one()
+    assert pdf.access == 'public'
+    page.access = 'mtan'
+    session.flush()
+
+    pdf = FileCollection(session).query().one()
+    assert pdf.access == 'mtan'
+    # publication has ended
+    page.publication_end = utcnow() - timedelta(days=1)
+    session.flush()
+
+    pdf = FileCollection(session).query().one()
+    assert pdf.access == 'private'
 
 
 def test_pages_person_link_extension(client):

--- a/tests/onegov/org/test_views_pages.py
+++ b/tests/onegov/org/test_views_pages.py
@@ -173,21 +173,21 @@ def test_pages_explicitly_link_referenced_files(client):
         .filter(Page.title == 'Linking files').one()
     )
     assert page.files == [pdf]
-    session.flush()
-
-    pdf = FileCollection(session).query().one()
     assert pdf.access == 'public'
+
     page.access = 'mtan'
     session.flush()
-
-    pdf = FileCollection(session).query().one()
     assert pdf.access == 'mtan'
+
     # publication has ended
     page.publication_end = utcnow() - timedelta(days=1)
     session.flush()
-
-    pdf = FileCollection(session).query().one()
     assert pdf.access == 'private'
+
+    # link removed
+    page.files = []
+    session.flush()
+    assert pdf.access == 'secret'
 
 
 def test_pages_person_link_extension(client):

--- a/tests/onegov/org/test_views_resources.py
+++ b/tests/onegov/org/test_views_resources.py
@@ -9,14 +9,16 @@ from datetime import datetime, date
 from freezegun import freeze_time
 from libres.db.models import Reservation
 from libres.modules.errors import AffectedReservationError
-from onegov.core.utils import normalize_for_url
+from onegov.core.utils import module_path, normalize_for_url
+from onegov.file import FileCollection
 from onegov.form import FormSubmission
 from onegov.org.models import ResourceRecipientCollection
-from onegov.reservation import ResourceCollection
+from onegov.reservation import Resource, ResourceCollection
 from onegov.ticket import TicketCollection
 from openpyxl import load_workbook
 from pathlib import Path
 from unittest.mock import patch
+from webtest import Upload
 
 from tests.shared.utils import add_reservation
 
@@ -145,6 +147,54 @@ def test_resources_person_link_extension(client):
     edit_resource.form['western_ordered'] = True
     resource = edit_resource.form.submit().follow()
     assert 'Franz Müller' in resource
+
+
+def test_resources_explicitly_link_referenced_files(client):
+    admin = client.spawn()
+    admin.login_admin()
+
+    path = module_path('tests.onegov.org', 'fixtures/sample.pdf')
+    with open(path, 'rb') as f:
+        page = admin.get('/files')
+        page.form['file'] = Upload('Sample.pdf', f.read(), 'application/pdf')
+        page.form.submit()
+
+    pdf_url = (
+        admin.get('/files')
+        .pyquery('[ic-trigger-from="#button-1"]')
+        .attr('ic-get-from')
+        .removesuffix('/details')
+    )
+    pdf_link = f'<a href="{pdf_url}">Sample.pdf</a>'
+
+    editor = client.spawn()
+    editor.login_editor()
+
+    # add resource
+    resources = editor.get('/resources')
+    new_item = resources.click('Gegenstand')
+    new_item.form['title'] = 'Dorf Bike'
+    new_item.form['text'] = pdf_link
+    resource = new_item.form.submit().follow()
+    assert 'Dorf Bike' in resource
+
+    session = client.app.session()
+    pdf = FileCollection(session).query().one()
+    resource = (
+        ResourceCollection(client.app.libres_context).query()
+        .filter(Resource.title == 'Dorf Bike').one()
+    )
+    assert resource.files == [pdf]
+    assert pdf.access == 'public'
+
+    resource.access = 'mtan'
+    session.flush()
+    assert pdf.access == 'mtan'
+
+    # link removed
+    resource.files = []
+    session.flush()
+    assert pdf.access == 'secret'
 
 
 @freeze_time("2020-01-01", tick=True)

--- a/tests/onegov/reservation/conftest.py
+++ b/tests/onegov/reservation/conftest.py
@@ -1,7 +1,6 @@
 import pytest
 
 from libres.context.registry import create_default_registry
-from libres.db.models import ORMBase
 from onegov.reservation import LibresIntegration
 from uuid import uuid4
 
@@ -9,7 +8,6 @@ from uuid import uuid4
 @pytest.fixture(scope="function")
 def libres_context(session_manager):
 
-    session_manager.bases.append(ORMBase)
     session_manager.set_current_schema('test_' + uuid4().hex)
 
     registry = create_default_registry()

--- a/tests/onegov/search/test_integration.py
+++ b/tests/onegov/search/test_integration.py
@@ -8,7 +8,6 @@ from elasticsearch_dsl.query import MatchPhrase, FunctionScore
 from onegov.core import Framework
 from onegov.core.orm.mixins import TimestampMixin
 from onegov.core.utils import scan_morepath_modules
-from onegov.file import DepotApp
 from onegov.search import ElasticsearchApp, ORMSearchable
 from sqlalchemy import Boolean, Column, Integer, Text
 from sqlalchemy.ext.declarative import declarative_base
@@ -18,7 +17,7 @@ from time import sleep
 
 def test_app_integration(es_url):
 
-    class App(Framework, DepotApp, ElasticsearchApp):
+    class App(Framework, ElasticsearchApp):
         pass
 
     app = App()
@@ -74,6 +73,8 @@ def test_search_query(es_url, postgres_dsn):
         base=Base,
         elasticsearch_hosts=[es_url]
     )
+    # remove ORMBase
+    app.session_manager.bases.pop()
 
     app.namespace = 'documents'
     app.set_application_id('documents/home')
@@ -254,6 +255,8 @@ def test_orm_integration(es_url, postgres_dsn, redis_url):
         elasticsearch_hosts=[es_url],
         redis_url=redis_url
     )
+    # remove ORMBase
+    app.session_manager.bases.pop()
 
     app.namespace = 'documents'
     app.set_application_id('documents/home')
@@ -326,6 +329,8 @@ def test_alternate_id_property(es_url, postgres_dsn):
         base=Base,
         elasticsearch_hosts=[es_url]
     )
+    # remove ORMBase
+    app.session_manager.bases.pop()
 
     app.namespace = 'users'
     app.set_application_id('users/corporate')
@@ -404,6 +409,8 @@ def test_orm_polymorphic(es_url, postgres_dsn):
         base=Base,
         elasticsearch_hosts=[es_url]
     )
+    # remove ORMBase
+    app.session_manager.bases.pop()
 
     app.namespace = 'pages'
     app.set_application_id('pages/site')
@@ -480,6 +487,8 @@ def test_orm_polymorphic_sublcass_only(es_url, postgres_dsn):
         base=Base,
         elasticsearch_hosts=[es_url]
     )
+    # remove ORMBase
+    app.session_manager.bases.pop()
 
     app.namespace = 'pages'
     app.set_application_id('pages/site')
@@ -554,6 +563,8 @@ def test_suggestions(es_url, postgres_dsn):
         base=Base,
         elasticsearch_hosts=[es_url]
     )
+    # remove ORMBase
+    app.session_manager.bases.pop()
 
     app.namespace = 'documents'
     app.set_application_id('documents/home')
@@ -644,6 +655,8 @@ def test_language_detection(es_url, postgres_dsn):
         base=Base,
         elasticsearch_hosts=[es_url]
     )
+    # remove ORMBase
+    app.session_manager.bases.pop()
 
     app.namespace = 'documents'
     app.set_application_id('documents/home')
@@ -698,6 +711,8 @@ def test_language_update(es_url, postgres_dsn):
         base=Base,
         elasticsearch_hosts=[es_url]
     )
+    # remove ORMBase
+    app.session_manager.bases.pop()
 
     app.namespace = 'documents'
     app.set_application_id('documents/home')
@@ -750,6 +765,8 @@ def test_date_decay(es_url, postgres_dsn):
         base=Base,
         elasticsearch_hosts=[es_url]
     )
+    # remove ORMBase
+    app.session_manager.bases.pop()
 
     app.namespace = 'documents'
     app.set_application_id('documents/home')

--- a/tests/onegov/search/test_integration.py
+++ b/tests/onegov/search/test_integration.py
@@ -8,6 +8,7 @@ from elasticsearch_dsl.query import MatchPhrase, FunctionScore
 from onegov.core import Framework
 from onegov.core.orm.mixins import TimestampMixin
 from onegov.core.utils import scan_morepath_modules
+from onegov.file import DepotApp
 from onegov.search import ElasticsearchApp, ORMSearchable
 from sqlalchemy import Boolean, Column, Integer, Text
 from sqlalchemy.ext.declarative import declarative_base
@@ -17,7 +18,7 @@ from time import sleep
 
 def test_app_integration(es_url):
 
-    class App(Framework, ElasticsearchApp):
+    class App(Framework, DepotApp, ElasticsearchApp):
         pass
 
     app = App()

--- a/tests/shared/fixtures.py
+++ b/tests/shared/fixtures.py
@@ -17,6 +17,7 @@ from contextlib import suppress
 from elasticsearch import Elasticsearch
 from fs.tempfs import TempFS
 from functools import lru_cache
+from libres.db.models import ORMBase
 from mirakuru import HTTPExecutor, TCPExecutor
 from onegov.core.crypto import hash_password
 from onegov.core.orm import Base, SessionManager
@@ -217,6 +218,9 @@ def session_manager(postgres_dsn):
             'echo': 'ECHO' in os.environ
         }
     )
+    # we used to only add this base sometimes, but we always need it now
+    # since otherwise some of our backrefs lead to nowhere
+    mgr.bases.append(ORMBase)
     yield mgr
     mgr.dispose()
 


### PR DESCRIPTION
## Commit message

Org: Allows uploaded files to appear in public search results more often

Previously only files marked as a publication would appear in search results, but now it will also check for any public pages linking to the file in which case it will appear in the search results as well.

This also creates an explicit link for any files linked within a page's text.

TYPE: Feature
LINK: OGC-921

## Checklist

- [x] I have performed a self-review of my code
- [x] I have tested my code thoroughly by hand
- [x] I have added tests for my changes/features
