### PR TITLE
Adds option to pages not showing files in side panel

### DIFF
--- a/src/onegov/org/locale/de_CH/LC_MESSAGES/onegov.org.po
+++ b/src/onegov/org/locale/de_CH/LC_MESSAGES/onegov.org.po
@@ -5592,5 +5592,12 @@ msgstr "Ein Konto wurde für Sie erstellt"
 msgid "The user was created successfully"
 msgstr "Der Benutzer wurde erfolgreich erstellt"
 
+msgid ""
+"Files linked in text and uploaded files are no longer displayed in the "
+"sidebar if this option is deselected."
+msgstr ""
+"Im Text verlinkte Dateien und hochgeladene Dateien werden nicht mehr "
+"in der Seitenleiste angezeigt, wenn diese Option abgewählt ist."
+
 #~ msgid "Chat with"
 #~ msgstr "Chat mit"

--- a/src/onegov/org/locale/fr_CH/LC_MESSAGES/onegov.org.po
+++ b/src/onegov/org/locale/fr_CH/LC_MESSAGES/onegov.org.po
@@ -5610,5 +5610,12 @@ msgstr "Un compte a été créé pour vous"
 msgid "The user was created successfully"
 msgstr "L'utilisateur a bien été créé"
 
+msgid ""
+"Files linked in text and uploaded files are no longer displayed in the "
+"sidebar if this option is deselected."
+msgstr ""
+"Les fichiers liés dans le texte et les fichiers chargés ne sont plus "
+"affichés dans la barre latérale si cette option est désélectionnée."
+
 #~ msgid "Chat with"
 #~ msgstr "Chat avec"

--- a/src/onegov/org/locale/it_CH/LC_MESSAGES/onegov.org.po
+++ b/src/onegov/org/locale/it_CH/LC_MESSAGES/onegov.org.po
@@ -5604,6 +5604,13 @@ msgstr "È stato creato un account per te"
 msgid "The user was created successfully"
 msgstr "Utente creato correttamente"
 
+msgid ""
+"Files linked in text and uploaded files are no longer displayed in the "
+"sidebar if this option is deselected."
+msgstr ""
+"I file collegati nel testo e i file caricati non vengono più visualizzati "
+"nella barra laterale se questa opzione è deselezionata."
+
 #~ msgid "Chat with"
 #~ msgstr "Chat con"
 

--- a/src/onegov/org/models/extensions.py
+++ b/src/onegov/org/models/extensions.py
@@ -864,6 +864,30 @@ class GeneralFileLinkExtension(ContentExtension):
         class GeneralFileForm(form_class):  # type:ignore
             files = UploadOrSelectExistingMultipleFilesField(
                 label=_("Documents"),
+                fieldset=_("Documents")
             )
 
         return GeneralFileForm
+
+
+class FileLinksShownInSidebar(ContentExtension):
+    """ Extends any class that has a content dictionary field with a file
+    link list with the option to show/not show the file links in the sidebar.
+    """
+
+    show_file_links_in_sidebar: dict_property[bool] = (
+        meta_property(default=True))
+
+    def extend_form(
+        self,
+        form_class: type['_FormT'],
+        request: 'OrgRequest'
+    ) -> type['_FormT']:
+
+        class FileLinksShownInSidebarForm(form_class):  # type:ignore
+            show_file_links_in_sidebar = BooleanField(
+                label=_("Show file links in sidebar"),
+                fieldset=_("Documents")
+            )
+
+        return FileLinksShownInSidebarForm

--- a/src/onegov/org/models/extensions.py
+++ b/src/onegov/org/models/extensions.py
@@ -887,7 +887,12 @@ class FileLinksShownInSidebar(ContentExtension):
         class FileLinksShownInSidebarForm(form_class):  # type:ignore
             show_file_links_in_sidebar = BooleanField(
                 label=_("Show file links in sidebar"),
-                fieldset=_("Documents")
+                fieldset=_("Documents"),
+                description=_(
+                    "Files linked in text and uploaded files are no "
+                    "longer displayed in the sidebar if this option is "
+                    "deselected."
+                )
             )
 
         return FileLinksShownInSidebarForm

--- a/src/onegov/org/models/page.py
+++ b/src/onegov/org/models/page.py
@@ -8,7 +8,7 @@ from onegov.org.models.atoz import AtoZ
 from onegov.org.models.extensions import (
     ContactExtension, ContactHiddenOnPageExtension,
     PeopleShownOnMainPageExtension, ImageExtension,
-    NewsletterExtension, PublicationExtension
+    NewsletterExtension, PublicationExtension, FileLinksShownInSidebar
 )
 from onegov.org.models.extensions import AccessExtension
 from onegov.org.models.extensions import CoordinatesExtension
@@ -36,7 +36,7 @@ class Topic(Page, TraitInfo, SearchableContent, AccessExtension,
             ContactExtension, ContactHiddenOnPageExtension,
             PeopleShownOnMainPageExtension, PersonLinkExtension,
             CoordinatesExtension, ImageExtension,
-            GeneralFileLinkExtension):
+            GeneralFileLinkExtension, FileLinksShownInSidebar):
 
     __mapper_args__ = {'polymorphic_identity': 'topic'}
 

--- a/src/onegov/org/templates/macros.pt
+++ b/src/onegov/org/templates/macros.pt
@@ -578,7 +578,7 @@
                     <div tal:condition="coordinates" class="marker-map" data-map-type="thumbnail" data-lat="${coordinates.lat}" data-lon="${coordinates.lon}" data-zoom="${coordinates.zoom}" data-marker-icon="${marker_icon|nothing}" data-marker-color="${marker_color|nothing}"></div>
                     <div class="location" tal:condition="location">${location}</div>
                 </div>
-                <div class="side-panel files-panel" tal:condition="files">
+                <div class="side-panel files-panel" tal:condition="files and page.show_file_links_in_sidebar|True">
                     <h2 i18n:translate>Documents</h2>
                     <ul class="panel-links">
                         <li tal:repeat="file files">

--- a/src/onegov/town6/templates/macros.pt
+++ b/src/onegov/town6/templates/macros.pt
@@ -660,8 +660,6 @@
                 <div tal:condition="coordinates" class="marker-map" data-map-type="thumbnail" data-lat="${coordinates.lat}" data-lon="${coordinates.lon}" data-zoom="${coordinates.zoom}" data-marker-icon="${marker_icon|nothing}" data-marker-color="${marker_color|nothing}"></div>
                 <div class="location" tal:condition="location">${location}</div>
             </div>
-            ${page.show_file_links_in_sidebar}<br>
-            ${files}<br>
             <div class="side-panel files-panel" tal:condition="files and page.show_file_links_in_sidebar|True">
                 <h3 i18n:translate>Documents</h3>
                 <ul class="more-list">

--- a/src/onegov/town6/templates/macros.pt
+++ b/src/onegov/town6/templates/macros.pt
@@ -660,7 +660,9 @@
                 <div tal:condition="coordinates" class="marker-map" data-map-type="thumbnail" data-lat="${coordinates.lat}" data-lon="${coordinates.lon}" data-zoom="${coordinates.zoom}" data-marker-icon="${marker_icon|nothing}" data-marker-color="${marker_color|nothing}"></div>
                 <div class="location" tal:condition="location">${location}</div>
             </div>
-            <div class="side-panel files-panel" tal:condition="files">
+            ${page.show_file_links_in_sidebar}<br>
+            ${files}<br>
+            <div class="side-panel files-panel" tal:condition="files and page.show_file_links_in_sidebar|True">
                 <h3 i18n:translate>Documents</h3>
                 <ul class="more-list">
                     <li tal:repeat="file files">

--- a/tests/shared/utils.py
+++ b/tests/shared/utils.py
@@ -41,6 +41,8 @@ def open_in_browser(response, browser='firefox'):
     path = f'/tmp/test-{str(uuid4())}.html'
     with open(path, 'w') as f:
         print(response.text, file=f)
+    # os.system(f'{browser} {path} &')
+    print(f'Opening file {path} ..')
     os.system(f'{browser} {path} &')
 
 
@@ -83,6 +85,16 @@ def create_image(width=50, height=50, output=None):
 
     im.seek(0)
     return im
+
+
+def create_pdf(filename='simple.pdf'):
+    from reportlab.pdfgen import canvas
+
+    c = canvas.Canvas(filename)
+    c.drawString(100, 750,
+                 "Hello, I am a PDF document created with Python!")
+    c.save()
+    return c
 
 
 def assert_explicit_permissions(module, app_class):


### PR DESCRIPTION
Org: Per page option to switch off showing files in the sidebar

TYPE: Feature
LINK: ogc-1477

## Checklist

- [ ] I have performed a self-review of my code
- [x] I considered adding a reviewer
- [x] I have updated the PO files
- [ ] I made changes/features for both org and town6
- [ ] I have tested my code thoroughly by hand
    - [ ] I have tested styling changes/features on different browsers
    - [ ] I have tested javascript changes/features on different browsers
    - [ ] I have tested database upgrades
    - [ ] I have tested sending mails
    - [ ] I have tested building the documentation
- [ ] I have added tests for my changes/features
    - [ ] I am using freezegun for tests depending on date and times
    - [ ] I considered using browser tests für javascript changes/features
    - [ ] I have added/updated jest tests for d3rendering (election_day, swissvotes)
