### PR TITLE
Remove obsolete storage link expansion (as it is html now)

### DIFF
--- a/src/onegov/feriennet/layout.py
+++ b/src/onegov/feriennet/layout.py
@@ -847,6 +847,7 @@ class NotificationTemplateCollectionLayout(DefaultLayout):
     ) -> None:
         super().__init__(model, request)
         self.subtitle = subtitle
+        self.include_editor()
 
     @cached_property
     def breadcrumbs(self) -> list[Link]:


### PR DESCRIPTION
Feriennet: Remove obsolete storage link expansion (as it is html now)

TYPE: Bugfix
LINK: pro-1289