### PR TITLE
Ogc 1623 scheduled agenda item links ticker

### DIFF
--- a/src/onegov/landsgemeinde/assets/js/ticker.js
+++ b/src/onegov/landsgemeinde/assets/js/ticker.js
@@ -41,6 +41,7 @@ document.addEventListener("DOMContentLoaded", function() {
                         currentAgendaListItem.id = '';
                     }
                     agendaListItem.id = 'current';
+                    agendaListItem.href = '#' + message.node;
                     scrollToCurrentItem();
                 }
                 if (message.state === 'completed') {

--- a/src/onegov/landsgemeinde/templates/macros.pt
+++ b/src/onegov/landsgemeinde/templates/macros.pt
@@ -53,7 +53,7 @@
                 <li id="list-agenda-item-${current_agenda_item.number}">
                     <a class="list-link ${current_agenda_item.state}"
                     id="${'current' if current else ''}" tal:define="current current_agenda_item.state == 'ongoing'"
-                    href="#agenda-item-${current_agenda_item.number}">
+                    href="${f'#agenda-item-{current_agenda_item.number}' if current_agenda_item.state != 'scheduled' else request.link(current_agenda_item)}">
                         <div class="timeline">
                             <div class="line"></div>
                             <div class="circle">

--- a/src/onegov/landsgemeinde/theme/styles/landsgemeinde.scss
+++ b/src/onegov/landsgemeinde/theme/styles/landsgemeinde.scss
@@ -387,10 +387,6 @@ h1.main-title small {
             opacity: .5;
             transition: opacity 200ms linear;
         }
-
-        .scheduled {
-            cursor: default;
-        }
     }
 
     li:not(.medium-6):hover {


### PR DESCRIPTION
Please fill in the commit message below and work through the checklist. You can delete parts that are not needed, e.g. the optional description, the link to a ticket or irrelevant options of the checklist.

## Commit message

Landsgemeinde: Link agenda items in ticker to their own subpage

Agenda items, that are still "scheduled" so far had no working link. Now they are linkt to their own subpage so users can read the description even if the agenda item isn't ongoing yet.

TYPE: Feature
LINK: OGC-1623