### PR TITLE
Swissvotes: Removes uses of structure keyword in templates

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,10 +9,12 @@ repos:
       - id: debug-statements
         exclude: '^src/onegov/server/core.py$'
   - repo: https://github.com/seantis/pre-commit-hooks
-    rev: v1.0.1
+    rev: v1.1.0
     hooks:
       - id: nocheckin
         exclude: .pre-commit-config.yaml
+      - id: pt_structure
+        include: .*/swissvotes/.*\.pt$
   - repo: https://github.com/PyCQA/flake8
     rev: 7.0.0
     hooks:

--- a/src/onegov/core/elements.py
+++ b/src/onegov/core/elements.py
@@ -14,6 +14,7 @@ This module should eventually replace the elements.py module.
 
 """
 
+from markupsafe import Markup
 from onegov.core.templates import render_macro
 
 
@@ -105,7 +106,7 @@ class Element:
         self,
         layout: 'ChameleonLayout',
         extra_classes: 'Iterable[str] | None' = None
-    ) -> str:
+    ) -> Markup:
 
         assert self.id is not None
 
@@ -118,9 +119,12 @@ class Element:
         else:
             del self.attrs['class']
 
-        return render_macro(layout.elements[self.id], layout.request, {
-            'e': self, 'layout': layout,
-        })
+        # FIXME: render_macro should output Markup
+        return Markup(render_macro(  # noqa: MS001
+            layout.elements[self.id],
+            layout.request,
+            {'e': self, 'layout': layout}
+        ))
 
 
 class AccessMixin:

--- a/src/onegov/core/request.py
+++ b/src/onegov/core/request.py
@@ -11,7 +11,6 @@ from itsdangerous import (
     URLSafeSerializer,
     URLSafeTimedSerializer
 )
-from markupsafe import Markup
 from more.content_security import ContentSecurityRequest
 from more.webassets.core import IncludeRequest
 from morepath.authentication import NO_IDENTITY
@@ -66,7 +65,7 @@ _F = TypeVar('_F', bound='Form')
 
 
 class Message(NamedTuple):
-    text: Markup
+    text: str
     type: 'MessageType'
 
 
@@ -553,15 +552,13 @@ class CoreRequest(IncludeRequest, ContentSecurityRequest, ReturnToMixin):
         template using the messages should call :meth:`consume_messages`.
 
         """
-        # FIXME: Switch to escape or change signature to Markup
-        message = Message(Markup(text), type)  # noqa: MS001
         if not self.browser_session.has('messages'):
-            self.browser_session.messages = [message]
+            self.browser_session.messages = [Message(text, type)]
         else:
             # this is a bit akward, but I don't see an easy way for this atm.
             # (otoh, usually there's going to be one message only)
             self.browser_session.messages = self.browser_session.messages + [
-                message
+                Message(text, type)
             ]
 
     def consume_messages(self) -> 'Iterator[Message]':

--- a/src/onegov/core/request.py
+++ b/src/onegov/core/request.py
@@ -11,6 +11,7 @@ from itsdangerous import (
     URLSafeSerializer,
     URLSafeTimedSerializer
 )
+from markupsafe import Markup
 from more.content_security import ContentSecurityRequest
 from more.webassets.core import IncludeRequest
 from morepath.authentication import NO_IDENTITY
@@ -65,7 +66,7 @@ _F = TypeVar('_F', bound='Form')
 
 
 class Message(NamedTuple):
-    text: str
+    text: Markup
     type: 'MessageType'
 
 
@@ -552,13 +553,15 @@ class CoreRequest(IncludeRequest, ContentSecurityRequest, ReturnToMixin):
         template using the messages should call :meth:`consume_messages`.
 
         """
+        # FIXME: Switch to escape or change signature to Markup
+        message = Message(Markup(text), type)  # noqa: MS001
         if not self.browser_session.has('messages'):
-            self.browser_session.messages = [Message(text, type)]
+            self.browser_session.messages = [message]
         else:
             # this is a bit akward, but I don't see an easy way for this atm.
             # (otoh, usually there's going to be one message only)
             self.browser_session.messages = self.browser_session.messages + [
-                Message(text, type)
+                message
             ]
 
     def consume_messages(self) -> 'Iterator[Message]':

--- a/src/onegov/swissvotes/layouts/default.py
+++ b/src/onegov/swissvotes/layouts/default.py
@@ -150,7 +150,7 @@ class DefaultLayout(ChameleonLayout):
             ))
         return result
 
-    def format_policy_areas(self, vote: 'SwissVote') -> str:
+    def format_policy_areas(self, vote: 'SwissVote') -> Markup:
         paths: dict[str, list[list[str]]] = {}
         for path in (area.label_path for area in vote.policy_areas):
             paths.setdefault(path[0], []).append(path)

--- a/src/onegov/swissvotes/models/actor.py
+++ b/src/onegov/swissvotes/models/actor.py
@@ -213,7 +213,7 @@ class Actor:
             'vsa': _("actor-vsa-label"),
         }.get(self.name, self.name)
 
-    def html(self, request: 'SwissvotesRequest') -> str:
+    def html(self, request: 'SwissvotesRequest') -> Markup:
         return Markup('<span title="{}">{}</span>').format(
             request.translate(self.label),
             request.translate(self.abbreviation)

--- a/src/onegov/swissvotes/models/page.py
+++ b/src/onegov/swissvotes/models/page.py
@@ -1,3 +1,4 @@
+from markupsafe import Markup
 from onegov.core.orm import Base
 from onegov.core.orm import translation_hybrid
 from onegov.core.orm.abstract import associated
@@ -56,6 +57,12 @@ class TranslatablePage(Base, TimestampMixin):
         query = object_session(self).query(TranslatablePage)
         query = query.order_by(TranslatablePage.order)
         return query
+
+    @property
+    def html_content(self) -> Markup:
+        # FIXME: we should add a separate database type for Markup
+        #        so we don't need to convert it here.
+        return Markup(self.content)  # noqa: MS001
 
     def get_file(
         self,

--- a/src/onegov/swissvotes/models/policy_area.py
+++ b/src/onegov/swissvotes/models/policy_area.py
@@ -117,7 +117,7 @@ class PolicyArea:
             result.append(lookup.label or str(self.descriptor))
         return result
 
-    def html(self, request: 'SwissvotesRequest') -> str:
+    def html(self, request: 'SwissvotesRequest') -> Markup:
         title = Markup(' &gt; ').join(
             request.translate(part) for part in self.label_path
         )

--- a/src/onegov/swissvotes/models/region.py
+++ b/src/onegov/swissvotes/models/region.py
@@ -98,7 +98,7 @@ class Region:
             'vsr': _("canton-vsr-label"),
         }.get(self.name, self.name)
 
-    def html(self, request: 'SwissvotesRequest') -> str:
+    def html(self, request: 'SwissvotesRequest') -> Markup:
         return Markup('<span title="{}">{}</span>').format(
             request.translate(self.label),
             request.translate(self.abbreviation)

--- a/src/onegov/swissvotes/templates/layout.pt
+++ b/src/onegov/swissvotes/templates/layout.pt
@@ -82,7 +82,7 @@
             <div class="row">
                 <div class="small-12 columns" id="alert-boxes">
                     <div tal:repeat="message request.consume_messages()" data-alert class="alert-box ${message.type}">
-                        <tal:block tal:content="message.text" />
+                        <tal:block tal:content="Markup(message.text)" />
                         <a href="#" class="close">&times;</a>
                     </div>
                     <div i18n:translate tal:condition="request.agent['user_agent']['family'] == 'IE'" data-alert class="alert-box warning">

--- a/src/onegov/swissvotes/templates/layout.pt
+++ b/src/onegov/swissvotes/templates/layout.pt
@@ -82,7 +82,7 @@
             <div class="row">
                 <div class="small-12 columns" id="alert-boxes">
                     <div tal:repeat="message request.consume_messages()" data-alert class="alert-box ${message.type}">
-                        <tal:block tal:content="structure message.text" />
+                        <tal:block tal:content="message.text" />
                         <a href="#" class="close">&times;</a>
                     </div>
                     <div i18n:translate tal:condition="request.agent['user_agent']['family'] == 'IE'" data-alert class="alert-box warning">

--- a/src/onegov/swissvotes/templates/layout.pt
+++ b/src/onegov/swissvotes/templates/layout.pt
@@ -82,7 +82,7 @@
             <div class="row">
                 <div class="small-12 columns" id="alert-boxes">
                     <div tal:repeat="message request.consume_messages()" data-alert class="alert-box ${message.type}">
-                        <tal:block tal:content="Markup(request.translate(message.text))" />
+                        <tal:block tal:content="structure message.text" />
                         <a href="#" class="close">&times;</a>
                     </div>
                     <div i18n:translate tal:condition="request.agent['user_agent']['family'] == 'IE'" data-alert class="alert-box warning">

--- a/src/onegov/swissvotes/templates/layout.pt
+++ b/src/onegov/swissvotes/templates/layout.pt
@@ -82,7 +82,7 @@
             <div class="row">
                 <div class="small-12 columns" id="alert-boxes">
                     <div tal:repeat="message request.consume_messages()" data-alert class="alert-box ${message.type}">
-                        <tal:block tal:content="Markup(message.text)" />
+                        <tal:block tal:content="Markup(request.translate(message.text))" />
                         <a href="#" class="close">&times;</a>
                     </div>
                     <div i18n:translate tal:condition="request.agent['user_agent']['family'] == 'IE'" data-alert class="alert-box warning">

--- a/src/onegov/swissvotes/templates/layout.pt
+++ b/src/onegov/swissvotes/templates/layout.pt
@@ -82,7 +82,7 @@
             <div class="row">
                 <div class="small-12 columns" id="alert-boxes">
                     <div tal:repeat="message request.consume_messages()" data-alert class="alert-box ${message.type}">
-                        <tal:block tal:content="structure message.text" />
+                        <tal:block tal:content="message.text" />
                         <a href="#" class="close">&times;</a>
                     </div>
                     <div i18n:translate tal:condition="request.agent['user_agent']['family'] == 'IE'" data-alert class="alert-box warning">
@@ -106,13 +106,13 @@
                 <div class="links">
                      <div class="row">
                         <div class="small-12 medium-4 columns small-only-text-center">
-                            <tal:block replace="structure layout.disclaimer_link(layout)" />
+                            <tal:block replace="layout.disclaimer_link(layout)" />
                         </div>
                         <div class="small-12 medium-4 columns text-center">
-                            <tal:block replace="structure layout.imprint_link(layout)" />
+                            <tal:block replace="layout.imprint_link(layout)" />
                         </div>
                         <div class="small-12 medium-4 columns small-only-text-center medium-text-right manage-links">
-                            <tal:block replace="structure layout.data_protection_link(layout)" />
+                            <tal:block replace="layout.data_protection_link(layout)" />
                         </div>
                     </div>
                      <div class="row">

--- a/src/onegov/swissvotes/templates/macros.pt
+++ b/src/onegov/swissvotes/templates/macros.pt
@@ -21,7 +21,7 @@
                         <tal:block repeat="link links">
                             <li tal:attributes="data-sortable-id link.sortable_id|None;
                                                 class python: 'draggable' if getattr(link, 'sortable_id', None) else None">
-                                <tal:b replace="structure link(layout)" />
+                                <tal:b replace="link(layout)" />
                             </li>
                         </tal:block>
                     </ul>
@@ -42,12 +42,12 @@
                             </button>
                             <ul id="${dropdown_id}" data-dropdown-content class="f-dropdown disable-scroll">
                                 <li tal:repeat="link group.links">
-                                    <tal:b replace="structure link(layout)" />
+                                    <tal:b replace="link(layout)" />
                                 </li>
                             </ul>
                         </tal:b>
                         <tal:b condition="group.url|group.attrs|nothing" define="link group">
-                            <tal:b replace="structure link(layout, ('tiny', 'button'))" />
+                            <tal:b replace="link(layout, ('tiny', 'button'))" />
                         </tal:b>
                     </tal:b>
                 </div>
@@ -60,7 +60,7 @@
             <ul class="breadcrumbs" tal:condition="layout.breadcrumbs">
                 <tal:b repeat="link layout.breadcrumbs">
                     <li tal:attributes="class repeat.link.end and 'current' or ''"
-                        tal:content="structure link(layout)">
+                        tal:content="link(layout)">
                     </li>
                 </tal:b>
             </ul>

--- a/src/onegov/swissvotes/templates/page.pt
+++ b/src/onegov/swissvotes/templates/page.pt
@@ -10,7 +10,7 @@
             </div>
             <div class="row">
                 <div class="columns large-7 small-12" id="page-text">
-                    <tal:block tal:content="structure: layout.model.content"></tal:block>
+                    <tal:block tal:content="layout.model.html_content"></tal:block>
                 </div>
                 <div class="columns large-4 large-offset-1 small-12">
 

--- a/src/onegov/swissvotes/templates/strengths.pt
+++ b/src/onegov/swissvotes/templates/strengths.pt
@@ -65,7 +65,7 @@
                 </thead>
                 <tbody tal:define="actors vote.sorted_actors_list">
                     <tr tal:repeat="actor actors">
-                        <td tal:content="structure Actor(actor).html(request)" />
+                        <td tal:content="Actor(actor).html(request)" />
                         <td>${vote.get_recommendation(actor)}</td>
                         <td>${layout.format_number(vote.get_actors_share(actor), 1)}%</td>
                     </tr>

--- a/src/onegov/swissvotes/templates/vote.pt
+++ b/src/onegov/swissvotes/templates/vote.pt
@@ -59,7 +59,7 @@
                         <th class="column-30" i18n:translate>Policy area</th>
                         <td>
                             <tal:block tal:repeat="area vote.policy_areas">
-                                <tal:block tal:content="structure area.html(request)" /><br tal:condition="not repeat.area.end" />
+                                <tal:block tal:content="area.html(request)" /><br tal:condition="not repeat.area.end" />
                             </tal:block>
                         </td>
                     </tr>
@@ -322,7 +322,7 @@
                         <td>
                             <dl tal:repeat="(recommendation, parties) vote.recommendations_parties.items()" class="recommendation">
                                 <dt>${recommendation}</dt>
-                                <dd tal:repeat="party parties"><tal:block tal:content="structure party.html(request)" /></dd>
+                                <dd tal:repeat="party parties"><tal:block tal:content="party.html(request)" /></dd>
                             </dl>
                         </td>
                     </tr>
@@ -359,7 +359,7 @@
                         <td>
                             <dl tal:repeat="(recommendation, associations) vote.recommendations_associations.items()" class="recommendation">
                                 <dt>${recommendation}</dt>
-                                <dd tal:repeat="association associations"><tal:block tal:content="structure association.html(request)" /></dd>
+                                <dd tal:repeat="association associations"><tal:block tal:content="association.html(request)" /></dd>
                             </dl>
                         </td>
                     </tr>
@@ -368,7 +368,7 @@
                         <td>
                             <dl tal:repeat="(recommendation, branches) vote.recommendations_divergent_parties.items()"  class="recommendation">
                                 <dt>${recommendation}</dt>
-                                <dd tal:repeat="(actor, canton) branches"><tal:block tal:content="structure actor.html(request)" /> <tal:block tal:content="structure canton.html(request)" /></dd>
+                                <dd tal:repeat="(actor, canton) branches"><tal:block tal:content="actor.html(request)" /> <tal:block tal:content="canton.html(request)" /></dd>
                             </dl>
                         </td>
                     </tr>
@@ -506,7 +506,7 @@
                             </span>
                             <dl tal:repeat="(result, cantons) vote.results_cantons.items()">
                                 <dt>${result}</dt>
-                                <dd tal:repeat="canton cantons"><tal:block tal:content="structure canton.html(request)" /></dd>
+                                <dd tal:repeat="canton cantons"><tal:block tal:content="canton.html(request)" /></dd>
                             </dl>
                         </td>
                     </tr>

--- a/src/onegov/swissvotes/templates/votes.pt
+++ b/src/onegov/swissvotes/templates/votes.pt
@@ -54,7 +54,7 @@
                             <td class="left-aligned"><span title="${vote.title}">${vote.short_title}</span> <a href="${request.link(votes.by_order('title'))}" class="sort-title-fix sort-${votes.sort_order_by_key('title')}"></a></td>
                             <td class="left-aligned sort-${votes.sort_order_by_key('date')}">${layout.format_date(vote.date, 'date')}</td>
                             <td class="left-aligned sort-${votes.sort_order_by_key('legal_form')}">${vote.legal_form}</td>
-                            <td class="left-aligned" tal:content="structure layout.format_policy_areas(vote)"></td>
+                            <td class="left-aligned" tal:content="layout.format_policy_areas(vote)"></td>
                             <td class="left-aligned sort-${votes.sort_order_by_key('result')}">${vote.result}</td>
                             <td class="right-aligned sort-${votes.sort_order_by_key('result_people_yeas_p')}">${layout.format_number(vote.result_people_yeas_p)}%</td>
                             <td class="left-aligned sort-${votes.sort_order_by_key('result')}">${layout.format_number(vote.result_turnout)}%</td>


### PR DESCRIPTION
## Commit message

Swissvotes: Removes uses of structure keyword in templates

This also bans further uses of said keyword within swissvotes.

TYPE: Bugfix
LINK: OGC-1709

## Checklist

- [x] I have performed a self-review of my code
