### PR TITLE
Feature/ogc 1454 option displaying people in main column instead of sidebar

### DIFF
--- a/src/onegov/org/locale/de_CH/LC_MESSAGES/onegov.org.po
+++ b/src/onegov/org/locale/de_CH/LC_MESSAGES/onegov.org.po
@@ -5585,3 +5585,6 @@ msgstr "Ein Konto wurde für Sie erstellt"
 
 msgid "The user was created successfully"
 msgstr "Der Benutzer wurde erfolgreich erstellt"
+
+msgid "Show people on bottom of main page (instead of sidebar)"
+msgstr "Personen am unteren Rand der Hauptseite anzeigen (statt in Sidebar)"

--- a/src/onegov/org/locale/fr_CH/LC_MESSAGES/onegov.org.po
+++ b/src/onegov/org/locale/fr_CH/LC_MESSAGES/onegov.org.po
@@ -5601,3 +5601,6 @@ msgstr "Un compte a été créé pour vous"
 
 msgid "The user was created successfully"
 msgstr "L'utilisateur a bien été créé"
+
+msgid "Show people on bottom of main page (instead of sidebar)"
+msgstr "Afficher les personnes en bas de la page principale (au lieu de la barre latérale)"

--- a/src/onegov/org/locale/it_CH/LC_MESSAGES/onegov.org.po
+++ b/src/onegov/org/locale/it_CH/LC_MESSAGES/onegov.org.po
@@ -5599,3 +5599,6 @@ msgstr "Utente creato correttamente"
 #, python-format
 #~ msgid "{success_count} tickets deleted."
 #~ msgstr "{success_count} biglietti cancellati."
+
+msgid "Show people on bottom of main page (instead of sidebar)"
+msgstr "Mostra le persone in fondo alla pagina principale (invece che nella barra laterale)"

--- a/src/onegov/org/models/extensions.py
+++ b/src/onegov/org/models/extensions.py
@@ -295,7 +295,7 @@ class PeopleShownOnMainPageExtension(ContentExtension):
             request: 'OrgRequest'
     ) -> type['_FormT']:
 
-        class PeopleShownOnMainPageForm(form_class):
+        class PeopleShownOnMainPageForm(form_class):  # type:ignore
             show_people_on_main_page = BooleanField(
                 label=_("Show people on bottom of main page (instead of "
                         "sidebar)"),

--- a/src/onegov/org/models/extensions.py
+++ b/src/onegov/org/models/extensions.py
@@ -280,6 +280,30 @@ class ContactHiddenOnPageExtension(ContentExtension):
         return ContactHiddenOnPageForm
 
 
+class PeopleShownOnMainPageExtension(ContentExtension):
+    """ Extends any class that has a content dictionary field with a simple
+    contacts field where people will be shown on bottom of main page.
+
+    """
+
+    show_people_on_main_page: dict_property[bool] = (
+        meta_property(default=False))
+
+    def extend_form(
+            self,
+            form_class: type['_FormT'],
+            request: 'OrgRequest'
+    ) -> type['_FormT']:
+
+        class PeopleShownOnMainPageForm(form_class):
+            show_people_on_main_page = BooleanField(
+                label=_("Show people on bottom of main page (instead of "
+                        "sidebar)"),
+                fieldset=_("People"))
+
+        return PeopleShownOnMainPageForm
+
+
 class NewsletterExtension(ContentExtension):
     text_in_newsletter: dict_property[bool] = content_property(default=False)
 

--- a/src/onegov/org/models/page.py
+++ b/src/onegov/org/models/page.py
@@ -6,7 +6,8 @@ from onegov.org import _
 from onegov.org.forms import LinkForm, PageForm
 from onegov.org.models.atoz import AtoZ
 from onegov.org.models.extensions import (
-    ContactExtension, ContactHiddenOnPageExtension, ImageExtension,
+    ContactExtension, ContactHiddenOnPageExtension,
+    PeopleShownOnMainPageExtension, ImageExtension,
     NewsletterExtension, PublicationExtension
 )
 from onegov.org.models.extensions import AccessExtension
@@ -33,7 +34,8 @@ if TYPE_CHECKING:
 class Topic(Page, TraitInfo, SearchableContent, AccessExtension,
             PublicationExtension, VisibleOnHomepageExtension,
             ContactExtension, ContactHiddenOnPageExtension,
-            PersonLinkExtension, CoordinatesExtension, ImageExtension,
+            PeopleShownOnMainPageExtension, PersonLinkExtension,
+            CoordinatesExtension, ImageExtension,
             GeneralFileLinkExtension):
 
     __mapper_args__ = {'polymorphic_identity': 'topic'}

--- a/src/onegov/org/models/page.py
+++ b/src/onegov/org/models/page.py
@@ -123,7 +123,8 @@ class Topic(Page, TraitInfo, SearchableContent, AccessExtension,
 
 class News(Page, TraitInfo, SearchableContent, NewsletterExtension,
            AccessExtension, PublicationExtension, VisibleOnHomepageExtension,
-           ContactExtension, ContactHiddenOnPageExtension, PersonLinkExtension,
+           ContactExtension, ContactHiddenOnPageExtension,
+           PeopleShownOnMainPageExtension, PersonLinkExtension,
            CoordinatesExtension, ImageExtension, GeneralFileLinkExtension):
 
     __mapper_args__ = {'polymorphic_identity': 'news'}

--- a/src/onegov/town6/templates/macros.pt
+++ b/src/onegov/town6/templates/macros.pt
@@ -671,7 +671,7 @@
                     </li>
                 </ul>
             </div>
-            <div class="side-panel people-panel" tal:condition="people" tal:define="western_name_order page.western_name_order|resource.western_name_order|False">
+            <div class="side-panel people-panel" tal:condition="people and not page.show_people_on_main_page|False" tal:define="western_name_order page.western_name_order|resource.western_name_order|False">
                 <h3 i18n:translate>People</h3>
                 <ul class="more-list" data-sortable data-sortable-url="${layout.move_person_url_template}">
                     <li tal:repeat="person people" data-sortable-id="${request.is_manager and person.id}">
@@ -757,6 +757,33 @@
 
                     <div class="page-text" tal:condition="text" tal:content="structure text" />
                     <div metal:define-slot="after-text"></div>
+
+                    <div class="people-panel" tal:condition="people and page.show_people_on_main_page|False" tal:define="western_name_order page.western_name_order|resource.western_name_order|False">
+                        <h3 i18n:translate>People</h3>
+                        <div tal:repeat="person people" class="more-list" data-sortable data-sortable-url="${layout.move_person_url_template}">
+                            <div tal:define="link request.link(person); exclude request.app.org.excluded_person_fields(request)" data-sortable-id="${request.is_manager and person.id}" class="person-card person-list-card-mini">
+                                <a href="${link}" aria-hidden="true" tal:define="url (person.picture_url and layout.thumbnail_url(person.picture_url))">
+                                    <div class="person-card-portrait" style='${"border: 3px solid #DDDDDD;" if not url else ""}'>
+                                        <i class="fa fa-user" tal:condition="not:url"></i>
+                                        <div class="cover-image" style='background-image: url("${url}");'></div>
+                                    </div>
+                                </a>
+                                <ul>
+                                    <li>
+                                        <a class="list-link" href="${request.link(person)}">
+                                            <span tal:condition="western_name_order">${person.first_name} ${person.last_name}</span>
+                                            <span tal:condition="not western_name_order">${person.title}</span>
+                                        </a>
+                                    </li>
+                                    <li>
+                                        <a href="${request.link(person)}">
+                                            <p class="list-lead preview">${person.context_specific_function}</p>
+                                        </a>
+                                    </li>
+                                </ul>
+                            </div>
+                        </div>
+                    </div>
                 </div>
             </div>
             <metal:b use-macro="layout.macros['page_content_sidebar']" tal:define="filter_panel filter_panel|False" />
@@ -905,9 +932,10 @@
             </div>
         </a>
         <ul>
-            <li class="person-card-title">
+            <li class="person-card-title" tal:define="western_name_order page.western_name_order|resource.western_name_order|False">
                 <a href="${link}">
-                    <span>${person.title}</span>
+                    <span tal:condition="western_name_order">${person.first_name} ${person.last_name}</span>
+                    <span tal:condition="not western_name_order">${person.title}</span>
                 </a>
             </li>
             <li tal:condition="person.function" class="person-card-function">

--- a/src/onegov/town6/theme/styles/panels.scss
+++ b/src/onegov/town6/theme/styles/panels.scss
@@ -273,6 +273,8 @@ $checklist-icon: "\f0ae";
 }
 
 .people-panel {
+    margin-top: 2rem;
+
     li div:first-of-type {
         margin-top: .3rem;
     }

--- a/src/onegov/town6/theme/styles/person.scss
+++ b/src/onegov/town6/theme/styles/person.scss
@@ -208,6 +208,8 @@ Person card in lists
         height: 4rem;
         margin-right: 0.6rem;
         margin-left: 0.5rem;
+        margin-top: 0.5rem;
+        margin-bottom: 0.5rem;
         position: relative;
         text-align: center;
         width: 4rem;

--- a/src/onegov/town6/theme/styles/person.scss
+++ b/src/onegov/town6/theme/styles/person.scss
@@ -180,6 +180,67 @@ Person card in lists
 
     }
 
+    .person-card-title {
+        font-size: 1rem;
+        font-weight: bold;
+    }
+
+    .person-card-function {
+        -webkit-box-orient: vertical;
+        -webkit-line-clamp: 2;
+        display: -webkit-box;
+        margin-bottom: 0;
+        overflow: hidden;
+
+        span {
+            cursor: help;
+        }
+    }
+}
+
+.person-list-card-mini {
+    align-items: center;
+    display: flex;
+    justify-content: space-between;
+    width: 100%;
+
+    .person-card-portrait {
+        height: 4rem;
+        margin-right: 0.6rem;
+        margin-left: 0.5rem;
+        position: relative;
+        text-align: center;
+        width: 4rem;
+
+        .fa-user {
+            font-size: 4rem;
+            left: 50%;
+            position: absolute;
+            transform: translate(-50%);
+        }
+    }
+
+    ul {
+        flex-grow: 4;
+
+        > li {
+            max-width: calc(100vw - 7.5rem);
+            overflow: hidden;
+            text-overflow: ellipsis;
+        }
+    }
+
+    > a:last-child {
+        color: $gainsboro;
+        padding: 2rem 1rem;
+        transition: all 200ms linear;
+
+        &:hover {
+            color: $primary-color;
+            padding-left: 2rem;
+            padding-right: 0rem;
+        }
+    }
 
     .person-card-title {
         font-size: 1rem;
@@ -196,7 +257,6 @@ Person card in lists
         span {
             cursor: help;
         }
-
     }
 }
 


### PR DESCRIPTION
Town6: Adds option to Topics and News to show people on bottom of main page instead of sidebar

TYPE: Feature
LINK: ogc-1454

Note: Only implemented for town6 (not for org, agency, ect)
