### PR TITLE
Bugfix/pro 1285 timeline or ticket may access inexistent meta extra field

### DIFF
--- a/src/onegov/feriennet/locale/de_CH/LC_MESSAGES/onegov.feriennet.po
+++ b/src/onegov/feriennet/locale/de_CH/LC_MESSAGES/onegov.feriennet.po
@@ -2274,6 +2274,9 @@ msgstr "Angebot archiviert."
 msgid "Activity reassigned from ${old_username} to ${new_username}."
 msgstr "Zuteilung des Angebots an ${new_username} (von ${old_username})."
 
+msgid "Activity reassigned."
+msgstr "Zuteilung des Angebots."
+
 msgid "Period activated."
 msgstr "Zeitraum aktiviert."
 

--- a/src/onegov/feriennet/locale/fr_CH/LC_MESSAGES/onegov.feriennet.po
+++ b/src/onegov/feriennet/locale/fr_CH/LC_MESSAGES/onegov.feriennet.po
@@ -2288,6 +2288,9 @@ msgstr "Activité archivée."
 msgid "Activity reassigned from ${old_username} to ${new_username}."
 msgstr "Activité attribuée à ${old_username} à ${new_username}."
 
+msgid "Activity reassigned."
+msgstr "Activité attribuée."
+
 msgid "Period activated."
 msgstr "Période activée."
 

--- a/src/onegov/feriennet/locale/it_CH/LC_MESSAGES/onegov.feriennet.po
+++ b/src/onegov/feriennet/locale/it_CH/LC_MESSAGES/onegov.feriennet.po
@@ -2270,6 +2270,9 @@ msgstr "Attività archiviata."
 msgid "Activity reassigned from ${old_username} to ${new_username}."
 msgstr "Assegnazione dell'attività a ${new_username} (da ${old_username})."
 
+msgid "Activity reassigned."
+msgstr "Assegnazione dell'attività."
+
 msgid "Period activated."
 msgstr "Periodo attivato."
 

--- a/src/onegov/feriennet/templates/message_activity.pt
+++ b/src/onegov/feriennet/templates/message_activity.pt
@@ -11,15 +11,20 @@
                 <tal:b case="'archive'" i18n:translate>
                     Activity archived.
                 </tal:b>
-                <tal:b case="'reassign'" i18n:translate>
-                    Activity reassigned from
-                    <a i18n:name="old_username"
-                        href="mailto:${model.meta['extra_meta']['old_username']}">
-                        ${model.meta['extra_meta']['old_username']}</a>
-                    to
-                    <a i18n:name="new_username"
-                        href="mailto:${model.meta['extra_meta']['new_username']}">
-                        ${model.meta['extra_meta']['new_username']}</a>.
+                <tal:b case="'reassign'">
+                    <tal:b i18n:translate tal:condition="'extra_meta' in model.meta">
+                        Activity reassigned from
+                        <a i18n:name="old_username"
+                            href="mailto:${model.meta['extra_meta']['old_username']}">
+                            ${model.meta['extra_meta']['old_username']}</a>
+                        to
+                        <a i18n:name="new_username"
+                            href="mailto:${model.meta['extra_meta']['new_username']}">
+                            ${model.meta['extra_meta']['new_username']}</a>.
+                    </tal:b>
+                    <tal:b i18n:translate tal:condition="'extra_meta' not in model.meta">
+                        Activity reassigned.
+                    </tal:b>
                 </tal:b>
             </tal:b>
         </metal:b>


### PR DESCRIPTION
Ticket: Prevent accessing 'extra_meta' if not existing in model 

This also affected the '/timeline' view when reassign activities.

TYPE: Bugfix
LINK: pro-1285
