### PR TITLE
Add missing 'move_page_title' trait for links

### DIFF
--- a/src/onegov/org/models/traitinfo.py
+++ b/src/onegov/org/models/traitinfo.py
@@ -22,6 +22,7 @@ TRAIT_MESSAGES: dict[str, dict[str, str]] = {
         'new_page_title': _("New Link"),
         'new_page_added': _("Added a new link"),
         'edit_page_title': _("Edit Link"),
+        'move_page_title': _("Move Link"),
         'delete_message': _("The link was deleted"),
         'delete_button': _("Delete link"),
         'delete_question': _(


### PR DESCRIPTION

Topic: Adds missing trait to move links

TYPE: Bugfix
LINK: ogc-161
