### PR TITLE
Add rule that somehow makes navigation reappear for safari

### DIFF
--- a/src/onegov/town6/theme/styles/town6.scss
+++ b/src/onegov/town6/theme/styles/town6.scss
@@ -1005,15 +1005,21 @@ ul.recipients {
 }
 
 .videowrapper {
-	position: relative;
-	height: 0;
-	padding-bottom: 45%;
+    height: 0;
+    padding-bottom: 45%;
+    position: relative;
 }
 
 .videowrapper iframe {
-	position: absolute;
-	top: 0;
-	left: 0;
-	width: 100%;
-	height: 100%;
+    height: 100%;
+    left: 0;
+    position: absolute;
+    top: 0;
+    width: 100%;
+}
+
+@media #{$small-only} {
+    #offCanvas {
+        overflow-y: hidden !important;
+    }
 }


### PR DESCRIPTION
Please fill in the commit message below and work through the checklist. You can delete parts that are not needed, e.g. the optional description, the link to a ticket or irrelevant options of the checklist.

## Commit message

Town6: Bug Fix for hidden navigation in safari

TYPE: Bugfix
LINK: OGC-1570