### PR TITLE
Remove rule to hide last element in navigation

### DIFF
--- a/src/onegov/feriennet/theme/styles/feriennet.scss
+++ b/src/onegov/feriennet/theme/styles/feriennet.scss
@@ -1,17 +1,4 @@
 /*
-    hide the news in the topbar
-*/
-.top-bar-section:not(#quicklinks) {
-    ul {
-        width: 100%;
-    }
-
-    li:last-child {
-        display: none;
-    }
-}
-
-/*
     css animations keyframes
 */
 @keyframes oscillate-opacity {


### PR DESCRIPTION
Please fill in the commit message below and work through the checklist. You can delete parts that are not needed, e.g. the optional description, the link to a ticket or irrelevant options of the checklist.

## Commit message

Feriennet: Delete rule that hides last navigation Element

TYPE: Feature
LINK: PRO-1239