### PR TITLE
Align help text left

### DIFF
--- a/src/onegov/town6/theme/styles/forms.scss
+++ b/src/onegov/town6/theme/styles/forms.scss
@@ -75,11 +75,11 @@ form {
     .field-help {
         color: $steel;
         font-size: .8rem;
-        margin-left: 1.6rem;
+        margin-left: 25px;
     }
 
     input + .label-text + .field-help {
-        margin-left: 1.8rem;
+        margin-left: 25px;
     }
 
     .long-field-help,


### PR DESCRIPTION
Town6: Forms: Left align input text with help text below

TYPE: Bugfix
LINK: ogc-888
