### PR TITLE
Pin pycurl

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -119,7 +119,7 @@ install_requires =
     polib
     psycopg2
     purl
-    pycurl
+    pycurl<7.45.3
     pyparsing
     pyquery
     qrbill


### PR DESCRIPTION

Org: Pinning pycurl to 7.45.2

https://github.com/pycurl/pycurl/issues/834

TYPE: hotfix
