### PR TITLE
Ensure min age higher max age check by allowing age 0 (zero)

### DIFF
--- a/src/onegov/feriennet/forms/occasion.py
+++ b/src/onegov/feriennet/forms/occasion.py
@@ -275,7 +275,7 @@ class OccasionForm(Form):
         return valid
 
     def ensure_min_max_age(self):
-        if self.min_age.data is not None and self.max_age.data:
+        if self.min_age.data is not None and self.max_age.data is not None:
             if self.min_age.data > self.max_age.data:
                 self.min_age.errors = [
                     _("Minimum age must be lower than maximum age.")]


### PR DESCRIPTION
Feriennet: Occasion: Fix omitting verification of max age must be higher than min age for max age

max age higher than min age check can be omitted by setting max age to 0 (zero)

TYPE: Bugfix
LINK: ogc-1257
