### PR TITLE
Feature/ogc 1454 design people main page

### DIFF
--- a/src/onegov/org/models/extensions.py
+++ b/src/onegov/org/models/extensions.py
@@ -305,7 +305,7 @@ class PeopleShownOnMainPageExtension(ContentExtension):
         from onegov.org.request import OrgRequest
         # not using isinstance as e.g. FeriennetRequest inherits from
         # OrgRequest
-        if type(request) == OrgRequest:  # noqa: E721
+        if type(request) is OrgRequest:
             return PeopleShownOnMainPageForm
 
         return form_class

--- a/src/onegov/org/templates/macros.pt
+++ b/src/onegov/org/templates/macros.pt
@@ -546,29 +546,27 @@
                 <div metal:define-slot="after-text"></div>
                 <div class="people-panel" tal:condition="people and show_people_on_main_page" tal:define="show_people_on_main_page page.show_people_on_main_page|resource.show_people_on_main_page|False; western_name_order page.western_name_order|resource.western_name_order|False">
                     <h3 i18n:translate>People</h3>
-                    <div tal:repeat="person people" data-sortable data-sortable-url="${layout.move_person_url_template}">
-                        <div tal:define="link request.link(person); exclude request.app.org.excluded_person_fields(request)" data-sortable-id="${request.is_manager and person.id}" class="person-card person-list-card-mini">
-                            <a href="${link}" aria-hidden="true" tal:define="url (person.picture_url and layout.thumbnail_url(person.picture_url))">
-                                <div class="person-card-portrait" style='${"border: 3px solid #DDDDDD;" if not url else ""}'>
-                                    <i class="fa fa-user" tal:condition="not:url"></i>
-                                    <div class="cover-image" style='background-image: url("${url}");'></div>
-                                </div>
-                            </a>
-                            <ul>
-                                <li>
-                                    <a href="${request.link(person)}" style="font-weight: bold">
-                                        <span tal:condition="western_name_order">${person.first_name} ${person.last_name}</span>
-                                        <span tal:condition="not western_name_order">${person.title}</span>
-                                    </a>
-                                </li>
-                                <li>
-                                    <a href="${request.link(person)}">
-                                        <span>${person.context_specific_function}</span>
-                                    </a>
-                                </li>
-                            </ul>
-                        </div>
-                    </div>
+                    <ul data-sortable data-sortable-url="${layout.move_person_url_template}">
+                        <li tal:repeat="person people" class="person-card person-list-card" data-sortable-id="${request.is_manager and person.id}">
+                            <div>
+                                <a href="${request.link(person)}" aria-hidden="true" tal:define="url (person.picture_url and layout.thumbnail_url(person.picture_url))">
+                                    <div class="person-card-portrait" style='${"border: 3px solid #DDDDDD;" if not url else ""}'>
+                                        <i class="fa fa-user" tal:condition="not:url"></i>
+                                        <div class="cover-image" style='background-image: url("${url}");'></div>
+                                    </div>
+                                </a>
+                            </div>
+                            <div class="with-lead" style="margin-top: .9rem">
+                                <a href="${request.link(person)}" class="list-title">
+                                    <span tal:condition="western_name_order">${person.first_name} ${person.last_name}</span>
+                                    <span tal:condition="not western_name_order">${person.title}</span>
+                                </a>
+                                <a href="${request.link(person)}">
+                                    <p>${person.context_specific_function}</p>
+                                </a>
+                            </div>
+                        </li>
+                    </ul>
                 </div>
             </div>
             <div class="small-12 medium-4 columns page-content-sidebar" tal:condition="people or contact or coordinates or files or show_side_panel" tal:define="highlight_contacts highlight_contacts|True">

--- a/src/onegov/org/theme/styles/org.scss
+++ b/src/onegov/org/theme/styles/org.scss
@@ -2506,6 +2506,8 @@ $person-email-icon: '\f003';
 
     .person-card-portrait {
         height: 5rem;
+        margin-right: 1.2rem;
+        position: relative;
         text-align: center;
         width: 5rem;
 
@@ -2521,43 +2523,6 @@ $person-email-icon: '\f003';
     ul {
         > li {
             font-size: .875rem;
-            max-width: calc(100vw - 7.5rem);
-            overflow: hidden;
-            text-overflow: ellipsis;
-        }
-    }
-
-    .person-card-title {
-        font-size: 1rem;
-        font-weight: bold;
-    }
-
-    .person-card-function {
-        margin-bottom: 0;
-    }
-}
-
-.person-list-card-mini {
-    display: flex;
-    margin-bottom: 0.5rem;
-
-    .person-card-portrait {
-        height: 3rem;
-        text-align: center;
-        width: 3rem;
-
-        .fa-user {
-            font-size: 80px;
-        }
-    }
-
-    > a {
-        margin-right: 1em;
-    }
-
-    ul {
-        > li {
-            font-size: inherit;
             max-width: calc(100vw - 7.5rem);
             overflow: hidden;
             text-overflow: ellipsis;

--- a/src/onegov/town6/templates/macros.pt
+++ b/src/onegov/town6/templates/macros.pt
@@ -760,7 +760,7 @@
 
                     <div class="people-panel" tal:condition="people and show_people_on_main_page" tal:define="show_people_on_main_page page.show_people_on_main_page|resource.show_people_on_main_page|False; western_name_order page.western_name_order|resource.western_name_order|False">
                         <h3 i18n:translate>People</h3>
-                        <ul class="more-list" data-sortable data-sortable-url="${layout.move_person_url_template}">
+                        <ul data-sortable data-sortable-url="${layout.move_person_url_template}">
                             <li tal:repeat="person people" class="person-card person-list-card" data-sortable-id="${request.is_manager and person.id}">
                                 <div>
                                     <a href="${request.link(person)}" aria-hidden="true" tal:define="url (person.picture_url and layout.thumbnail_url(person.picture_url))">

--- a/src/onegov/town6/templates/macros.pt
+++ b/src/onegov/town6/templates/macros.pt
@@ -761,7 +761,7 @@
                     <div class="people-panel" tal:condition="people and show_people_on_main_page" tal:define="show_people_on_main_page page.show_people_on_main_page|resource.show_people_on_main_page|False; western_name_order page.western_name_order|resource.western_name_order|False">
                         <h3 i18n:translate>People</h3>
                         <div tal:repeat="person people" class="more-list" data-sortable data-sortable-url="${layout.move_person_url_template}">
-                            <div tal:define="link request.link(person); exclude request.app.org.excluded_person_fields(request)" data-sortable-id="${request.is_manager and person.id}" class="person-card person-list-card" >
+                            <div tal:define="link request.link(person); exclude request.app.org.excluded_person_fields(request)" data-sortable-id="${request.is_manager and person.id}" class="person-card person-list-card">
                                 <a href="${link}" aria-hidden="true" tal:define="url (person.picture_url and layout.thumbnail_url(person.picture_url))">
                                     <div class="person-card-portrait" style='${"border: 3px solid #DDDDDD;" if not url else ""}'>
                                         <i class="fa fa-user" tal:condition="not:url"></i>

--- a/src/onegov/town6/templates/macros.pt
+++ b/src/onegov/town6/templates/macros.pt
@@ -774,8 +774,6 @@
                                             <span class="list-title" tal:condition="western_name_order">${person.first_name} ${person.last_name}</span>
                                             <span class="list-title" tal:condition="not western_name_order">${person.title}</span>
                                         </a>
-                                    </li>
-                                    <li>
                                         <a href="${request.link(person)}">
                                             <p class="list-lead preview">${person.context_specific_function}</p>
                                         </a>

--- a/src/onegov/town6/templates/macros.pt
+++ b/src/onegov/town6/templates/macros.pt
@@ -771,7 +771,7 @@
                                     </a>
                                 </div>
                                 <div>
-                                    <a class="list-link" href="${request.link(person)}">
+                                    <a href="${request.link(person)}">
                                         <span class="list-title" tal:condition="western_name_order">${person.first_name} ${person.last_name}</span>
                                         <span class="list-title" tal:condition="not western_name_order">${person.title}</span>
                                     </a>

--- a/src/onegov/town6/templates/macros.pt
+++ b/src/onegov/town6/templates/macros.pt
@@ -771,8 +771,8 @@
                                 <ul>
                                     <li>
                                         <a class="list-link" href="${request.link(person)}">
-                                            <span tal:condition="western_name_order">${person.first_name} ${person.last_name}</span>
-                                            <span tal:condition="not western_name_order">${person.title}</span>
+                                            <span class="list-title" tal:condition="western_name_order">${person.first_name} ${person.last_name}</span>
+                                            <span class="list-title" tal:condition="not western_name_order">${person.title}</span>
                                         </a>
                                     </li>
                                     <li>

--- a/src/onegov/town6/templates/macros.pt
+++ b/src/onegov/town6/templates/macros.pt
@@ -761,7 +761,7 @@
                     <div class="people-panel" tal:condition="people and show_people_on_main_page" tal:define="show_people_on_main_page page.show_people_on_main_page|resource.show_people_on_main_page|False; western_name_order page.western_name_order|resource.western_name_order|False">
                         <h3 i18n:translate>People</h3>
                         <div tal:repeat="person people" class="more-list" data-sortable data-sortable-url="${layout.move_person_url_template}">
-                            <div tal:define="link request.link(person); exclude request.app.org.excluded_person_fields(request)" data-sortable-id="${request.is_manager and person.id}" class="person-card person-list-card-mini">
+                            <div tal:define="link request.link(person); exclude request.app.org.excluded_person_fields(request)" data-sortable-id="${request.is_manager and person.id}" class="person-card person-list-card" >
                                 <a href="${link}" aria-hidden="true" tal:define="url (person.picture_url and layout.thumbnail_url(person.picture_url))">
                                     <div class="person-card-portrait" style='${"border: 3px solid #DDDDDD;" if not url else ""}'>
                                         <i class="fa fa-user" tal:condition="not:url"></i>

--- a/src/onegov/town6/templates/macros.pt
+++ b/src/onegov/town6/templates/macros.pt
@@ -760,27 +760,27 @@
 
                     <div class="people-panel" tal:condition="people and show_people_on_main_page" tal:define="show_people_on_main_page page.show_people_on_main_page|resource.show_people_on_main_page|False; western_name_order page.western_name_order|resource.western_name_order|False">
                         <h3 i18n:translate>People</h3>
-                        <div tal:repeat="person people" class="more-list" data-sortable data-sortable-url="${layout.move_person_url_template}">
-                            <div tal:define="link request.link(person); exclude request.app.org.excluded_person_fields(request)" data-sortable-id="${request.is_manager and person.id}" class="person-card person-list-card">
-                                <a href="${link}" aria-hidden="true" tal:define="url (person.picture_url and layout.thumbnail_url(person.picture_url))">
-                                    <div class="person-card-portrait" style='${"border: 3px solid #DDDDDD;" if not url else ""}'>
-                                        <i class="fa fa-user" tal:condition="not:url"></i>
-                                        <div class="cover-image" style='background-image: url("${url}");'></div>
-                                    </div>
-                                </a>
-                                <ul>
-                                    <li>
-                                        <a class="list-link" href="${request.link(person)}">
-                                            <span class="list-title" tal:condition="western_name_order">${person.first_name} ${person.last_name}</span>
-                                            <span class="list-title" tal:condition="not western_name_order">${person.title}</span>
-                                        </a>
-                                        <a href="${request.link(person)}">
-                                            <p class="list-lead preview">${person.context_specific_function}</p>
-                                        </a>
-                                    </li>
-                                </ul>
-                            </div>
-                        </div>
+                        <ul class="more-list" data-sortable data-sortable-url="${layout.move_person_url_template}">
+                            <li tal:repeat="person people" class="person-card person-list-card" data-sortable-id="${request.is_manager and person.id}">
+                                <div>
+                                    <a href="${request.link(person)}" aria-hidden="true" tal:define="url (person.picture_url and layout.thumbnail_url(person.picture_url))">
+                                        <div class="person-card-portrait" style='${"border: 3px solid #DDDDDD;" if not url else ""}'>
+                                            <i class="fa fa-user" tal:condition="not:url"></i>
+                                            <div class="cover-image" style='background-image: url("${url}");'></div>
+                                        </div>
+                                    </a>
+                                </div>
+                                <div>
+                                    <a class="list-link" href="${request.link(person)}">
+                                        <span class="list-title" tal:condition="western_name_order">${person.first_name} ${person.last_name}</span>
+                                        <span class="list-title" tal:condition="not western_name_order">${person.title}</span>
+                                    </a>
+                                    <a href="${request.link(person)}">
+                                        <p class="list-lead preview">${person.context_specific_function}</p>
+                                    </a>
+                                </div>
+                            </li>
+                        </ul>
                     </div>
                 </div>
             </div>

--- a/src/onegov/town6/theme/styles/org.scss
+++ b/src/onegov/town6/theme/styles/org.scss
@@ -628,6 +628,11 @@ $pageref-color-hover: $iron;
 
             .list-title {
                 @include more-link-after;
+
+                &::after {
+                    position: absolute;
+                    right: 0;
+                }
             }
 
             .list-link {

--- a/src/onegov/town6/theme/styles/org.scss
+++ b/src/onegov/town6/theme/styles/org.scss
@@ -582,10 +582,6 @@ $pageref-color-hover: $iron;
 
         &:hover {
             transition: all 200ms linear;
-
-            .list-title::after {
-                padding-right: 0;
-            }
         }
 
         .list-lead {
@@ -630,9 +626,11 @@ $pageref-color-hover: $iron;
                 @include more-link-after;
 
                 &::after {
+                    padding-right: 6%;
                     position: absolute;
                     right: 0;
                 }
+
             }
 
             .list-link {
@@ -649,7 +647,7 @@ $pageref-color-hover: $iron;
 
                 .list-title::after {
                     opacity: 1 !important;
-                    padding-right: 0;
+                    padding-right: 3%;
                 }
             }
         }

--- a/src/onegov/town6/theme/styles/panels.scss
+++ b/src/onegov/town6/theme/styles/panels.scss
@@ -274,15 +274,6 @@ $checklist-icon: "\f0ae";
 
 .people-panel {
     margin-top: 2rem;
-
-    li div:first-of-type {
-        margin-top: .3rem;
-    }
-
-    ul div {
-        color: #444;
-        margin-top: -10px !important;
-    }
 }
 
 .page-content-sidebar {

--- a/src/onegov/town6/theme/styles/person.scss
+++ b/src/onegov/town6/theme/styles/person.scss
@@ -156,16 +156,6 @@ Person card in lists
         }
     }
 
-    ul {
-        flex-grow: 4;
-
-        > li {
-            max-width: calc(100vw - 7.5rem);
-            overflow: hidden;
-            text-overflow: ellipsis;
-        }
-    }
-
     > a:last-child {
         color: $gainsboro;
         padding: 2rem 1rem;

--- a/src/onegov/town6/theme/styles/person.scss
+++ b/src/onegov/town6/theme/styles/person.scss
@@ -138,15 +138,12 @@ Person card in lists
 .person-list-card {
     align-items: center;
     display: flex;
-    justify-content: space-between;
+    justify-content: flex-start;
     width: 100%;
 
     .person-card-portrait {
         height: 5rem;
-        margin-right: 0.6rem;
-        margin-left: 0.5rem;
-        margin-top: 0.5rem;
-        margin-bottom: 0.5rem;
+        margin: 0.25rem 1.4rem 0.2rem 0.5rem;
         position: relative;
         text-align: center;
         width: 5rem;

--- a/src/onegov/town6/theme/styles/person.scss
+++ b/src/onegov/town6/theme/styles/person.scss
@@ -140,10 +140,11 @@ Person card in lists
     display: flex;
     justify-content: flex-start;
     width: 100%;
+    border-top: 1px solid #f5f5f5;
 
     .person-card-portrait {
         height: 5rem;
-        margin: 0.25rem 1.4rem 0.2rem 0.5rem;
+        margin: 0.7rem 1.4rem 0.2rem 0.5rem;
         position: relative;
         text-align: center;
         width: 5rem;

--- a/src/onegov/town6/theme/styles/person.scss
+++ b/src/onegov/town6/theme/styles/person.scss
@@ -143,76 +143,13 @@ Person card in lists
 
     .person-card-portrait {
         height: 5rem;
-        margin-right: 1em;
-        position: relative;
-        text-align: center;
-        width: 5rem;
-
-        .fa-user {
-            font-size: 4rem;
-            left: 50%;
-            position: absolute;
-            transform: translate(-50%);
-        }
-    }
-
-    ul {
-        flex-grow: 4;
-
-        > li {
-            font-size: .875rem;
-            max-width: calc(100vw - 7.5rem);
-            overflow: hidden;
-            text-overflow: ellipsis;
-        }
-    }
-
-    > a:last-child {
-        color: $gainsboro;
-        padding: 2rem 1rem;
-        transition: all 200ms linear;
-
-        &:hover {
-            color: $primary-color;
-            padding-left: 2rem;
-            padding-right: 0rem;
-        }
-
-    }
-
-    .person-card-title {
-        font-size: 1rem;
-        font-weight: bold;
-    }
-
-    .person-card-function {
-        -webkit-box-orient: vertical;
-        -webkit-line-clamp: 2;
-        display: -webkit-box;
-        margin-bottom: 0;
-        overflow: hidden;
-
-        span {
-            cursor: help;
-        }
-    }
-}
-
-.person-list-card-mini {
-    align-items: center;
-    display: flex;
-    justify-content: space-between;
-    width: 100%;
-
-    .person-card-portrait {
-        height: 4rem;
         margin-right: 0.6rem;
         margin-left: 0.5rem;
         margin-top: 0.5rem;
         margin-bottom: 0.5rem;
         position: relative;
         text-align: center;
-        width: 4rem;
+        width: 5rem;
 
         .fa-user {
             font-size: 4rem;


### PR DESCRIPTION
Org/Town6: Adjust design for people shown on main page

TYPE: Feature
LINK: ogc-1454

In earlier commits I added the style class `person-list-card-mini` for a miniature portrait which I now revert.
I also checked no side effects on agency. Landsgemeinde I only verfied by code (as I still could not transfer/create a onegov_landsgemeinde/gl locally)