### PR TITLE
Ogc 1150 segmented notifications

### DIFF
--- a/src/onegov/election_day/app.py
+++ b/src/onegov/election_day/app.py
@@ -385,6 +385,7 @@ def get_common_asset() -> 'Iterator[str]':
 def get_custom_asset() -> 'Iterator[str]':
     # common code
     yield 'common.js'
+    yield 'form_dependencies.js'
 
     # D3 charts and maps
     yield 'd3.chart.bar.js'
@@ -410,7 +411,6 @@ def get_backend_common_asset() -> 'Iterator[str]':
     yield 'jquery.datetimepicker.css'
     yield 'jquery.datetimepicker.js'
     yield 'datetimepicker.js'
-    yield 'form_dependencies.js'
     yield 'doubleclick.js'
 
 

--- a/src/onegov/election_day/cli.py
+++ b/src/onegov/election_day/cli.py
@@ -8,6 +8,7 @@ from onegov.core.cli import pass_group_context
 from onegov.core.sms_processor import SmsQueueProcessor
 from onegov.election_day.collections import ArchivedResultCollection
 from onegov.election_day.models import ArchivedResult
+from onegov.election_day.models import Subscriber
 from onegov.election_day.utils import add_local_results
 from onegov.election_day.utils.archive_generator import ArchiveGenerator
 from onegov.election_day.utils.d3_renderer import D3Renderer
@@ -201,3 +202,22 @@ def update_archived_results(host: str, scheme: str) -> 'Processor':
         archive.update_all(request)
 
     return generate
+
+
+@cli.command('migrate-subscribers')
+def migrate_subscribers() -> 'Processor':
+    def migrate(request: 'ElectionDayRequest', app: 'ElectionDayApp') -> None:
+        if not app.principal or not app.principal.segmented_notifications:
+            return
+
+        click.secho(f'Migrating {app.schema}', fg='yellow')
+
+        session = request.app.session()
+        subscribers = session.query(Subscriber).filter_by(domain=None)
+        count = 0
+        for subscriber in subscribers:
+            subscriber.domain = 'canton'
+            count += 1
+        click.echo(f'Migrated {count} subscribers')
+
+    return migrate

--- a/src/onegov/election_day/collections/notifications.py
+++ b/src/onegov/election_day/collections/notifications.py
@@ -1,3 +1,4 @@
+from itertools import chain
 from onegov.ballot import Election
 from onegov.ballot import ElectionCompound
 from onegov.ballot import Vote
@@ -11,6 +12,7 @@ from onegov.election_day.models import WebhookNotification
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from collections.abc import Collection
+    from collections.abc import Iterator
     from collections.abc import Sequence
     from onegov.election_day.request import ElectionDayRequest
     from sqlalchemy.orm import Query
@@ -94,27 +96,21 @@ class NotificationCollection:
 
         """
 
-        if not (elections or election_compounds or votes) or not options:
+        model_chain: 'Iterator[Election|ElectionCompound|Vote]'
+        model_chain = chain(elections, election_compounds, votes)
+        models = tuple(model_chain)
+
+        if not models or not options:
             return
 
         notification: Notification
 
         if 'email' in options and request.app.principal.email_notification:
             completed = True
-            for election in elections:
-                completed &= election.completed
+            for model in models:
+                completed &= model.completed
                 notification = EmailNotification()
-                notification.update_from_model(election)
-                self.session.add(notification)
-            for election_compound in election_compounds:
-                completed &= election_compound.completed
-                notification = EmailNotification()
-                notification.update_from_model(election_compound)
-                self.session.add(notification)
-            for vote in votes:
-                completed &= vote.completed
-                notification = EmailNotification()
-                notification.update_from_model(vote)
+                notification.update_from_model(model)
                 self.session.add(notification)
 
             notification = EmailNotification()
@@ -128,22 +124,17 @@ class NotificationCollection:
             )
 
         if 'sms' in options and request.app.principal.sms_notification:
-            for election in elections:
+            for model in models:
                 notification = SmsNotification()
-                notification.update_from_model(election)
-                self.session.add(notification)
-            for election_compound in election_compounds:
-                notification = SmsNotification()
-                notification.update_from_model(election_compound)
-                self.session.add(notification)
-            for vote in votes:
-                notification = SmsNotification()
-                notification.update_from_model(vote)
+                notification.update_from_model(model)
                 self.session.add(notification)
 
             notification = SmsNotification()
             notification.send_sms(
                 request,
+                elections,
+                election_compounds,
+                votes,
                 _(
                     "New results are available on ${url}",
                     mapping={'url': request.app.principal.sms_notification}
@@ -151,17 +142,9 @@ class NotificationCollection:
             )
 
         if 'webhooks' in options and request.app.principal.webhooks:
-            for election in elections:
+            for model in models:
                 notification = WebhookNotification()
-                notification.trigger(request, election)
-                self.session.add(notification)
-            for election_compound in election_compounds:
-                notification = WebhookNotification()
-                notification.trigger(request, election_compound)
-                self.session.add(notification)
-            for vote in votes:
-                notification = WebhookNotification()
-                notification.trigger(request, vote)
+                notification.trigger(request, model)
                 self.session.add(notification)
 
         self.session.flush()

--- a/src/onegov/election_day/collections/subscribers.py
+++ b/src/onegov/election_day/collections/subscribers.py
@@ -66,9 +66,18 @@ class SubscriberCollection(Pagination[_S]):
     def for_active_only(self, active_only: bool) -> 'Self':
         return self.__class__(self.session, 0, self.term, active_only)
 
-    def add(self, address: str, locale: str, active: bool) -> _S:
+    def add(
+        self,
+        address: str,
+        domain: str | None,
+        domain_segment: str | None,
+        locale: str,
+        active: bool
+    ) -> _S:
         subscriber = self.model_class(
             address=address,
+            domain=domain,
+            domain_segment=domain_segment,
             locale=locale,
             active=active
         )
@@ -98,16 +107,27 @@ class SubscriberCollection(Pagination[_S]):
         query = query.filter(self.model_class.id == id)
         return query.first()
 
-    def by_address(self, address: str) -> _S | None:
+    def by_address(
+        self,
+        address: str,
+        domain: str | None,
+        domain_segment: str | None,
+    ) -> _S | None:
         """ Returns the (first) subscriber by its address. """
 
         query = self.query(active_only=False)
-        query = query.filter(self.model_class.address == address)
+        query = query.filter(
+            self.model_class.address == address,
+            self.model_class.domain == domain,
+            self.model_class.domain_segment == domain_segment,
+        )
         return query.first()
 
     def initiate_subscription(
         self,
         address: str,
+        domain: str | None,
+        domain_segment: str | None,
         request: 'ElectionDayRequest'
     ) -> _S:
         """ Initiate the subscription process.
@@ -116,19 +136,23 @@ class SubscriberCollection(Pagination[_S]):
 
         """
 
-        subscriber = self.by_address(address)
+        subscriber = self.by_address(address, domain, domain_segment)
         if not subscriber:
             locale = request.locale
             assert locale is not None
-            subscriber = self.add(address, locale, False)
+            subscriber = self.add(
+                address, domain, domain_segment, locale, False
+            )
 
-        self.handle_subscription(subscriber, request)
+        self.handle_subscription(subscriber, domain, domain_segment, request)
 
         return subscriber
 
     def handle_subscription(
         self,
         subscriber: _S,
+        domain: str | None,
+        domain_segment: str | None,
         request: 'ElectionDayRequest'
     ) -> None:
         """ Send the subscriber a request to confirm the subscription. """
@@ -138,11 +162,13 @@ class SubscriberCollection(Pagination[_S]):
     def initiate_unsubscription(
         self,
         address: str,
+        domain: str | None,
+        domain_segment: str | None,
         request: 'ElectionDayRequest'
     ) -> None:
         """ Initiate the unsubscription process. """
 
-        subscriber = self.by_address(address)
+        subscriber = self.by_address(address, domain, domain_segment)
         if subscriber:
             self.handle_unsubscription(subscriber, request)
 
@@ -151,8 +177,7 @@ class SubscriberCollection(Pagination[_S]):
         subscriber: _S,
         request: 'ElectionDayRequest'
     ) -> None:
-        """ Send the subscriber a request to confirm the unsubscription.
-        """
+        """ Send the subscriber a request to confirm the unsubscription. """
 
         raise NotImplementedError()
 
@@ -162,6 +187,8 @@ class SubscriberCollection(Pagination[_S]):
         return [
             {
                 'address': subscriber.address,
+                'domain': subscriber.domain,
+                'domain_segment': subscriber.domain_segment,
                 'locale': subscriber.locale,
                 'active': subscriber.active
             }
@@ -174,7 +201,11 @@ class SubscriberCollection(Pagination[_S]):
         mimetype: str,
         delete: bool
     ) -> tuple[list['FileImportError'], int]:
-        """ Disables or deletes the subscribers in the given CSV. """
+        """ Disables or deletes the subscribers in the given CSV.
+
+        Ignores domain and domain segment, as this is inteded to cleanup
+        bounced addresses.
+        """
 
         csv, error = load_csv(file, mimetype, expected_headers=['address'])
         if error:
@@ -206,6 +237,8 @@ class EmailSubscriberCollection(SubscriberCollection[EmailSubscriber]):
     def handle_subscription(
         self,
         subscriber: EmailSubscriber,
+        domain: str | None,
+        domain_segment: str | None,
         request: 'ElectionDayRequest'
     ) -> None:
         """ Send the (new) subscriber a request to confirm the subscription.
@@ -216,6 +249,8 @@ class EmailSubscriberCollection(SubscriberCollection[EmailSubscriber]):
 
         token = request.new_url_safe_token({
             'address': subscriber.address,
+            'domain': domain,
+            'domain_segment': domain_segment,
             'locale': request.locale
         })
         optin = request.link(request.app.principal, 'optin-email')
@@ -252,10 +287,16 @@ class EmailSubscriberCollection(SubscriberCollection[EmailSubscriber]):
             }
         )
 
-    def confirm_subscription(self, address: str, locale: str) -> bool:
+    def confirm_subscription(
+        self,
+        address: str,
+        domain: str | None,
+        domain_segment: str | None,
+        locale: str,
+    ) -> bool:
         """ Confirm the subscription. """
 
-        subscriber = self.by_address(address)
+        subscriber = self.by_address(address, domain, domain_segment)
         if subscriber:
             subscriber.active = True
             subscriber.locale = locale
@@ -272,7 +313,11 @@ class EmailSubscriberCollection(SubscriberCollection[EmailSubscriber]):
 
         from onegov.election_day.layouts import MailLayout  # circular
 
-        token = request.new_url_safe_token({'address': subscriber.address})
+        token = request.new_url_safe_token({
+            'address': subscriber.address,
+            'domain': subscriber.domain,
+            'domain_segment': subscriber.domain_segment
+        })
         optout = request.link(request.app.principal, 'optout-email')
         optout = f'{optout}?opaque={token}'
 
@@ -304,10 +349,15 @@ class EmailSubscriberCollection(SubscriberCollection[EmailSubscriber]):
             }
         )
 
-    def confirm_unsubscription(self, address: str) -> bool:
+    def confirm_unsubscription(
+        self,
+        address: str,
+        domain: str | None,
+        domain_segment: str | None,
+    ) -> bool:
         """ Confirm the unsubscription. """
 
-        subscriber = self.by_address(address)
+        subscriber = self.by_address(address, domain, domain_segment)
         if subscriber:
             subscriber.active = False
             return True
@@ -323,6 +373,8 @@ class SmsSubscriberCollection(SubscriberCollection[SmsSubscriber]):
     def handle_subscription(
         self,
         subscriber: SmsSubscriber,
+        domain: str | None,
+        domain_segment: str | None,
         request: 'ElectionDayRequest'
     ) -> None:
         """ Confirm the subscription by sending an SMS (if not already

--- a/src/onegov/election_day/locale/de_CH/LC_MESSAGES/onegov.election_day.po
+++ b/src/onegov/election_day/locale/de_CH/LC_MESSAGES/onegov.election_day.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-14 08:27+0200\n"
+"POT-Creation-Date: 2024-04-26 13:21+0200\n"
 "PO-Revision-Date: 2022-03-24 15:35+0100\n"
 "Last-Translator: Marc Sommerhalder <marc.sommerhalder@seantis.ch>\n"
 "Language-Team: German\n"
@@ -757,6 +757,30 @@ msgstr "Vorlage"
 msgid "Tie-Breaker"
 msgstr "Stichfrage"
 
+msgid "Yay"
+msgstr "Ja"
+
+msgid "Nay"
+msgstr "Nein"
+
+msgid "Yeas"
+msgstr "Ja-Stimmen"
+
+msgid "Nays"
+msgstr "Nein-Stimmen"
+
+msgid "Proposal %"
+msgstr "Vorlage %"
+
+msgid "Yes %"
+msgstr "Ja %"
+
+msgid "Counter proposal %"
+msgstr "Gegenentwurf %"
+
+msgid "No %"
+msgstr "Nein %"
+
 #, python-format
 msgid "Regional (${on})"
 msgstr "Regional (${on})"
@@ -863,12 +887,6 @@ msgstr "Noch keine Resultate"
 
 msgid "Result"
 msgstr "Resultat"
-
-msgid "Yes %"
-msgstr "Ja %"
-
-msgid "No %"
-msgstr "Nein %"
 
 msgid "Archive Search"
 msgstr "Archivsuche"
@@ -1017,18 +1035,6 @@ msgstr "Resultate löschen"
 msgid "Clear media"
 msgstr "Medien löschen"
 
-msgid "Yeas"
-msgstr "Ja-Stimmen"
-
-msgid "Nays"
-msgstr "Nein-Stimmen"
-
-msgid "Proposal %"
-msgstr "Vorlage %"
-
-msgid "Counter proposal %"
-msgstr "Gegenentwurf %"
-
 msgid "Not yet counted"
 msgstr "Noch nicht ausgezählt"
 
@@ -1054,12 +1060,6 @@ msgstr "Ungültige Stimmen"
 #.
 msgid "turnout_vote"
 msgstr "Stimmbeteiligung"
-
-msgid "Nay"
-msgstr "Nein"
-
-msgid "Yay"
-msgstr "Ja"
 
 msgid "List connection"
 msgstr "Listenverbindung"

--- a/src/onegov/election_day/locale/fr_CH/LC_MESSAGES/onegov.election_day.po
+++ b/src/onegov/election_day/locale/fr_CH/LC_MESSAGES/onegov.election_day.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-14 08:27+0200\n"
+"POT-Creation-Date: 2024-04-26 13:21+0200\n"
 "PO-Revision-Date: 2022-03-22 07:59+0100\n"
 "Last-Translator: Marc Sommerhalder <marc.sommerhalder@seantis.ch>\n"
 "Language-Team: \n"
@@ -758,6 +758,30 @@ msgstr "Objet de la votation"
 msgid "Tie-Breaker"
 msgstr "Question subsidiaire"
 
+msgid "Yay"
+msgstr "Oui"
+
+msgid "Nay"
+msgstr "Non"
+
+msgid "Yeas"
+msgstr "Oui"
+
+msgid "Nays"
+msgstr "Non"
+
+msgid "Proposal %"
+msgstr "Objet de la votation %"
+
+msgid "Yes %"
+msgstr "Oui %"
+
+msgid "Counter proposal %"
+msgstr "Contre-projet %"
+
+msgid "No %"
+msgstr "Non %"
+
 #, python-format
 msgid "Regional (${on})"
 msgstr "Régional (${on})"
@@ -864,12 +888,6 @@ msgstr "Pas de résultats à l'heure actuelle"
 
 msgid "Result"
 msgstr "Résultat"
-
-msgid "Yes %"
-msgstr "Oui %"
-
-msgid "No %"
-msgstr "Non %"
 
 msgid "Archive Search"
 msgstr "Recherche dans les archives"
@@ -1019,18 +1037,6 @@ msgstr "Effacer les résultats"
 msgid "Clear media"
 msgstr "Supprimer le média"
 
-msgid "Yeas"
-msgstr "Oui"
-
-msgid "Nays"
-msgstr "Non"
-
-msgid "Proposal %"
-msgstr "Objet de la votation %"
-
-msgid "Counter proposal %"
-msgstr "Contre-projet %"
-
 msgid "Not yet counted"
 msgstr "Pas encore compté"
 
@@ -1056,12 +1062,6 @@ msgstr "Votes non valides"
 #.
 msgid "turnout_vote"
 msgstr "Participation au vote"
-
-msgid "Nay"
-msgstr "Non"
-
-msgid "Yay"
-msgstr "Oui"
 
 msgid "List connection"
 msgstr "Connexion de listes"

--- a/src/onegov/election_day/locale/it_CH/LC_MESSAGES/onegov.election_day.po
+++ b/src/onegov/election_day/locale/it_CH/LC_MESSAGES/onegov.election_day.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-14 08:27+0200\n"
+"POT-Creation-Date: 2024-04-26 13:21+0200\n"
 "PO-Revision-Date: 2022-03-22 08:00+0100\n"
 "Last-Translator: Marc Sommerhalder <marc.sommerhalder@seantis.ch>\n"
 "Language-Team: \n"
@@ -752,6 +752,30 @@ msgstr "Oggetto della votazione"
 msgid "Tie-Breaker"
 msgstr "Domanda risolutiva"
 
+msgid "Yay"
+msgstr "Sì"
+
+msgid "Nay"
+msgstr "No"
+
+msgid "Yeas"
+msgstr "Voti favorevoli"
+
+msgid "Nays"
+msgstr "Voti contrari"
+
+msgid "Proposal %"
+msgstr "Oggetto della votazione %"
+
+msgid "Yes %"
+msgstr "Sì %"
+
+msgid "Counter proposal %"
+msgstr "Controprogett %"
+
+msgid "No %"
+msgstr "No %"
+
 #, python-format
 msgid "Regional (${on})"
 msgstr "Regionale (${on})"
@@ -858,12 +882,6 @@ msgstr "Ancora nessun risultato"
 
 msgid "Result"
 msgstr "Risultato"
-
-msgid "Yes %"
-msgstr "Sì %"
-
-msgid "No %"
-msgstr "No %"
 
 msgid "Archive Search"
 msgstr "Ricerca in archivio"
@@ -1012,18 +1030,6 @@ msgstr "Ripristina risultati"
 msgid "Clear media"
 msgstr "Cancellare i media"
 
-msgid "Yeas"
-msgstr "Voti favorevoli"
-
-msgid "Nays"
-msgstr "Voti contrari"
-
-msgid "Proposal %"
-msgstr "Oggetto della votazione %"
-
-msgid "Counter proposal %"
-msgstr "Controprogett %"
-
 msgid "Not yet counted"
 msgstr "Non ancora conteggiato"
 
@@ -1049,12 +1055,6 @@ msgstr "Voti nulli"
 #.
 msgid "turnout_vote"
 msgstr "Partecipazione al voto"
-
-msgid "Nay"
-msgstr "No"
-
-msgid "Yay"
-msgstr "Sì"
 
 msgid "List connection"
 msgstr "Collegamenti tra liste"

--- a/src/onegov/election_day/locale/rm_CH/LC_MESSAGES/onegov.election_day.po
+++ b/src/onegov/election_day/locale/rm_CH/LC_MESSAGES/onegov.election_day.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-14 08:27+0200\n"
+"POT-Creation-Date: 2024-04-26 13:21+0200\n"
 "PO-Revision-Date: 2022-03-22 08:01+0100\n"
 "Last-Translator: Marc Sommerhalder <marc.sommerhalder@seantis.ch>\n"
 "Language-Team: \n"
@@ -764,6 +764,30 @@ msgstr "Project da votaziun"
 msgid "Tie-Breaker"
 msgstr "Dumonda decisiva"
 
+msgid "Yay"
+msgstr "GEA"
+
+msgid "Nay"
+msgstr "NA"
+
+msgid "Yeas"
+msgstr "Vuschs affirmativas"
+
+msgid "Nays"
+msgstr "Vuschs negativas"
+
+msgid "Proposal %"
+msgstr "Project da votaziun %"
+
+msgid "Yes %"
+msgstr "% GEA"
+
+msgid "Counter proposal %"
+msgstr "Cuntraproposta %"
+
+msgid "No %"
+msgstr "% NA"
+
 #, python-format
 msgid "Regional (${on})"
 msgstr "Plaun regiunal (${on})"
@@ -870,12 +894,6 @@ msgstr "Anc nagins resultats avant maun"
 
 msgid "Result"
 msgstr "Resultat"
-
-msgid "Yes %"
-msgstr "% GEA"
-
-msgid "No %"
-msgstr "% NA"
 
 msgid "Archive Search"
 msgstr "Tschertga en l'archiv"
@@ -1026,18 +1044,6 @@ msgstr "Stizzar ils resultats"
 msgid "Clear media"
 msgstr "Stizzar las medias"
 
-msgid "Yeas"
-msgstr "Vuschs affirmativas"
-
-msgid "Nays"
-msgstr "Vuschs negativas"
-
-msgid "Proposal %"
-msgstr "Project da votaziun %"
-
-msgid "Counter proposal %"
-msgstr "Cuntraproposta %"
-
 msgid "Not yet counted"
 msgstr "Anc betg eruì il resultat"
 
@@ -1063,12 +1069,6 @@ msgstr "Vuschs nunvalaivlas"
 #.
 msgid "turnout_vote"
 msgstr "Participaziun a la votaziun"
-
-msgid "Nay"
-msgstr "NA"
-
-msgid "Yay"
-msgstr "GEA"
 
 msgid "List connection"
 msgstr "Colliaziun da glistas"

--- a/src/onegov/election_day/models/notification.py
+++ b/src/onegov/election_day/models/notification.py
@@ -309,6 +309,9 @@ class SmsNotification(Notification):
     def send_sms(
         self,
         request: 'ElectionDayRequest',
+        elections: 'Sequence[Election]',
+        election_compounds: 'Sequence[ElectionCompound]',
+        votes: 'Sequence[Vote]',
         content: 'TranslationString'
     ) -> None:
         """ Sends the given text to all subscribers. """
@@ -344,7 +347,12 @@ class SmsNotification(Notification):
 
         self.send_sms(
             request,
-            _(
+            elections=[model] if isinstance(model, Election) else [],
+            election_compounds=(
+                [model] if isinstance(model, ElectionCompound) else []
+            ),
+            votes=[model] if isinstance(model, Vote) else [],
+            content=_(
                 "New results are available on ${url}",
                 mapping={'url': request.app.principal.sms_notification}
             )

--- a/src/onegov/election_day/models/subscriber.py
+++ b/src/onegov/election_day/models/subscriber.py
@@ -49,6 +49,12 @@ class Subscriber(Base, TimestampMixin):
     #: True, if the subscriber has been confirmed
     active: 'Column[bool | None]' = Column(Boolean, nullable=True)
 
+    #: The domain of the election compound part.
+    domain: 'Column[str | None]' = Column(Text, nullable=True)
+
+    #: The domain segment of the election compound part.
+    domain_segment: 'Column[str | None]' = Column(Text, nullable=True)
+
 
 class SmsSubscriber(Subscriber):
 

--- a/src/onegov/election_day/templates/macros.pt
+++ b/src/onegov/election_day/templates/macros.pt
@@ -321,7 +321,7 @@
             data-label-left-hand="${layout.label('Nay')}"
             data-label-right-hand="${layout.label('Yay')}"
             data-label-expats="Expats"
-            i18n:attributes="data-embed-link; data-label-left-hand; data-label-right-hand; data-label-expats"
+            i18n:attributes="data-embed-link; data-label-expats"
             >
         </div>
     </tal:block>
@@ -335,7 +335,7 @@
             data-label-left-hand="${layout.label('Nay')}"
             data-label-right-hand="${layout.label('Yay')}"
             data-label-expats="Expats"
-            i18n:attributes="data-label-left-hand; data-label-right-hand; data-label-expats"
+            i18n:attributes="data-label-expats"
             >
         </div>
     </tal:block>
@@ -354,7 +354,7 @@
             data-label-left-hand="${layout.label('Nay')}"
             data-label-right-hand="${layout.label('Yay')}"
             data-label-expats="Expats"
-            i18n:attributes="data-embed-link; data-label-left-hand; data-label-right-hand; data-label-expats"
+            i18n:attributes="data-embed-link; data-label-expats"
             >
         </div>
     </tal:block>
@@ -368,7 +368,7 @@
             data-label-left-hand="${layout.label('Nay')}"
             data-label-right-hand="${layout.label('Yay')}"
             data-label-expats="Expats"
-            i18n:attributes="data-label-left-hand; data-label-right-hand; data-label-expats"
+            i18n:attributes="data-label-expats"
             >
         </div>
     </tal:block>

--- a/src/onegov/election_day/templates/manage/subscribers.pt
+++ b/src/onegov/election_day/templates/manage/subscribers.pt
@@ -56,6 +56,7 @@
                     <thead>
                         <tr>
                             <th>${address_title}</th>
+                            <th tal:condition="request.app.principal.segmented_notifications" i18n:translate>Domain</th>
                             <th i18n:translate>Locale</th>
                             <th i18n:translate>Active</th>
                             <th i18n:translate class="row-actions right-aligned">Actions</th>
@@ -64,6 +65,10 @@
                     <tbody>
                     <tr tal:repeat="subscriber subscribers">
                         <td>${subscriber.address}</td>
+                        <td tal:condition="request.app.principal.segmented_notifications">
+                            <tal:block tal:condition="subscriber.domain == 'canton'" i18n:translate>Cantonal</tal:block>
+                            <tal:block tal:condition="subscriber.domain_segment" i18n:translate>${subscriber.domain_segment}</tal:block>
+                        </td>
                         <td>${subscriber.locale}</td>
                         <td tal:condition="subscriber.active">✔︎</td>
                         <td tal:condition="not subscriber.active">✘︎</td>

--- a/src/onegov/election_day/upgrade.py
+++ b/src/onegov/election_day/upgrade.py
@@ -235,3 +235,13 @@ def make_upload_take_none_nullable(context: UpgradeContext) -> None:
         context.operations.alter_column(
             'upload_tokens', 'token', nullable=False
         )
+
+
+@upgrade_task('Add domain and segment to subscribers')
+def add_domain_and_segment_to_subscribers(context: UpgradeContext) -> None:
+    for column in ('domain', 'domain_segment'):
+        if not context.has_column('subscribers', column):
+            context.operations.add_column(
+                'subscribers',
+                Column(column, Text, nullable=True)
+            )

--- a/src/onegov/election_day/utils/__init__.py
+++ b/src/onegov/election_day/utils/__init__.py
@@ -6,6 +6,7 @@ from onegov.election_day.utils.common import get_parameter
 from onegov.election_day.utils.common import replace_url
 from onegov.election_day.utils.filenames import pdf_filename
 from onegov.election_day.utils.filenames import svg_filename
+from onegov.election_day.utils.notification import segment_models
 from onegov.election_day.utils.summaries import get_election_compound_summary
 from onegov.election_day.utils.summaries import get_election_summary
 from onegov.election_day.utils.summaries import get_summaries
@@ -26,5 +27,6 @@ __all__ = (
     'get_vote_summary',
     'pdf_filename',
     'replace_url',
+    'segment_models',
     'svg_filename',
 )

--- a/src/onegov/election_day/utils/notification.py
+++ b/src/onegov/election_day/utils/notification.py
@@ -1,0 +1,97 @@
+from itertools import chain
+from onegov.election_day.models.subscriber import Subscriber
+from sqlalchemy import and_
+from typing import NamedTuple
+
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from collections.abc import Sequence
+    from onegov.ballot.models import Election
+    from onegov.ballot.models import ElectionCompound
+    from onegov.ballot.models import Vote
+    from sqlalchemy.sql import ColumnElement
+    from typing import Literal
+    from typing import TypeAlias
+
+    DomainSubset: TypeAlias = Literal['canton', 'municipality'] | None
+
+
+class ModelGroup(NamedTuple):
+    domain: 'DomainSubset'
+    domain_segment: str | None
+    elections: 'Sequence[Election]'
+    election_compounds: 'Sequence[ElectionCompound]'
+    votes: 'Sequence[Vote]'
+    filter: 'ColumnElement[bool]'
+
+
+def segment_models(
+    elections: 'Sequence[Election]',
+    election_compounds: 'Sequence[ElectionCompound]',
+    votes: 'Sequence[Vote]'
+) -> list[ModelGroup]:
+    """ Group elections, compounds and votes by subscribable notification
+    segmenation.
+
+    """
+
+    model_chain: 'Iterator[Election|ElectionCompound|Vote]'
+    model_chain = chain(elections, election_compounds, votes)
+    models = tuple(model_chain)
+    if not models:
+        return []
+
+    domains_and_segments: set[tuple['DomainSubset', str | None]]
+    domains_and_segments = {
+        (
+            'municipality' if model.domain == 'municipality' else 'canton',
+            getattr(model, 'domain_segment', None) or None
+        )
+        for model in models
+    }
+
+    def match_(
+        model: 'Election | ElectionCompound | Vote',
+        domain: 'DomainSubset',
+        domain_segment: str | None
+    ) -> bool:
+        if domain != 'municipality':
+            return model.domain != 'municipality'
+        return (
+            model.domain == 'municipality'
+            and getattr(model, 'domain_segment', None) == domain_segment
+        )
+
+    result = [
+        ModelGroup(
+            domain=None,
+            domain_segment=None,
+            elections=elections,
+            election_compounds=election_compounds,
+            votes=votes,
+            filter=Subscriber.domain.is_(None)
+        )
+    ]
+    for domain, domain_segment in domains_and_segments:
+        result.append(
+            ModelGroup(
+                domain=domain,
+                domain_segment=domain_segment,
+                elections=[
+                    m for m in elections if match_(m, domain, domain_segment)
+                ],
+                election_compounds=[
+                    m for m in election_compounds
+                    if match_(m, domain, domain_segment)
+                ],
+                votes=[m for m in votes if match_(m, domain, domain_segment)],
+                filter=and_(
+                    Subscriber.domain == 'municipality',
+                    Subscriber.domain_segment == domain_segment
+                ) if domain == 'municipality'
+                else Subscriber.domain != 'municipality',
+            )
+        )
+
+    return result

--- a/src/onegov/election_day/views/subscription.py
+++ b/src/onegov/election_day/views/subscription.py
@@ -40,7 +40,12 @@ def subscribe_email(
     if form.submitted(request):
         assert form.email.data is not None
         subscribers = EmailSubscriberCollection(request.session)
-        subscribers.initiate_subscription(form.email.data, request)
+        subscribers.initiate_subscription(
+            form.email.data,
+            form.domain.data if form.domain else None,
+            form.domain_segment.data if form.domain_segment else None,
+            request
+        )
         callout = _(
             "You will shortly receive an email to confirm your email."
         )
@@ -79,13 +84,18 @@ def optin_email(
         assert data is not None
         address = data['address']
         locale = data['locale']
+        domain = data.get('domain')
+        domain_segment = data.get('domain_segment')
         assert address
         assert locale
     except Exception:
         log.warning('Invalid email optin')
     else:
         subscribers = EmailSubscriberCollection(request.session)
-        if subscribers.confirm_subscription(address, locale):
+        result = subscribers.confirm_subscription(
+            address, domain, domain_segment, locale
+        )
+        if result:
             callout = _(
                 "Successfully subscribed to the email service. You will "
                 "receive an email every time new results are published."
@@ -119,7 +129,12 @@ def unsubscribe_email(
     if form.submitted(request):
         assert form.email.data is not None
         subscribers = EmailSubscriberCollection(request.session)
-        subscribers.initiate_unsubscription(form.email.data, request)
+        subscribers.initiate_unsubscription(
+            form.email.data,
+            form.domain.data if form.domain else None,
+            form.domain_segment.data if form.domain_segment else None,
+            request
+        )
         callout = _(
             "You will shortly receive an email to confirm your unsubscription."
         )
@@ -160,12 +175,16 @@ def optout_email(
         data = request.load_url_safe_token(raw_data)
         assert data is not None
         address = data['address']
+        domain = data.get('domain')
+        domain_segment = data.get('domain_segment')
         assert address
     except Exception:
         log.warning('Invalid email optout')
     else:
         subscribers = EmailSubscriberCollection(request.session)
-        result = subscribers.confirm_unsubscription(address)
+        result = subscribers.confirm_unsubscription(
+            address, domain, domain_segment
+        )
         if request.method == 'POST':
             # one-click unsubscribe
             return Response()
@@ -205,7 +224,12 @@ def subscribe_sms(
         phone_number = form.phone_number.formatted_data
         assert phone_number is not None
         subscribers = SmsSubscriberCollection(request.session)
-        subscribers.initiate_subscription(phone_number, request)
+        subscribers.initiate_subscription(
+            phone_number,
+            form.domain.data if form.domain else None,
+            form.domain_segment.data if form.domain_segment else None,
+            request
+        )
         callout = _(
             "Successfully subscribed to the SMS service. You will receive a "
             "SMS every time new results are published."
@@ -247,7 +271,12 @@ def unsubscribe_sms(
         phone_number = form.phone_number.formatted_data
         assert phone_number is not None
         subscribers = SmsSubscriberCollection(request.session)
-        subscribers.initiate_unsubscription(phone_number, request)
+        subscribers.initiate_unsubscription(
+            phone_number,
+            form.domain.data if form.domain else None,
+            form.domain_segment.data if form.domain_segment else None,
+            request
+        )
         callout = _(
             "Successfully unsubscribed from the SMS services. You will no "
             "longer receive SMS when new results are published."

--- a/tests/onegov/election_day/collections/test_subscriber_collection.py
+++ b/tests/onegov/election_day/collections/test_subscriber_collection.py
@@ -12,30 +12,39 @@ from unittest.mock import Mock
 def test_subscriber_collection(session):
     # add generic
     collection = SubscriberCollection(session)
-    collection.add('endpoint', 'de_CH', True)
+    collection.add('endpoint', 'municipality', 'Govikon', 'de_CH', True)
     subscriber = collection.query().one()
     assert subscriber.address == 'endpoint'
+    assert subscriber.domain == 'municipality'
+    assert subscriber.domain_segment == 'Govikon'
     assert subscriber.locale == 'de_CH'
     assert collection.by_id(subscriber.id) == subscriber
-    assert collection.by_address('endpoint') == subscriber
+    assert collection.by_address('endpoint', 'municipality', 'Govikon') \
+        == subscriber
 
     # add email
     collection = EmailSubscriberCollection(session)
-    collection.add('a@example.org', 'fr_CH', True)
+    collection.add('a@example.org', 'municipality', 'Govikon', 'fr_CH', True)
     subscriber = collection.query().one()
     assert subscriber.address == 'a@example.org'
+    assert subscriber.domain == 'municipality'
+    assert subscriber.domain_segment == 'Govikon'
     assert subscriber.locale == 'fr_CH'
     assert collection.by_id(subscriber.id) == subscriber
-    assert collection.by_address('a@example.org') == subscriber
+    assert collection.by_address('a@example.org', 'municipality', 'Govikon') \
+        == subscriber
 
     # add sms
     collection = SmsSubscriberCollection(session)
-    collection.add('+41791112233', 'it_CH', True)
+    collection.add('+41791112233', 'municipality', 'Govikon', 'it_CH', True)
     subscriber = collection.query().one()
     assert subscriber.address == '+41791112233'
+    assert subscriber.domain == 'municipality'
+    assert subscriber.domain_segment == 'Govikon'
     assert subscriber.locale == 'it_CH'
     assert collection.by_id(subscriber.id) == subscriber
-    assert collection.by_address('+41791112233') == subscriber
+    assert collection.by_address('+41791112233', 'municipality', 'Govikon') \
+        == subscriber
 
     # active_only
     subscriber.active = False
@@ -56,14 +65,14 @@ def test_subscriber_collection_subscribe_email(election_day_app_zg, session):
     collection = EmailSubscriberCollection(session, active_only=False)
 
     # Unsubscribe but not yet subscribed
-    collection.initiate_unsubscription('howard@example.org', request)
+    collection.initiate_unsubscription('hue@the.org', None, None, request)
     assert mock.call_count == 0
     assert collection.query().count() == 0
 
     # Initiate
-    collection.initiate_subscription('howard@example.org', request)
+    collection.initiate_subscription('hue@the.org', None, None, request)
     assert mock.call_count == 1
-    assert mock.call_args[-1]['receivers'] == ('howard@example.org',)
+    assert mock.call_args[-1]['receivers'] == ('hue@the.org',)
     assert mock.call_args[-1]['subject'] == (
         'Bitte bestätigen Sie Ihre E-Mail-Adresse'
     )
@@ -72,30 +81,33 @@ def test_subscriber_collection_subscribe_email(election_day_app_zg, session):
     )
     assert mock.call_args[-1]['headers']['List-Unsubscribe'] == (
         "<Principal/optout-email?"
-        "opaque={'address': 'howard@example.org', 'locale': 'de_CH'}>"
+        "opaque={'address': 'hue@the.org', 'domain': None, "
+        "'domain_segment': None, 'locale': 'de_CH'}>"
     )
     assert (
         "Principal/optout-email?"
-        "opaque={'address': 'howard@example.org', 'locale': 'de_CH'}"
+        "opaque={'address': 'hue@the.org', 'domain': None, "
+        "'domain_segment': None, 'locale': 'de_CH'}"
     ) in mock.call_args[-1]['content']
     assert (
         "Principal/optin-email?"
-        "opaque={'address': 'howard@example.org', 'locale': 'de_CH'}"
+        "opaque={'address': 'hue@the.org', 'domain': None, "
+        "'domain_segment': None, 'locale': 'de_CH'}"
     ) in mock.call_args[-1]['content']
     subscriber = collection.query().one()
     assert subscriber.active is False
     assert subscriber.locale == 'de_CH'
-    assert subscriber.address == 'howard@example.org'
+    assert subscriber.address == 'hue@the.org'
 
     # Initiate again to send the email again
-    collection.initiate_subscription('howard@example.org', request)
+    collection.initiate_subscription('hue@the.org', None, None, request)
     assert mock.call_count == 2
     assert collection.query().one().active is False
 
     # Unsubscribe, but not yet confirmed
-    collection.initiate_unsubscription('howard@example.org', request)
+    collection.initiate_unsubscription('hue@the.org', None, None, request)
     assert mock.call_count == 3
-    assert mock.call_args[-1]['receivers'] == ('howard@example.org',)
+    assert mock.call_args[-1]['receivers'] == ('hue@the.org',)
     assert mock.call_args[-1]['subject'] == (
         'Bitte bestätigen Sie Ihre Abmeldung'
     )
@@ -104,72 +116,92 @@ def test_subscriber_collection_subscribe_email(election_day_app_zg, session):
     )
     assert mock.call_args[-1]['headers']['List-Unsubscribe'] == (
         "<Principal/optout-email?"
-        "opaque={'address': 'howard@example.org'}>"
+        "opaque={'address': 'hue@the.org', 'domain': None, "
+        "'domain_segment': None}>"
     )
     assert (
         "Principal/optout-email?"
-        "opaque={'address': 'howard@example.org'}"
+        "opaque={'address': 'hue@the.org', 'domain': None, "
+        "'domain_segment': None}"
     ) in mock.call_args[-1]['content']
     assert collection.query().one().active is False
 
     # Confirm
-    assert collection.confirm_subscription('howard@example.org', 'de_CH')
+    assert collection.confirm_subscription('hue@the.org', None, None, 'de_CH')
     subscriber = collection.query().one()
     assert subscriber.active is True
     assert subscriber.locale == 'de_CH'
-    assert subscriber.address == 'howard@example.org'
+    assert subscriber.address == 'hue@the.org'
 
     # Confirm again
-    assert collection.confirm_subscription('howard@example.org', 'de_CH')
+    assert collection.confirm_subscription('hue@the.org', None, None, 'de_CH')
     subscriber = collection.query().one()
     assert subscriber.active is True
     assert subscriber.locale == 'de_CH'
-    assert subscriber.address == 'howard@example.org'
+    assert subscriber.address == 'hue@the.org'
 
     # Confirm with wrong email
-    assert not collection.confirm_subscription('h0wrad@examp1e.org', 'de_CH')
+    assert not collection.confirm_subscription('h1e@z.g', None, None, 'de_CH')
 
     # Initiate again with different locale, but already confirmed
     request.locale = 'fr_CH'
-    collection.initiate_subscription('howard@example.org', request)
+    collection.initiate_subscription('hue@the.org', None, None, request)
     assert mock.call_count == 4
     subscriber = collection.query().one()
     assert subscriber.active is True
     assert subscriber.locale == 'de_CH'
-    assert subscriber.address == 'howard@example.org'
+    assert subscriber.address == 'hue@the.org'
 
     # Confirm to change locale
-    assert collection.confirm_subscription('howard@example.org', 'fr_CH')
+    assert collection.confirm_subscription('hue@the.org', None, None, 'fr_CH')
     subscriber = collection.query().one()
     assert subscriber.active is True
     assert subscriber.locale == 'fr_CH'
-    assert subscriber.address == 'howard@example.org'
+    assert subscriber.address == 'hue@the.org'
 
     # Unsubscribe
-    collection.initiate_unsubscription('howard@example.org', request)
+    collection.initiate_unsubscription('hue@the.org', None, None, request)
     assert mock.call_count == 5
     assert collection.query().one().active is True
 
     # Unusbscribe again
-    collection.initiate_unsubscription('howard@example.org', request)
+    collection.initiate_unsubscription('hue@the.org', None, None, request)
     assert mock.call_count == 6
     assert collection.query().one().active is True
 
     # Cofirm unsubscription
-    assert collection.confirm_unsubscription('howard@example.org')
+    assert collection.confirm_unsubscription('hue@the.org', None, None)
     assert collection.query().one().active is False
 
     # Cofirm unsubscription again
-    assert collection.confirm_unsubscription('howard@example.org')
+    assert collection.confirm_unsubscription('hue@the.org', None, None)
     assert collection.query().one().active is False
 
     # Cofirm unsubscription with wrong email
-    assert not collection.confirm_unsubscription('h0wrad@examp1e.org')
+    assert not collection.confirm_unsubscription('g1@1.org', None, None)
     assert collection.query().one().active is False
 
     # Confirm email again to reactivate
-    assert collection.confirm_subscription('howard@example.org', 'de_CH')
+    assert collection.confirm_subscription('hue@the.org', None, None, 'de_CH')
     assert collection.query().one().active is True
+
+    # Additionally subscribe only for a segment
+    collection.initiate_subscription('hue@the.org', 'a', 'b', request)
+    assert mock.call_count == 7
+    assert mock.call_args[-1]['headers']['List-Unsubscribe'] == (
+        "<Principal/optout-email?"
+        "opaque={'address': 'hue@the.org', 'domain': 'a', "
+        "'domain_segment': 'b', 'locale': 'fr_CH'}>"
+    )
+    assert (
+        "Principal/optout-email?"
+        "opaque={'address': 'hue@the.org', 'domain': 'a', "
+        "'domain_segment': 'b', 'locale': 'fr_CH'}"
+    ) in mock.call_args[-1]['content']
+    assert collection.confirm_subscription('hue@the.org', 'a', 'b', 'fr_CH')
+    assert {(s.domain, s.domain_segment) for s in collection.query()} == {
+        (None, None), ('a', 'b')
+    }
 
 
 def test_subscriber_collection_subscribe_sms(election_day_app_zg, session):
@@ -181,11 +213,11 @@ def test_subscriber_collection_subscribe_sms(election_day_app_zg, session):
     collection = SmsSubscriberCollection(session, active_only=False)
 
     # Unsubscribe but not existing
-    collection.initiate_unsubscription('+41791112233', request)
+    collection.initiate_unsubscription('+41791112233', None, None, request)
     assert collection.query().count() == 0
 
     # Subscribe
-    collection.initiate_subscription('+41791112233', request)
+    collection.initiate_subscription('+41791112233', None, None, request)
     assert mock.call_count == 1
     assert mock.call_args[0][0] == '+41791112233'
     assert mock.call_args[0][1] == (
@@ -194,26 +226,37 @@ def test_subscriber_collection_subscribe_sms(election_day_app_zg, session):
     )
     subscriber = collection.query().one()
     assert subscriber.address == '+41791112233'
+    assert subscriber.domain is None
+    assert subscriber.domain_segment is None
     assert subscriber.locale == 'de_CH'
     assert subscriber.active is True
 
     # Subscribe again with different locale
     request.locale = 'fr_CH'
-    collection.initiate_subscription('+41791112233', request)
+    collection.initiate_subscription('+41791112233', None, None, request)
     assert mock.call_count == 2
     subscriber = collection.query().one()
     assert subscriber.address == '+41791112233'
+    assert subscriber.domain is None
+    assert subscriber.domain_segment is None
     assert subscriber.locale == 'fr_CH'
     assert subscriber.active is True
 
     # Unsubscribe
-    collection.initiate_unsubscription('+41791112233', request)
+    collection.initiate_unsubscription('+41791112233', None, None, request)
     assert collection.query().one().active is False
 
     # Subscribe again
-    collection.initiate_subscription('+41791112233', request)
+    collection.initiate_subscription('+41791112233', None, None, request)
     assert mock.call_count == 3
     assert collection.query().one().active is True
+
+    # Additionally subscribe only for a segment
+    collection.initiate_subscription('+41791112233', 'a', 'b', request)
+    assert mock.call_count == 4
+    assert {(s.domain, s.domain_segment) for s in collection.query()} == {
+        (None, None), ('a', 'b')
+    }
 
 
 def test_subscriber_collection_pagination(session):
@@ -222,6 +265,8 @@ def test_subscriber_collection_pagination(session):
     for number in range(100):
         collection.add(
             'user{:02}@example.org'.format(number),
+            None,
+            None,
             'de_CH',
             True
         )
@@ -232,6 +277,8 @@ def test_subscriber_collection_pagination(session):
     for number in range(100):
         collection.add(
             '+417911122{:02}'.format(number),
+            None,
+            None,
             'de_CH',
             True
         )
@@ -298,6 +345,8 @@ def test_subscriber_collection_term(session):
     for number in range(100):
         collection.add(
             'user{:02}@example.org'.format(number),
+            None,
+            None,
             'de_CH',
             active=True
         )
@@ -308,6 +357,8 @@ def test_subscriber_collection_term(session):
     for number in range(100):
         collection.add(
             '+417911122{:02}'.format(number),
+            None,
+            None,
             'de_CH',
             active=True
         )
@@ -385,15 +436,15 @@ def test_subscriber_collection_term(session):
 def test_subscriber_collection_export(session):
     # Add email subscribers
     emails = EmailSubscriberCollection(session, active_only=False)
-    emails.add('a@example.org', 'de_CH', True)
-    emails.add('b@example.org', 'de_CH', False)
-    emails.add('c@example.org', 'fr_CH', True)
+    emails.add('a@example.org', None, None, 'de_CH', True)
+    emails.add('b@example.org', 'canton', None, 'de_CH', False)
+    emails.add('c@example.org', 'municipality', 'Govikon', 'fr_CH', True)
 
     # Add SMS subscribers
     sms = SmsSubscriberCollection(session, active_only=False)
-    sms.add('+41791112201', 'de_CH', True)
-    sms.add('+41791112202', 'fr_CH', False)
-    sms.add('+41791112203', 'fr_CH', True)
+    sms.add('+41791112201', None, None, 'de_CH', True)
+    sms.add('+41791112202', 'canton', None, 'fr_CH', False)
+    sms.add('+41791112203', 'municipality', 'Govikon', 'fr_CH', True)
 
     mixed = SubscriberCollection(session, active_only=False)
     assert mixed.query().count() == 6
@@ -401,46 +452,60 @@ def test_subscriber_collection_export(session):
     # Test email export
     data = emails.export()
     assert sorted(data, key=lambda x: x['address']) == [
-        {'active': True, 'address': 'a@example.org', 'locale': 'de_CH'},
-        {'active': False, 'address': 'b@example.org', 'locale': 'de_CH'},
-        {'active': True, 'address': 'c@example.org', 'locale': 'fr_CH'},
+        {'active': True, 'address': 'a@example.org', 'domain': None,
+         'domain_segment': None, 'locale': 'de_CH'},
+        {'active': False, 'address': 'b@example.org', 'domain': 'canton',
+         'domain_segment': None, 'locale': 'de_CH'},
+        {'active': True, 'address': 'c@example.org', 'domain': 'municipality',
+         'domain_segment': 'Govikon', 'locale': 'fr_CH'},
     ]
 
     # Test SMS export
     data = sms.export()
     assert sorted(data, key=lambda x: x['address']) == [
-        {'active': True, 'address': '+41791112201', 'locale': 'de_CH'},
-        {'active': False, 'address': '+41791112202', 'locale': 'fr_CH'},
-        {'active': True, 'address': '+41791112203', 'locale': 'fr_CH'},
+        {'active': True, 'address': '+41791112201', 'domain': None,
+         'domain_segment': None, 'locale': 'de_CH'},
+        {'active': False, 'address': '+41791112202', 'domain': 'canton',
+         'domain_segment': None, 'locale': 'fr_CH'},
+        {'active': True, 'address': '+41791112203', 'domain': 'municipality',
+         'domain_segment': 'Govikon', 'locale': 'fr_CH'},
     ]
 
     # Test mixed export
     data = mixed.export()
     assert sorted(data, key=lambda x: x['address']) == [
-        {'active': True, 'address': '+41791112201', 'locale': 'de_CH'},
-        {'active': False, 'address': '+41791112202', 'locale': 'fr_CH'},
-        {'active': True, 'address': '+41791112203', 'locale': 'fr_CH'},
-        {'active': True, 'address': 'a@example.org', 'locale': 'de_CH'},
-        {'active': False, 'address': 'b@example.org', 'locale': 'de_CH'},
-        {'active': True, 'address': 'c@example.org', 'locale': 'fr_CH'},
+        {'active': True, 'address': '+41791112201', 'domain': None,
+         'domain_segment': None, 'locale': 'de_CH'},
+        {'active': False, 'address': '+41791112202', 'domain': 'canton',
+         'domain_segment': None, 'locale': 'fr_CH'},
+        {'active': True, 'address': '+41791112203', 'domain': 'municipality',
+         'domain_segment': 'Govikon', 'locale': 'fr_CH'},
+        {'active': True, 'address': 'a@example.org', 'domain': None,
+         'domain_segment': None, 'locale': 'de_CH'},
+        {'active': False, 'address': 'b@example.org', 'domain': 'canton',
+         'domain_segment': None, 'locale': 'de_CH'},
+        {'active': True, 'address': 'c@example.org', 'domain': 'municipality',
+         'domain_segment': 'Govikon', 'locale': 'fr_CH'},
     ]
 
 
 def test_subscriber_collection_cleanup(session):
     # Add email subscribers
     collection = EmailSubscriberCollection(session)
-    collection.add('a@example.org', 'de_CH', True)
-    collection.add('b@EXAMPLE.org', 'de_CH', True)
-    collection.add('c@example.org', 'fr_CH', True)
-    collection.add('d@example.org', 'de_CH', True)
+    collection.add('a@example.org', None, None, 'de_CH', True)
+    collection.add('a@example.org', 'canton', None, 'de_CH', True)
+    collection.add('b@EXAMPLE.org', None, None, 'de_CH', True)
+    collection.add('c@example.org', None, None, 'fr_CH', True)
+    collection.add('d@example.org', None, None, 'de_CH', True)
 
     # Add SMS subscribers
     collection = SmsSubscriberCollection(session)
-    collection.add('+41791112201', 'de_CH', True)
-    collection.add('+41791112202', 'fr_CH', True)
-    collection.add('+41791112203', 'fr_CH', True)
+    collection.add('+41791112201', None, None, 'de_CH', True)
+    collection.add('+41791112201', 'canton', None, 'fr_CH', True)
+    collection.add('+41791112202', None, None, 'fr_CH', True)
+    collection.add('+41791112203', None, None, 'fr_CH', True)
 
-    assert SubscriberCollection(session).query().count() == 7
+    assert SubscriberCollection(session).query().count() == 9
 
     # Test deactivate email subscribers
     collection = EmailSubscriberCollection(session)
@@ -468,9 +533,9 @@ def test_subscriber_collection_cleanup(session):
         delete=False
     )
     assert not errors
-    assert count == 3
+    assert count == 4
     assert collection.query().count() == 1
-    assert collection.query(active_only=False).count() == 4
+    assert collection.query(active_only=False).count() == 5
 
     # Test delete email subscribers
     errors, count = collection.cleanup(
@@ -479,7 +544,7 @@ def test_subscriber_collection_cleanup(session):
         delete=True
     )
     assert not errors
-    assert count == 3
+    assert count == 4
     assert collection.query().count() == 1
     assert collection.query(active_only=False).count() == 1
 
@@ -508,9 +573,9 @@ def test_subscriber_collection_cleanup(session):
         delete=False
     )
     assert not errors
-    assert count == 2
+    assert count == 3
     assert collection.query().count() == 1
-    assert collection.query(active_only=False).count() == 3
+    assert collection.query(active_only=False).count() == 4
 
     # Test delete SMS subscribers
     errors, count = collection.cleanup(
@@ -519,6 +584,6 @@ def test_subscriber_collection_cleanup(session):
         delete=True
     )
     assert not errors
-    assert count == 2
+    assert count == 3
     assert collection.query().count() == 1
     assert collection.query(active_only=False).count() == 1

--- a/tests/onegov/election_day/common.py
+++ b/tests/onegov/election_day/common.py
@@ -143,6 +143,7 @@ class DummyPrincipal:
         self.reply_to = None
         self.superregions = []
         self.official_host = None
+        self.segmented_notifications = False
 
     @property
     def notifications(self):

--- a/tests/onegov/election_day/forms/test_subscriber_form.py
+++ b/tests/onegov/election_day/forms/test_subscriber_form.py
@@ -1,32 +1,71 @@
 from onegov.election_day.forms import EmailSubscriptionForm
 from onegov.election_day.forms import SmsSubscriptionForm
 from tests.onegov.election_day.common import DummyPostData
+from tests.onegov.election_day.common import DummyRequest
 
 
 def test_email_subscription_form():
     form = EmailSubscriptionForm()
+    form.request = DummyRequest()
+    form.on_request()
     assert not form.validate()
 
     form = EmailSubscriptionForm(DummyPostData({'email': 'test'}))
+    form.request = DummyRequest()
+    form.on_request()
     assert not form.validate()
 
     form = EmailSubscriptionForm(DummyPostData({'email': 'te@s.t'}))
+    form.request = DummyRequest()
+    form.on_request()
+    assert form.validate()
+
+    form = EmailSubscriptionForm(DummyPostData({
+        'email': 'te@s.t',
+        'domain': 'municipality',
+        'domain_segment': 'a'
+    }))
+    form.request = DummyRequest()
+    form.request.app.principal.segmented_notifications = True
+    form.request.app.principal.get_entities = lambda x: ['a', 'b']
+    form.on_request()
+    assert form.domain_segment.choices == [('a', 'a'), ('b', 'b')]
     assert form.validate()
 
 
 def test_sms_subscription_form():
     form = SmsSubscriptionForm()
+    form.request = DummyRequest()
+    form.on_request()
     assert not form.validate()
 
     form = SmsSubscriptionForm(DummyPostData({'phone_number': 'test'}))
+    form.request = DummyRequest()
+    form.on_request()
     assert not form.validate()
 
     form = SmsSubscriptionForm(DummyPostData({
         'phone_number': '+261339743405'
     }))
+    form.request = DummyRequest()
+    form.on_request()
     assert not form.validate()
 
     form = SmsSubscriptionForm(DummyPostData({
         'phone_number': '+41791234567'
     }))
+    form.request = DummyRequest()
+    form.on_request()
+    assert form.validate()
+
+    form = SmsSubscriptionForm(DummyPostData({
+        'phone_number': '+41791234567',
+        'domain': 'municipality',
+        'domain_segment': 'a'
+    }))
+    form.request = DummyRequest()
+    form.request.app.principal.segmented_notifications = True
+    form.request.app.principal.get_entities = lambda x: ['a', 'b']
+    form.on_request()
+    assert form.domain_segment.choices == [('a', 'a'), ('b', 'b')]
     assert form.validate()

--- a/tests/onegov/election_day/models/test_notification.py
+++ b/tests/onegov/election_day/models/test_notification.py
@@ -1110,6 +1110,12 @@ def test_sms_notification(election_day_app_zg, session):
     with freeze_time("2008-01-01 00:00"):
         election_day_app_zg.send_sms = Mock()
 
+        def sms_queue():
+            return tuple(
+                (set(call[0][0]), call[0][1])
+                for call in election_day_app_zg.send_sms.call_args_list
+            )
+
         principal = election_day_app_zg.principal
         principal.sms_notification = 'https://wab.ch.ch'
         # use the default reply_to
@@ -1206,17 +1212,19 @@ def test_sms_notification(election_day_app_zg, session):
         assert notification.election_id == election.id
         assert notification.last_modified == freezed
         assert election_day_app_zg.send_sms.call_count == 3
-        assert election_day_app_zg.send_sms.call_args_list[0][0] == (
-            {'+41791112233', '+41791112277'},
-            'Neue Resultate verfügbar auf https://wab.ch.ch'
-        )
-        assert election_day_app_zg.send_sms.call_args_list[1][0] == (
-            {'+41791112233', '+41791112244'},
-            'New results are available on https://wab.ch.ch'
-        )
-        assert election_day_app_zg.send_sms.call_args_list[2][0] == (
-            {'+41791112277'},
-            'Les nouveaux résultats sont disponibles sur https://wab.ch.ch'
+        assert sms_queue() == (
+            (
+                {'+41791112233', '+41791112277'},
+                'Neue Resultate verfügbar auf https://wab.ch.ch'
+            ),
+            (
+                {'+41791112233', '+41791112244'},
+                'New results are available on https://wab.ch.ch'
+            ),
+            (
+                {'+41791112277'},
+                'Les nouveaux résultats sont disponibles sur https://wab.ch.ch'
+            )
         )
 
         # Intermediate election compound results
@@ -1228,17 +1236,19 @@ def test_sms_notification(election_day_app_zg, session):
         assert notification.election_compound_id == election_compound.id
         assert notification.last_modified == freezed
         assert election_day_app_zg.send_sms.call_count == 3
-        assert election_day_app_zg.send_sms.call_args_list[0][0] == (
-            {'+41791112233', '+41791112277'},
-            'Neue Resultate verfügbar auf https://wab.ch.ch'
-        )
-        assert election_day_app_zg.send_sms.call_args_list[1][0] == (
-            {'+41791112233', '+41791112244'},
-            'New results are available on https://wab.ch.ch'
-        )
-        assert election_day_app_zg.send_sms.call_args_list[2][0] == (
-            {'+41791112277'},
-            'Les nouveaux résultats sont disponibles sur https://wab.ch.ch'
+        assert sms_queue() == (
+            (
+                {'+41791112233', '+41791112277'},
+                'Neue Resultate verfügbar auf https://wab.ch.ch'
+            ),
+            (
+                {'+41791112233', '+41791112244'},
+                'New results are available on https://wab.ch.ch'
+            ),
+            (
+                {'+41791112277'},
+                'Les nouveaux résultats sont disponibles sur https://wab.ch.ch'
+            )
         )
 
         # Intermediate vote results
@@ -1250,13 +1260,15 @@ def test_sms_notification(election_day_app_zg, session):
         assert notification.vote_id == vote.id
         assert notification.last_modified == freezed
         assert election_day_app_zg.send_sms.call_count == 2
-        assert election_day_app_zg.send_sms.call_args_list[0][0] == (
-            {'+41791112233', '+41791112277'},
-            'Neue Resultate verfügbar auf https://wab.ch.ch'
-        )
-        assert election_day_app_zg.send_sms.call_args_list[1][0] == (
-            {'+41791112233', '+41791112244'},
-            'New results are available on https://wab.ch.ch'
+        assert sms_queue() == (
+            (
+                {'+41791112233', '+41791112277'},
+                'Neue Resultate verfügbar auf https://wab.ch.ch'
+            ),
+            (
+                {'+41791112233', '+41791112244'},
+                'New results are available on https://wab.ch.ch'
+            )
         )
 
         # Final election results
@@ -1269,17 +1281,19 @@ def test_sms_notification(election_day_app_zg, session):
         assert notification.election_id == election.id
         assert notification.last_modified == freezed
         assert election_day_app_zg.send_sms.call_count == 3
-        assert election_day_app_zg.send_sms.call_args_list[0][0] == (
-            {'+41791112233', '+41791112277'},
-            'Neue Resultate verfügbar auf https://wab.ch.ch'
-        )
-        assert election_day_app_zg.send_sms.call_args_list[1][0] == (
-            {'+41791112233', '+41791112244'},
-            'New results are available on https://wab.ch.ch'
-        )
-        assert election_day_app_zg.send_sms.call_args_list[2][0] == (
-            {'+41791112277'},
-            'Les nouveaux résultats sont disponibles sur https://wab.ch.ch'
+        assert sms_queue() == (
+            (
+                {'+41791112233', '+41791112277'},
+                'Neue Resultate verfügbar auf https://wab.ch.ch'
+            ),
+            (
+                {'+41791112233', '+41791112244'},
+                'New results are available on https://wab.ch.ch'
+            ),
+            (
+                {'+41791112277'},
+                'Les nouveaux résultats sont disponibles sur https://wab.ch.ch'
+            )
         )
 
         # Final election compound results
@@ -1294,17 +1308,19 @@ def test_sms_notification(election_day_app_zg, session):
         assert notification.election_compound_id == election_compound.id
         assert notification.last_modified == freezed
         assert election_day_app_zg.send_sms.call_count == 3
-        assert election_day_app_zg.send_sms.call_args_list[0][0] == (
-            {'+41791112233', '+41791112277'},
-            'Neue Resultate verfügbar auf https://wab.ch.ch'
-        )
-        assert election_day_app_zg.send_sms.call_args_list[1][0] == (
-            {'+41791112233', '+41791112244'},
-            'New results are available on https://wab.ch.ch'
-        )
-        assert election_day_app_zg.send_sms.call_args_list[2][0] == (
-            {'+41791112277'},
-            'Les nouveaux résultats sont disponibles sur https://wab.ch.ch'
+        assert sms_queue() == (
+            (
+                {'+41791112233', '+41791112277'},
+                'Neue Resultate verfügbar auf https://wab.ch.ch'
+            ),
+            (
+                {'+41791112233', '+41791112244'},
+                'New results are available on https://wab.ch.ch'
+            ),
+            (
+                {'+41791112277'},
+                'Les nouveaux résultats sont disponibles sur https://wab.ch.ch'
+            )
         )
 
         # Final vote results
@@ -1317,11 +1333,13 @@ def test_sms_notification(election_day_app_zg, session):
         assert notification.vote_id == vote.id
         assert notification.last_modified == freezed
         assert election_day_app_zg.send_sms.call_count == 2
-        assert election_day_app_zg.send_sms.call_args_list[0][0] == (
-            {'+41791112233', '+41791112277'},
-            'Neue Resultate verfügbar auf https://wab.ch.ch'
-        )
-        assert election_day_app_zg.send_sms.call_args_list[1][0] == (
-            {'+41791112233', '+41791112244'},
-            'New results are available on https://wab.ch.ch'
+        assert sms_queue() == (
+            (
+                {'+41791112233', '+41791112277'},
+                'Neue Resultate verfügbar auf https://wab.ch.ch'
+            ),
+            (
+                {'+41791112233', '+41791112244'},
+                'New results are available on https://wab.ch.ch'
+            )
         )

--- a/tests/onegov/election_day/models/test_principal.py
+++ b/tests/onegov/election_day/models/test_principal.py
@@ -212,6 +212,7 @@ def test_canton():
     assert list(canton.domains_election.keys()) == [
         'federation', 'canton', 'region', 'district', 'none', 'municipality'
     ]
+    assert canton.get_entities(2022)
     assert canton.get_districts(2022)
     assert canton.get_regions(2022)
     assert canton.get_superregions(2022)
@@ -228,6 +229,7 @@ def test_canton():
     assert list(canton.domains_election.keys()) == [
         'federation', 'canton', 'region', 'district', 'none', 'municipality'
     ]
+    assert canton.get_entities(2022)
     assert canton.get_districts(2022)
     assert canton.get_regions(2022)
     assert not canton.get_superregions(2022)
@@ -240,6 +242,7 @@ def test_canton():
     assert list(canton.domains_election.keys()) == [
         'federation', 'canton', 'district', 'none', 'municipality'
     ]
+    assert canton.get_entities(2022)
     assert canton.get_districts(2022)
     assert not canton.get_regions(2022)
     assert not canton.get_superregions(2022)
@@ -252,6 +255,7 @@ def test_canton():
     assert list(canton.domains_election.keys()) == [
         'federation', 'canton', 'district', 'none', 'municipality'
     ]
+    assert canton.get_entities(2022)
     assert canton.get_districts(2022)
     assert not canton.get_regions(2022)
     assert not canton.get_superregions(2022)
@@ -264,6 +268,7 @@ def test_canton():
     assert list(canton.domains_election.keys()) == [
         'federation', 'canton', 'none', 'municipality'
     ]
+    assert canton.get_entities(2022)
     assert not canton.get_districts(2022)
     assert not canton.get_regions(2022)
     assert not canton.get_superregions(2022)

--- a/tests/onegov/election_day/utils/test_notification_utils.py
+++ b/tests/onegov/election_day/utils/test_notification_utils.py
@@ -1,0 +1,62 @@
+from onegov.ballot import Election
+from onegov.ballot import ElectionCompound
+from onegov.ballot import Vote
+from onegov.election_day.utils import segment_models
+from onegov.core.utils import groupbylist
+
+
+def test_segment_models():
+    assert segment_models([], [], []) == []
+
+    elections = [
+        Election(domain='federation'),
+        Election(domain='canton'),
+        Election(domain='district'),
+        Election(domain='district'),
+    ]
+    compounds = [
+        ElectionCompound(domain='canton')
+    ]
+    votes = [
+        Vote(domain='canton'),
+        Vote(domain='municipality', domain_segment='A'),
+        Vote(domain='municipality', domain_segment='B'),
+    ]
+    groups = segment_models(elections, compounds, votes)
+    assert len(groups) == 4
+    groups = dict(groupbylist(groups, lambda x: (x.domain, x.domain_segment)))
+
+    def compile(group):
+        return str(
+            group.filter.compile(compile_kwargs={"literal_binds": True})
+        )
+
+    group = groups[(None, None)][0]
+    assert group.elections == elections
+    assert group.election_compounds == compounds
+    assert group.votes == votes
+    assert compile(group) == 'subscribers.domain IS NULL'
+
+    group = groups[('canton', None)][0]
+    assert group.elections == elections
+    assert group.election_compounds == compounds
+    assert group.votes == votes[:1]
+    assert compile(group) == "subscribers.domain != 'municipality'"
+
+    group = groups[('municipality', 'A')][0]
+    assert group.elections == []
+    assert group.election_compounds == []
+    assert group.votes == votes[1:2]
+    assert compile(group) == (
+        "subscribers.domain = 'municipality' "
+        "AND subscribers.domain_segment = 'A'"
+    )
+
+    group = groups[('municipality', 'B')][0]
+    assert group.elections == []
+    assert group.election_compounds == []
+    assert group.votes == votes[2:3]
+    assert compile(group) == (
+        "subscribers.domain = 'municipality' "
+        "AND subscribers.domain_segment = 'B'"
+    )


### PR DESCRIPTION
## Commit message

Election Day: Add notification segmentation.

If `segmented_notifications` is enabled for a principal, email and SMS subscribers can subscribe either to elections and votes of a specific municipality or everything else. Multiple subscriptions are possible.

TYPE: Feature
LINK: OGC-1150
HINT: onegov-election-day --select /onegov_election_day/* migrate-subscribers

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added an upgrade hint such as data migration commands to be run
- [x] I have updated the PO files
- [x] I have tested my code thoroughly by hand
    - [x] I have tested database upgrades
    - [x] I have tested sending mails
- [x] I have added tests for my changes/features