### PR TITLE
Search: Allows executing the `PostgresIndexer` mid-transaction

### DIFF
--- a/src/onegov/agency/data_import.py
+++ b/src/onegov/agency/data_import.py
@@ -205,13 +205,7 @@ def import_bs_agencies(
         added_count += 1
         if added_count % 50 == 0:
             app.es_indexer.process()
-            # FIXME: the psql_indexer runs in a separate transaction
-            #        so it will invalidate our transaction, which will
-            #        prompt us to retry but then we invalidate ourselves
-            #        again right here, so we give up after three tries.
-            #        We should add an option to run the indexer in the
-            #        current connection & transaction without commit
-            # app.psql_indexer.process()
+            app.psql_indexer.bulk_process(session)
         line = lines_by_id[basisid]
         agency = parse_agency(line, parent=parent)
         for child_id in children.get(line.verzorgeinheitid, []):
@@ -286,13 +280,7 @@ def import_bs_persons(
     for ix, line in enumerate(csvfile.lines):
         if ix % 50 == 0:
             app.es_indexer.process()
-            # FIXME: the psql_indexer runs in a separate transaction
-            #        so it will invalidate our transaction, which will
-            #        prompt us to retry but then we invalidate ourselves
-            #        again right here, so we give up after three tries.
-            #        We should add an option to run the indexer in the
-            #        current connection & transaction without commit
-            # app.psql_indexer.process()
+            app.psql_indexer.bulk_process(session)
         parse_person(line)
 
     return persons
@@ -437,13 +425,7 @@ def match_person_membership_title(
     for ix, line in enumerate(csvfile.lines):
         if ix % 50 == 0:
             app.es_indexer.process()
-            # FIXME: the psql_indexer runs in a separate transaction
-            #        so it will invalidate our transaction, which will
-            #        prompt us to retry but then we invalidate ourselves
-            #        again right here, so we give up after three tries.
-            #        We should add an option to run the indexer in the
-            #        current connection & transaction without commit
-            # app.psql_indexer.process()
+            app.psql_indexer.bulk_process(session)
         total_entries += 1
         match_membership_title(line, agencies)
 

--- a/src/onegov/fsi/cli.py
+++ b/src/onegov/fsi/cli.py
@@ -371,8 +371,7 @@ def fetch_users(
             if not dry_run:
                 if ix % 200 == 0:
                     app.es_indexer.process()
-                    # FIXME: the psql_indexer runs in a separate transaction
-                    # app.psql_indexer.process()
+                    app.psql_indexer.bulk_process(session)
 
     client = LDAPClient(ldap_server, ldap_username, ldap_password)
     client.try_configuration()
@@ -421,13 +420,7 @@ def fetch_users(
         if not dry_run:
             if ix % 200 == 0:
                 app.es_indexer.process()
-                # FIXME: the psql_indexer runs in a separate transaction
-                #        so it will invalidate our transaction, which will
-                #        prompt us to retry but then we invalidate ourselves
-                #        again right here, so we give up after three tries.
-                #        We should add an option to run the indexer in the
-                #        current connection & transaction without commit
-                # app.psql_indexer.process()
+                app.psql_indexer.bulk_process(session)
 
     log.info(f'Synchronized {count} users')
 

--- a/src/onegov/search/indexer.py
+++ b/src/onegov/search/indexer.py
@@ -439,9 +439,8 @@ class PostgresIndexer(IndexerBase):
                     connection.execute(stmt, content)
             else:
                 # use a savepoint instead
-                with session.begin_nested() as transaction:
-                    connection = transaction.connection()
-                    connection.execute(stmt, content)
+                with session.begin_nested():
+                    session.execute(stmt, content)
         except Exception as ex:
             index_log.error(f'Error \'{ex}\' indexing schema '
                             f'{tasks[0]["schema"]} table '

--- a/src/onegov/search/indexer.py
+++ b/src/onegov/search/indexer.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
     from collections.abc import Iterable, Iterator, Sequence
     from elasticsearch import Elasticsearch
     from sqlalchemy.engine import Engine
+    from sqlalchemy.orm import Session
     from typing import TypedDict
     from typing_extensions import TypeAlias
     from uuid import UUID
@@ -376,14 +377,23 @@ class PostgresIndexer(IndexerBase):
         self.queue = queue
         self.engine = engine
 
-    def index(self, tasks: 'list[IndexTask] | IndexTask') -> bool:
+    def index(
+        self,
+        tasks: 'list[IndexTask] | IndexTask',
+        session: 'Session | None' = None
+    ) -> bool:
         """ Update the 'fts_idx' column (full text search index) of the given
         object(s)/task(s).
 
         In case of a bunch of tasks we are assuming they are all from the
         same schema and table in order to optimize the indexing process.
 
+        When a session is passed we use that session's transaction context
+        and use a savepoint instead of our own transaction to perform the
+        action.
+
         :param tasks: A list of tasks to index
+        :param session: Supply an active session
         :return: True if the indexing was successful, False otherwise
         """
         content = []
@@ -423,10 +433,15 @@ class PostgresIndexer(IndexerBase):
                 .where(id_col == sqlalchemy.bindparam('_id'))
                 .values({self.TEXT_SEARCH_COLUMN_NAME: tsvector_expr})
             )
-            connection = self.engine.connect()
-            trans = connection.begin()
-            connection.execute(stmt, content)
-            trans.commit()
+            if session is None:
+                connection = self.engine.connect()
+                with connection.begin():
+                    connection.execute(stmt, content)
+            else:
+                # use a savepoint instead
+                with session.begin_nested() as transaction:
+                    connection = transaction.connection()
+                    connection.execute(stmt, content)
         except Exception as ex:
             index_log.error(f'Error \'{ex}\' indexing schema '
                             f'{tasks[0]["schema"]} table '
@@ -435,7 +450,10 @@ class PostgresIndexer(IndexerBase):
 
         return True
 
-    def bulk_process(self) -> None:
+    # FIXME: bulk_process should probably be the only function we use for
+    #        the Postgres indexer, we don't have to worry about individual
+    #        transactions failing as much
+    def bulk_process(self, session: 'Session | None' = None) -> None:
         """ Processes the queue in bulk. This offers better performance but it
         is less safe at the moment and should only be used as part of
         reindexing.
@@ -454,7 +472,7 @@ class PostgresIndexer(IndexerBase):
         for (action, tablename), tasks in grouped_tasks:
             task_list = list(tasks)
             if action == 'index':
-                self.index(task_list)
+                self.index(task_list, session)
             else:
                 raise NotImplementedError('Action \'{action}\' not '
                                           'implemented')

--- a/src/onegov/search/integration.py
+++ b/src/onegov/search/integration.py
@@ -502,7 +502,10 @@ def process_indexer_tween_factory(
         #        we may want to be able to toggle it on or off, just
         #        like with `enable_elasticsearch` so we don't waste
         #        CPU cycles on applications that don't use this search
-        app.psql_indexer.process()
+        # NOTE: Since we install ourselves over the transaction tween
+        #       the transaction has already been comitted at this point
+        #       so we don't need to pass in the current session
+        app.psql_indexer.bulk_process()
         return result
 
     return process_indexer_tween

--- a/src/onegov/translator_directory/cli.py
+++ b/src/onegov/translator_directory/cli.py
@@ -88,8 +88,7 @@ def fetch_users(
             if not dry_run:
                 if ix % 200 == 0:
                     app.es_indexer.process()
-                    # FIXME: the psql_indexer runs in a separate transaction
-                    # app.psql_indexer.process()
+                    app.psql_indexer.bulk_process(session)
 
     client = LDAPClient(ldap_server, ldap_username, ldap_password)
     client.try_configuration()
@@ -130,13 +129,7 @@ def fetch_users(
             if ix % 200 == 0:
                 session.flush()
                 app.es_indexer.process()
-                # FIXME: the psql_indexer runs in a separate transaction
-                #        so it will invalidate our transaction, which will
-                #        prompt us to retry but then we invalidate ourselves
-                #        again right here, so we give up after three tries.
-                #        We should add an option to run the indexer in the
-                #        current connection & transaction without commit
-                # app.psql_indexer.process()
+                app.psql_indexer.bulk_process(session)
 
     log.info(f'Synchronized {count} users')
 


### PR DESCRIPTION
## Commit message

Search: Allows executing the `PostgresIndexer` mid-transaction

Previously the indexer would've invalidated our transaction and vice versa causing the entire request to semi-silently fail with a 409.

TYPE: Bugfix
LINK: OGC-1707

## Checklist

- [x] I have performed a self-review of my code
- [x] I have tested my code thoroughly by hand
- [x] I have added tests for my changes/features
