### PR TITLE
Drops pyquery library in favor of pure lxml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,9 +72,6 @@ module = [
     "pdftotext.*",
     "pglast.*",
     "purl.*",
-    # FIXME: We only use this for a single util function, try to implement
-    #        the same functionality with just lxml or BeautifulSoup
-    "pyquery.*",
     "svglib.*",
     "stdnum.*",
     "ua_parser.*",

--- a/setup.cfg
+++ b/setup.cfg
@@ -122,7 +122,6 @@ install_requires =
     purl
     pycurl<7.45.3
     pyparsing
-    pyquery
     qrbill
     qrcode
     py

--- a/src/onegov/activity/utils.py
+++ b/src/onegov/activity/utils.py
@@ -6,7 +6,6 @@ import string
 
 from datetime import date, datetime, timedelta
 from functools import partial
-from pyquery import PyQuery as pq
 
 
 from typing import Any, Literal, TYPE_CHECKING
@@ -14,7 +13,7 @@ if TYPE_CHECKING:
     from _typeshed import SupportsGetItem, SupportsRichComparison
     from collections.abc import Iterable
     from typing import TypeVar
-    from typing_extensions import TypeAlias
+    from typing_extensions import TypeAlias, TypeGuard
 
     SupportsRichComparisonT = TypeVar(
         'SupportsRichComparisonT',
@@ -239,14 +238,15 @@ def dates_overlap(
     return False
 
 
-def is_internal_image(url: str | None) -> bool:
+def is_internal_image(url: str | None) -> 'TypeGuard[str]':
     return url and INTERNAL_IMAGE_EX.match(url) and True or False
 
 
 def extract_thumbnail(text: str | None) -> str | None:
 
     try:
-        first_image = next((img for img in pq(text or '')('img')), None)
+        root = lxml.html.fromstring(text or '')
+        first_image = root.find('.//img')
     except (lxml.etree.XMLSyntaxError, lxml.etree.ParserError):
         first_image = None
 


### PR DESCRIPTION
## Commit message

Drops pyquery library in favor of pure lxml

We already use lxml in most places anyways, so no point in having this dependency for a function that's just as easy to write with lxml

## Checklist

- [x] I have performed a self-review of my code
