### PR TITLE
Search: Avoids Postgres indexer causing invalid transactions

### DIFF
--- a/src/onegov/agency/cli.py
+++ b/src/onegov/agency/cli.py
@@ -111,7 +111,13 @@ def consolidate_cli(
             consolidate_memberships(session, person, persons)
             if ix % buffer == 0:
                 app.es_indexer.process()
-                app.psql_indexer.process()
+                # FIXME: the psql_indexer runs in a separate transaction
+                #        so it will invalidate our transaction, which will
+                #        prompt us to retry but then we invalidate ourselves
+                #        again right here, so we give up after three tries.
+                #        We should add an option to run the indexer in the
+                #        current connection & transaction without commit
+                # app.psql_indexer.process()
         count_after = session.query(ExtendedAgencyMembership).count()
         assert count == count_after, f'before: {count}, after {count_after}'
         if dry_run:
@@ -179,19 +185,22 @@ def import_bs_data_files(
                 session.delete(membership)
                 if ix % buffer == 0:
                     app.es_indexer.process()
-                    app.psql_indexer.process()
+                    # FIXME: the psql_indexer runs in a separate transaction
+                    # app.psql_indexer.process()
 
             for ix, person in enumerate(session.query(Person)):
                 session.delete(person)
                 if ix % buffer == 0:
                     app.es_indexer.process()
-                    app.psql_indexer.process()
+                    # FIXME: the psql_indexer runs in a separate transaction
+                    # app.psql_indexer.process()
 
             for ix, agency in enumerate(session.query(Agency)):
                 session.delete(agency)
                 if ix % buffer == 0:
                     app.es_indexer.process()
-                    app.psql_indexer.process()
+                    # FIXME: the psql_indexer runs in a separate transaction
+                    # app.psql_indexer.process()
 
             session.flush()
             click.secho(

--- a/src/onegov/agency/data_import.py
+++ b/src/onegov/agency/data_import.py
@@ -205,7 +205,13 @@ def import_bs_agencies(
         added_count += 1
         if added_count % 50 == 0:
             app.es_indexer.process()
-            app.psql_indexer.process()
+            # FIXME: the psql_indexer runs in a separate transaction
+            #        so it will invalidate our transaction, which will
+            #        prompt us to retry but then we invalidate ourselves
+            #        again right here, so we give up after three tries.
+            #        We should add an option to run the indexer in the
+            #        current connection & transaction without commit
+            # app.psql_indexer.process()
         line = lines_by_id[basisid]
         agency = parse_agency(line, parent=parent)
         for child_id in children.get(line.verzorgeinheitid, []):
@@ -280,7 +286,13 @@ def import_bs_persons(
     for ix, line in enumerate(csvfile.lines):
         if ix % 50 == 0:
             app.es_indexer.process()
-            app.psql_indexer.process()
+            # FIXME: the psql_indexer runs in a separate transaction
+            #        so it will invalidate our transaction, which will
+            #        prompt us to retry but then we invalidate ourselves
+            #        again right here, so we give up after three tries.
+            #        We should add an option to run the indexer in the
+            #        current connection & transaction without commit
+            # app.psql_indexer.process()
         parse_person(line)
 
     return persons
@@ -425,7 +437,13 @@ def match_person_membership_title(
     for ix, line in enumerate(csvfile.lines):
         if ix % 50 == 0:
             app.es_indexer.process()
-            app.psql_indexer.process()
+            # FIXME: the psql_indexer runs in a separate transaction
+            #        so it will invalidate our transaction, which will
+            #        prompt us to retry but then we invalidate ourselves
+            #        again right here, so we give up after three tries.
+            #        We should add an option to run the indexer in the
+            #        current connection & transaction without commit
+            # app.psql_indexer.process()
         total_entries += 1
         match_membership_title(line, agencies)
 

--- a/src/onegov/fsi/cli.py
+++ b/src/onegov/fsi/cli.py
@@ -371,7 +371,8 @@ def fetch_users(
             if not dry_run:
                 if ix % 200 == 0:
                     app.es_indexer.process()
-                    app.psql_indexer.process()
+                    # FIXME: the psql_indexer runs in a separate transaction
+                    # app.psql_indexer.process()
 
     client = LDAPClient(ldap_server, ldap_username, ldap_password)
     client.try_configuration()
@@ -420,7 +421,13 @@ def fetch_users(
         if not dry_run:
             if ix % 200 == 0:
                 app.es_indexer.process()
-                app.psql_indexer.process()
+                # FIXME: the psql_indexer runs in a separate transaction
+                #        so it will invalidate our transaction, which will
+                #        prompt us to retry but then we invalidate ourselves
+                #        again right here, so we give up after three tries.
+                #        We should add an option to run the indexer in the
+                #        current connection & transaction without commit
+                # app.psql_indexer.process()
 
     log.info(f'Synchronized {count} users')
 

--- a/src/onegov/user/auth/provider.py
+++ b/src/onegov/user/auth/provider.py
@@ -308,7 +308,12 @@ def ensure_user(
         user.active = True
 
     # update the username
-    user.username = username
+    if user.username != username:
+        # ensure the new username is available
+        if users.by_username(username) is not None:
+            log.error(f'Cannot rename user {user.username} to {username}')
+        else:
+            user.username = username
 
     # update the role even if the user exists already
     if force_role:


### PR DESCRIPTION
## Commit message

Search: Avoids Postgres indexer causing invalid transactions

This problem only manifested itself in large import jobs where a lot of ORM events are being generated and the indexer has to be called in the middle of a transaction, rather than at the end. Since we don't yet use the Postgres index we haven't fully fixed this yet and instead drop the ORM events we can't fit into our queue.

This also fixes `ensure_user` failing if the new `username` is already taken by another user.

TYPE: Bugfix
LINK: OGC-1400

## Checklist

- [x] I have performed a self-review of my code
