### PR TITLE
Org: Makes autofill of honeypot field in mTAN forms less likely

### DIFF
--- a/src/onegov/org/forms/mtan.py
+++ b/src/onegov/org/forms/mtan.py
@@ -19,9 +19,9 @@ class MTANForm(Form):
         validators=[InputRequired()]
     )
 
-    name = HoneyPotField(
+    duplicate_of = HoneyPotField(
         render_kw={
-            'autocomplete': 'off'
+            'autocomplete': 'lazy-wolves'
         }
     )
 
@@ -49,8 +49,8 @@ class RequestMTANForm(Form):
         }
     )
 
-    name = HoneyPotField(
+    duplicate_of = HoneyPotField(
         render_kw={
-            'autocomplete': 'off'
+            'autocomplete': 'lazy-wolves'
         }
     )


### PR DESCRIPTION
## Commit message

Org: Makes autofill of honeypot field in mTAN forms less likely

TYPE: Bugfix
LINK: OGC-1484

## Checklist

- [x] I have performed a self-review of my code
- [x] I have tested my code thoroughly by hand