### PR TITLE
Pro 1237 day labels

### DIFF
--- a/src/onegov/feriennet/cli.py
+++ b/src/onegov/feriennet/cli.py
@@ -3,6 +3,7 @@ import sys
 
 from onegov.core.cli import command_group
 from onegov.activity.models import Period
+from onegov.activity.models import Occasion
 from sqlalchemy import text
 
 
@@ -130,5 +131,24 @@ def delete_period(title):
 
         # triggers a cache update
         request.session.delete(period)
+
+    return delete_period
+
+
+@cli.command(name='compute-occasion-durations')
+def compute_occasion_durations():
+    """ Deletes all the data associated with a period, including:
+
+    Example:
+
+        onegov-feriennet --select /foo/bar delete-period "Ferienpass Test"
+
+    """
+
+    def delete_period(request, app):
+        occasions = request.session.query(Occasion)
+
+        for o in occasions:
+            o.duration = o.compute_duration(o.dates)
 
     return delete_period

--- a/src/onegov/feriennet/models/activity.py
+++ b/src/onegov/feriennet/models/activity.py
@@ -69,6 +69,7 @@ class VacationActivity(Activity, CoordinatesExtension, SearchableContent):
                 .with_entities(Occasion.duration)
                 .distinct()
                 .filter_by(activity_id=self.id)
+                .filter_by(period=request.app.active_period)
             ))
 
         if DAYS.has(durations, DAYS.half):

--- a/src/onegov/feriennet/views/activity.py
+++ b/src/onegov/feriennet/views/activity.py
@@ -490,7 +490,10 @@ def view_activities_as_json(self, request):
         return {'lat': lat, 'lon': lon}
 
     def tags(activity):
-        durations = sum({o.duration for o in activity.occasions})
+        period = request.app.active_period
+        durations = sum(
+            {o.duration for o in activity.occasions if o.period == period}
+        )
         return activity.ordered_tags(request, durations)
 
     provider = request.app.org.title


### PR DESCRIPTION
Please fill in the commit message below and work through the checklist. You can delete parts that are not needed, e.g. the optional description, the link to a ticket or irrelevant options of the checklist.

## Commit message

Feriennet: Fix day labels

Add CLI for re-calculating occasion durations, filter for current period only

TYPE: Bugfix
LINK: PRO-1237

## Checklist

- [x] I have performed a self-review of my code
- [x] I considered adding a reviewer
- [x] I have tested my code thoroughly by hand