### PR TITLE
Extend github tests to 8 groups/splits

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -99,7 +99,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        group: [1, 2, 3, 4, 5, 6, 7]
+        group: [1, 2, 3, 4, 5, 6, 7, 8]
 
     runs-on: ubuntu-latest
 
@@ -204,7 +204,7 @@ jobs:
     - name: Run tests
       run: |
         py.test \
-          --splits "7" \
+          --splits "8" \
           --group "${{matrix.group}}" \
           --cov \
           --cov-config=pyproject.toml \


### PR DESCRIPTION
Please fill in the commit message below and work through the checklist. You can delete parts that are not needed, e.g. the optional description, the link to a ticket or irrelevant options of the checklist.

## Commit message

<Module>: <Message>

<Optional Description>

TYPE: <Feature|Bugfix>
LINK: <Ticket-Number>
HINT: <Optional upgrade hint>

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I considered adding a reviewer
- [ ] I have added an upgrade hint such as data migration commands to be run
- [ ] I have updated the PO files
- [ ] I have added new modules to the docs
- [ ] I made changes/features for both org and town6
- [ ] I have updated the election_day API docs
- [ ] I have tested my code thoroughly by hand
    - [ ] I have tested styling changes/features on different browsers
    - [ ] I have tested javascript changes/features on different browsers
    - [ ] I have tested database upgrades
    - [ ] I have tested sending mails
    - [ ] I have tested building the documentation
- [ ] I have added tests for my changes/features
    - [ ] I am using freezegun for tests depending on date and times
    - [ ] I considered using browser tests für javascript changes/features
    - [ ] I have added/updated jest tests for d3rendering (election_day, swissvotes)
