### PR TITLE
Fix type errors in Occasion

### DIFF
--- a/src/onegov/activity/models/occasion.py
+++ b/src/onegov/activity/models/occasion.py
@@ -325,11 +325,11 @@ class Occasion(Base, TimestampMixin):
 
     @hybrid_property  # type:ignore[no-redef]
     def operable(self) -> bool:
-        return self.attendee_count >= self.spots.lower
+        return self.attendee_count >= (self.spots.lower or 0)
 
     @hybrid_property  # type:ignore[no-redef]
     def full(self) -> bool:
-        return self.attendee_count == self.spots.upper - 1
+        return self.attendee_count == (self.spots.upper or 0) - 1
 
     @hybrid_property  # type:ignore[no-redef]
     def available_spots(self) -> int:
@@ -348,7 +348,7 @@ class Occasion(Base, TimestampMixin):
 
     @property
     def max_spots(self) -> int:
-        return self.spots.upper - 1
+        return int(self.spots.upper or 0) - 1
 
     def is_past_deadline(self, now: datetime) -> bool:
         return now > self.period.as_local_datetime(
@@ -418,12 +418,12 @@ class Occasion(Base, TimestampMixin):
         return self.period.age_barrier.is_too_young(
             birth_date=birth_date,
             start_date=self.dates[0].start.date(),
-            min_age=self.age.lower
+            min_age=int(self.age.lower or 0)
         )
 
     def is_too_old(self, birth_date: date | datetime) -> bool:
         return self.period.age_barrier.is_too_old(
             birth_date=birth_date,
             start_date=self.dates[0].start.date(),
-            max_age=self.age.upper - 1
+            max_age=int(self.age.upper or 0) - 1
         )

--- a/src/onegov/activity/models/occasion_need.py
+++ b/src/onegov/activity/models/occasion_need.py
@@ -15,7 +15,7 @@ from uuid import uuid4
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     import uuid
-    from psycopg2.extras import NumericRange
+    from onegov.activity.types import BoundedIntegerRange
     from .occasion import Occasion
     from .volunteer import Volunteer
 
@@ -39,7 +39,7 @@ class OccasionNeed(Base, TimestampMixin):
     description: 'Column[str | None]' = Column(Text, nullable=True)
 
     #: the required range of resources
-    number: 'Column[NumericRange]' = Column(INT4RANGE, nullable=False)
+    number: 'Column[BoundedIntegerRange]' = Column(INT4RANGE, nullable=False)
 
     #: true if volunteers may sign up for this
     accept_signups: 'Column[bool]' = Column(

--- a/src/onegov/activity/types.py
+++ b/src/onegov/activity/types.py
@@ -1,0 +1,29 @@
+from psycopg2.extras import NumericRange
+
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    class BoundedIntegerRange(NumericRange):
+        def __init__(
+            self,
+            lower: int,
+            upper: int,
+            bounds: str = '[)'
+        ) -> None: ...
+        @property
+        def upper(self) -> int: ...
+        @property
+        def lower(self) -> int: ...
+else:
+    # NOTE: We can probably get rid of this once we upgrade to SQLAlchemy 2.0
+    #       since they provide their own Range value types that we can inherit
+    #       from (if even necessary at that point).
+    def BoundedIntegerRange(
+        lower: int,
+        upper: int,
+        bounds: str = '[)'
+    ) -> NumericRange:
+        """
+        A NumericRange which can't be empty or have unbounded edges.
+        """
+        assert lower is not None and upper is not None
+        return NumericRange(lower, upper, bounds)


### PR DESCRIPTION
Resolves the following messages:
```
 src/onegov/activity/models/occasion.py:328: error: Unsupported operand types for >= ("int" and "None")  [operator]
src/onegov/activity/models/occasion.py:328: note: Right operand is of type "float | None"
src/onegov/activity/models/occasion.py:332: error: Unsupported operand types for - ("None" and "int")  [operator]
src/onegov/activity/models/occasion.py:332: note: Left operand is of type "float | None"
src/onegov/activity/models/occasion.py:351: error: Unsupported operand types for - ("None" and "int")  [operator]
src/onegov/activity/models/occasion.py:351: note: Left operand is of type "float | None"
src/onegov/activity/models/occasion.py:351: error: Incompatible return value type (got "float | int", expected "int")  [return-value]
src/onegov/activity/models/occasion.py:421: error: Argument "min_age" to "is_too_young" of "AgeBarrier" has incompatible type "float | None"; expected "int"  [arg-type]
src/onegov/activity/models/occasion.py:428: error: Unsupported operand types for - ("None" and "int")  [operator]
src/onegov/activity/models/occasion.py:428: note: Left operand is of type "float | None"
src/onegov/activity/models/occasion.py:428: error: Argument "max_age" to "is_too_old" of "AgeBarrier" has incompatible type "float | int"; expected "int"  [arg-type]
```

## Commit message

Feriennet: Fix type errors. 

TYPE: Bugfix

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I considered adding a reviewer