### PR TITLE
Gazette: Removes uses of structure keyword in templates

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
       - id: nocheckin
         exclude: .pre-commit-config.yaml
       - id: pt_structure
-        include: .*/(election_day|swissvotes|wtfs)/.*\.pt$
+        include: .*/(election_day|gazette|onboarding|swissvotes|wtfs)/.*\.pt$
   - repo: https://github.com/PyCQA/flake8
     rev: 7.0.0
     hooks:

--- a/src/onegov/core/orm/types/__init__.py
+++ b/src/onegov/core/orm/types/__init__.py
@@ -1,5 +1,6 @@
 from onegov.core.orm.types.hstore_type import HSTORE
 from onegov.core.orm.types.json_type import JSON
+from onegov.core.orm.types.markup_text_type import MarkupText
 from onegov.core.orm.types.utcdatetime_type import UTCDateTime
 from onegov.core.orm.types.uuid_type import UUID
 from onegov.core.orm.types.lowercase_text_type import LowercaseText
@@ -7,6 +8,7 @@ from onegov.core.orm.types.lowercase_text_type import LowercaseText
 __all__ = [
     'HSTORE',
     'JSON',
+    'MarkupText',
     'UTCDateTime',
     'UUID',
     'LowercaseText'

--- a/src/onegov/core/orm/types/lowercase_text_type.py
+++ b/src/onegov/core/orm/types/lowercase_text_type.py
@@ -14,6 +14,8 @@ class LowercaseText(_Base):
     """ Text column that forces all text to be lowercase. """
 
     impl = TEXT
+    # FIXME: This was spelled incorrectly, but fixing the spelling
+    #        causes some issues with custom join conditions
     omparator_factory = CaseInsensitiveComparator
 
     def process_bind_param(

--- a/src/onegov/core/orm/types/markup_text_type.py
+++ b/src/onegov/core/orm/types/markup_text_type.py
@@ -1,0 +1,48 @@
+from markupsafe import escape, Markup
+from sqlalchemy.types import TypeDecorator, TEXT
+
+
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    from sqlalchemy.engine.interfaces import Dialect
+    _Base = TypeDecorator[Markup]
+else:
+    _Base = TypeDecorator
+
+
+class MarkupText(_Base):
+    """ Text column that contains HTML/XML markup. """
+
+    impl = TEXT
+
+    cache_ok = True
+
+    def process_bind_param(
+        self,
+        value: str | None,
+        dialect: 'Dialect'
+    ) -> Markup | None:
+
+        return None if value is None else escape(value)
+
+    def process_literal_param(
+        self,
+        value: str | None,
+        dialect: 'Dialect'
+    ) -> Markup | None:
+
+        return None if value is None else escape(value)
+
+    def process_result_value(
+        self,
+        value: str | None,
+        dialect: 'Dialect'
+    ) -> Markup | None:
+
+        # NOTE: It would be safer to sanitize the text, in case someone
+        #       managed to bypass `process_bind_param` and inserted
+        #       unsanitized markup into the database. However, this would
+        #       also add a ton of static overhead. If we decide we want
+        #       the additional safety, we should use an approach like
+        #       OCQMS' lazy Sanitized text type.
+        return None if value is None else Markup(value)  # noqa: MS001

--- a/src/onegov/gazette/collections/notices.py
+++ b/src/onegov/gazette/collections/notices.py
@@ -27,17 +27,16 @@ if TYPE_CHECKING:
     from collections.abc import Iterable
     from collections.abc import Sized
     from onegov.gazette.request import GazetteRequest
+    from onegov.notice.collections import _StrColumnLike
     from onegov.notice.models import NoticeState
     from datetime import date
     from sqlalchemy.orm import Query
     from sqlalchemy.orm import Session
-    from sqlalchemy.sql import ColumnElement
     from typing import TypeVar
     from typing_extensions import Self
     from uuid import UUID
 
     _T = TypeVar('_T')
-    _StrColumnLike = ColumnElement[str] | ColumnElement[str | None]
 
 
 TRANSLATIONS: dict[str | None, str] = {

--- a/src/onegov/gazette/forms/notice.py
+++ b/src/onegov/gazette/forms/notice.py
@@ -9,7 +9,7 @@ from onegov.gazette.layout import Layout
 from onegov.gazette.models import Category
 from onegov.gazette.models import Issue
 from onegov.gazette.models import Organization
-from onegov.quill import QuillField
+from onegov.quill.fields import QuillMarkupField
 from onegov.quill.validators import HtmlDataRequired
 from sedate import as_datetime
 from sedate import standardize_date
@@ -99,7 +99,7 @@ class NoticeForm(Form):
         ]
     )
 
-    text = QuillField(
+    text = QuillMarkupField(
         label=_("Text"),
         tags=('strong', 'ol', 'ul'),
         validators=[

--- a/src/onegov/gazette/layout.py
+++ b/src/onegov/gazette/layout.py
@@ -1,4 +1,5 @@
 from functools import cached_property
+from markupsafe import Markup
 from onegov.core.layout import ChameleonLayout
 from onegov.core.static import StaticFile
 from onegov.gazette import _
@@ -363,8 +364,7 @@ class Layout(ChameleonLayout):
             ))
 
     def format_text(self, text: str | None) -> str:
-        # FIXME: Markupsafe
-        return '<br>'.join((text or '').splitlines())
+        return Markup('<br>').join((text or '').splitlines())
 
 
 class MailLayout(Layout):

--- a/src/onegov/gazette/models/notice.py
+++ b/src/onegov/gazette/models/notice.py
@@ -186,7 +186,7 @@ class GazetteNotice(
     )
 
     @property
-    def text_html(self) -> str:
+    def text_html(self) -> Markup:
         # FIXME: Consider changing Text column to a MarkupText column, if
         #        we ever decide to add that type, then we don't need this
         #        conversion here. Although this would imply that all children

--- a/src/onegov/gazette/models/notice.py
+++ b/src/onegov/gazette/models/notice.py
@@ -1,6 +1,5 @@
 from collections import OrderedDict
 from datetime import date
-from markupsafe import Markup
 from onegov.chat import Message
 from onegov.core.orm.mixins import content_property
 from onegov.core.orm.mixins import dict_property
@@ -184,14 +183,6 @@ class GazetteNotice(
         cascade='all,delete-orphan',
         order_by='desc(GazetteNoticeChange.id)'
     )
-
-    @property
-    def text_html(self) -> Markup:
-        # FIXME: Consider changing Text column to a MarkupText column, if
-        #        we ever decide to add that type, then we don't need this
-        #        conversion here. Although this would imply that all children
-        #        of OfficialNotice would need to supply text as Markup
-        return Markup(self.text)  # noqa: MS001
 
     @observes('user', 'user.realname', 'user.username')
     def user_observer(

--- a/src/onegov/gazette/models/notice.py
+++ b/src/onegov/gazette/models/notice.py
@@ -1,5 +1,6 @@
 from collections import OrderedDict
 from datetime import date
+from markupsafe import Markup
 from onegov.chat import Message
 from onegov.core.orm.mixins import content_property
 from onegov.core.orm.mixins import dict_property
@@ -183,6 +184,14 @@ class GazetteNotice(
         cascade='all,delete-orphan',
         order_by='desc(GazetteNoticeChange.id)'
     )
+
+    @property
+    def text_html(self) -> str:
+        # FIXME: Consider changing Text column to a MarkupText column, if
+        #        we ever decide to add that type, then we don't need this
+        #        conversion here. Although this would imply that all children
+        #        of OfficialNotice would need to supply text as Markup
+        return Markup(self.text)  # noqa: MS001
 
     @observes('user', 'user.realname', 'user.username')
     def user_observer(

--- a/src/onegov/gazette/templates/layout.pt
+++ b/src/onegov/gazette/templates/layout.pt
@@ -67,7 +67,7 @@
         <div class="row">
           <div class="small-12 columns" id="alert-boxes">
             <div tal:repeat="message request.consume_messages()" data-alert class="alert-box ${message.type}">
-              <tal:block tal:content="structure message.text" />
+              <tal:block tal:content="message.text" />
               <a href="#" class="close">&times;</a>
             </div>
           </div>

--- a/src/onegov/gazette/templates/macros.pt
+++ b/src/onegov/gazette/templates/macros.pt
@@ -166,10 +166,10 @@
 </metal:deadline_callout>
 
 <metal:notice_text define-macro="notice_text" i18n:domain="onegov.gazette">
-    <tal:block tal:content="structure notice.text"></tal:block>
+    <tal:block tal:content="notice.text_html"></tal:block>
     <p tal:condition="notice.author_place and notice.author_date">
         ${notice.author_place}, ${layout.format_date(notice.author_date, 'date_long')}<br>
-        <tal:block tal:content="structure layout.format_text(notice.author_name)" />
+        <tal:block tal:content="layout.format_text(notice.author_name)" />
     </p>
 </metal:notice_text>
 

--- a/src/onegov/gazette/templates/macros.pt
+++ b/src/onegov/gazette/templates/macros.pt
@@ -166,7 +166,7 @@
 </metal:deadline_callout>
 
 <metal:notice_text define-macro="notice_text" i18n:domain="onegov.gazette">
-    <tal:block tal:content="notice.text_html"></tal:block>
+    <tal:block tal:content="notice.text"></tal:block>
     <p tal:condition="notice.author_place and notice.author_date">
         ${notice.author_place}, ${layout.format_date(notice.author_date, 'date_long')}<br>
         <tal:block tal:content="layout.format_text(notice.author_name)" />

--- a/src/onegov/gazette/templates/mail_notice_rejected.pt
+++ b/src/onegov/gazette/templates/mail_notice_rejected.pt
@@ -26,7 +26,7 @@
             <dd>${model.id}</dd>
 
             <dt i18n:translate>Text</dt>
-            <dd class="callout" tal:content="model.text_html"></dd>
+            <dd class="callout" tal:content="model.text"></dd>
 
             <dt i18n:translate>Comment</dt>
             <dd>${comment}</dd>

--- a/src/onegov/gazette/templates/mail_notice_rejected.pt
+++ b/src/onegov/gazette/templates/mail_notice_rejected.pt
@@ -26,7 +26,7 @@
             <dd>${model.id}</dd>
 
             <dt i18n:translate>Text</dt>
-            <dd class="callout" tal:content="structure model.text"></dd>
+            <dd class="callout" tal:content="model.text_html"></dd>
 
             <dt i18n:translate>Comment</dt>
             <dd>${comment}</dd>

--- a/src/onegov/gazette/templates/mail_on_accept.pt
+++ b/src/onegov/gazette/templates/mail_on_accept.pt
@@ -21,7 +21,7 @@
 
             <tal:block tal:condition="model.at_cost">
                 <dt i18n:translate>Billing address</dt>
-                <dd><tal:block tal:content="structure layout.format_text(model.billing_address)" /></dd>
+                <dd><tal:block tal:content="layout.format_text(model.billing_address)" /></dd>
             </tal:block>
 
             <dt tal:condition="model.files" i18n:translate>Attachments</dt>

--- a/src/onegov/gazette/templates/notice.pt
+++ b/src/onegov/gazette/templates/notice.pt
@@ -59,7 +59,7 @@
                             <dd tal:condition="not: notice.at_cost" i18n:translate>No</dd>
 
                             <dt tal:condition="notice.at_cost" i18n:translate>Billing address</dt>
-                            <dd tal:condition="notice.at_cost" tal:content="structure layout.format_text(notice.billing_address)"></dd>
+                            <dd tal:condition="notice.at_cost" tal:content="layout.format_text(notice.billing_address)"></dd>
 
                             <dt i18n:translate>User</dt>
                             <dd>
@@ -89,7 +89,7 @@
 
                 <tal:block tal:condition="publisher and notice.note">
                     <h3 i18n:translate>Note</h3>
-                    <p tal:content="structure layout.format_text(notice.note)"></p>
+                    <p tal:content="layout.format_text(notice.note)"></p>
                 </tal:block>
 
                 <h3 i18n:translate>Changes</h3>

--- a/src/onegov/gazette/utils/sogc_converter.py
+++ b/src/onegov/gazette/utils/sogc_converter.py
@@ -1,6 +1,6 @@
 from dateutil.parser import parse
+from markupsafe import Markup
 from onegov.gazette.models import Issue
-from textwrap import dedent
 
 
 from typing import overload
@@ -17,9 +17,13 @@ if TYPE_CHECKING:
     _T = TypeVar('_T')
 
 
-def html_converter(text: str) -> str:
-    # FIXME: Markupsafe
-    return '<br>'.join((line.strip() for line in text.split('\n')))
+def html_converter(text: str) -> Markup:
+    return Markup('<br>').join(line.strip() for line in text.split('\n'))
+
+
+def line_converter(text: str) -> str:
+    assert '\n' not in text, "Encountered line break in single line field"
+    return text.strip()
 
 
 class SogcConverter:
@@ -36,9 +40,9 @@ class SogcConverter:
     def get(
         self,
         path: str,
-        converter: 'Callable[[str], str] | None' = html_converter,
+        converter: 'Callable[[str], Markup] | None' = html_converter,
         root: '_Element | None' = None
-    ) -> str: ...
+    ) -> Markup | Literal['']: ...
 
     @overload
     def get(
@@ -62,16 +66,16 @@ class SogcConverter:
             result = converter(result)
         return result
 
-    def dedent(self, text: str) -> str:
-        return dedent(text).strip().replace('\n', '')
+    def get_line(self, path: str, root: '_Element | None' = None) -> str:
+        return self.get(path, converter=line_converter, root=root)
 
     @property
     def title(self) -> str:
-        return self.get('meta/title/de')
+        return self.get_line('meta/title/de')
 
     @property
     def source(self) -> str:
-        return self.get('meta/publicationNumber')
+        return self.get_line('meta/publicationNumber')
 
     @property
     def publication_date(self) -> 'datetime | Literal[""]':
@@ -88,7 +92,6 @@ class SogcConverter:
         row = query.first()
         return list(row) if row else []
 
-    # FIXME: Markupsafe
     def p(
         self,
         value: object,
@@ -97,7 +100,7 @@ class SogcConverter:
         subtitle: str = '',
         subtitle_break: bool = False,
         fmt: str | None = None
-    ) -> str:
+    ) -> Markup:
         """ Adds a paragraph.
 
             <p>
@@ -107,7 +110,7 @@ class SogcConverter:
             </p>
         """
         if not value:
-            return ""
+            return Markup("")
 
         if fmt == 'date':
             value = f"{value:%d.%m.%Y}"
@@ -118,23 +121,27 @@ class SogcConverter:
 
         if subtitle:
             if subtitle_break:
-                value = f"{subtitle}:<br>{value}"
+                template = Markup("{}:<br>{}")
             else:
-                value = f"{subtitle}: {value}"
+                template = Markup("{}: {}")
+
+            value = template.format(subtitle, value)
 
         if title:
             if title_break:
-                value = f"<strong>{title}</strong><br>{value}"
+                template = Markup("<strong>{}</strong><br>{}")
             else:
-                value = f"<strong>{title}</strong>{value}"
+                template = Markup("<strong>{}</strong>{}")
 
-        return f"<p>{value}</p>"
+            value = template.format(title, value)
+
+        return Markup("<p>{}</p>").format(value)
 
 
 class KK(SogcConverter):
 
     @property
-    def addition(self) -> str:
+    def addition(self) -> Markup:
         value = self.get('content/addition')
         if value == 'legacy':
             return self.p("Erbschaft", "Zusatz")
@@ -144,17 +151,17 @@ class KK(SogcConverter):
             value = self.get('content/additionCustom')
             return self.p(value, "Zusatz")
         else:
-            return ""
+            return Markup('')
 
     @property
-    def comment_entry_deadline(self) -> str:
+    def comment_entry_deadline(self) -> Markup:
         return self.p(
             self.get('content/commentEntryDeadline'),
             "Kommentar zur Frist"
         )
 
     @property
-    def days_after_publication(self) -> str:
+    def days_after_publication(self) -> Markup:
         return self.p(
             self.get('content/daysAfterPublication', int),
             "Frist",
@@ -162,11 +169,11 @@ class KK(SogcConverter):
         )
 
     @property
-    def debtor(self) -> str | None:
+    def debtor(self) -> Markup:
         debtor_type = self.get('content/debtor/selectType')
         if debtor_type == 'company':
             companies = self.root.findall('content/debtor/companies/company')
-            result = ""
+            result = Markup("")
             for company in companies:
                 result += self.p(
                     self.get('name', root=company),
@@ -174,16 +181,16 @@ class KK(SogcConverter):
                 )
                 result += self.p(self.get('uid', root=company), subtitle="UID")
                 result += self.p(
-                    '<br>'.join([
-                        '{} {}'.format(
+                    Markup('<br>').join((
+                        Markup('{} {}').format(
                             self.get('address/street', root=company),
                             self.get('address/houseNumber', root=company)
                         ).strip(),
-                        '{} {}'.format(
+                        Markup('{} {}').format(
                             self.get('address/swissZipCode', root=company),
                             self.get('address/town', root=company)
                         ).strip()
-                    ]),
+                    )),
                 )
                 result += self.p(self.get('customAddress', root=company))
                 result += self.p(self.get('country/name/de', root=company))
@@ -191,7 +198,7 @@ class KK(SogcConverter):
 
         elif debtor_type == 'person':
             result = self.p(
-                '{} {}'.format(
+                Markup('{} {}').format(
                     self.get('content/debtor/person/prename'),
                     self.get('content/debtor/person/name')
                 ).strip(),
@@ -222,26 +229,26 @@ class KK(SogcConverter):
             if residence_type == 'switzerland':
                 path = 'content/debtor/person/addressSwitzerland'
                 result += self.p(
-                    '<br>'.join([
-                        '{} {}'.format(
+                    Markup('<br>').join((
+                        Markup('{} {}').format(
                             self.get(f'{path}/street'),
                             self.get(f'{path}/houseNumber')
                         ).strip(),
-                        '{} {}'.format(
+                        Markup('{} {}').format(
                             self.get(f'{path}/swissZipCode'),
                             self.get(f'{path}/town')
                         ).strip()
-                    ]),
+                    )),
                     subtitle="Wohnsitz",
                     subtitle_break=True
                 )
             elif residence_type == 'foreign':
                 path = 'content/debtor/person/addressForeign'
                 result += self.p(
-                    '<br>'.join([
+                    Markup('<br>').join((
                         self.get(f'{path}/addressCustomText'),
                         self.get(f'{path}/country/name/de')
-                    ]),
+                    )),
                     subtitle="Wohnsitz",
                     subtitle_break=True
                 )
@@ -255,11 +262,10 @@ class KK(SogcConverter):
             )
             return result
 
-        # FIXME: are we allowed to get here?
-        return None
+        return Markup("")
 
     @property
-    def entry_deadline(self) -> str:
+    def entry_deadline(self) -> Markup:
         result = self.p(
             self.get('content/entryDeadline', parse),
             "Ablauf der Frist",
@@ -272,14 +278,14 @@ class KK(SogcConverter):
         return result
 
     @property
-    def information_about_edition(self) -> str:
+    def information_about_edition(self) -> Markup:
         return self.p(
             self.get('content/informationAboutEdition'),
             "Angaben zur Auflage"
         )
 
     @property
-    def legal(self) -> str:
+    def legal(self) -> Markup:
         result = self.p(
             self.get('meta/legalRemedy'),
             "Rechtliche Hinweise und Fristen"
@@ -297,21 +303,21 @@ class KK(SogcConverter):
         return result
 
     @property
-    def remarks(self) -> str:
+    def remarks(self) -> Markup:
         return self.p(
             self.get('content/remarks'),
             "Bemerkungen"
         )
 
     @property
-    def registration_office(self) -> str:
+    def registration_office(self) -> Markup:
         return self.p(
             self.get('content/registrationOffice'),
             "Anmeldestelle"
         )
 
     @property
-    def resolution_date(self) -> str:
+    def resolution_date(self) -> Markup:
         return self.p(
             self.get('content/resolutionDate', parse),
             "Datum der Konkurseröffnung",
@@ -322,20 +328,20 @@ class KK(SogcConverter):
 class KK01(KK):
 
     @property
-    def text(self) -> str:
-        return self.dedent(f"""
-        {self.debtor}
-        {self.resolution_date}
-        {self.addition}
-        {self.legal}
-        {self.remarks}
-        """)
+    def text(self) -> Markup:
+        return Markup("").join((
+            self.debtor,
+            self.resolution_date,
+            self.addition,
+            self.legal,
+            self.remarks,
+        ))
 
 
 class KK02(KK):
 
     @property
-    def proceeding(self) -> str:
+    def proceeding(self) -> Markup:
         value = self.get('content/proceeding/selectType')
         if value == 'summary':
             return self.p("summarisch", "Art des Konkursverfahrens")
@@ -345,44 +351,44 @@ class KK02(KK):
             value = self.get('content/otherProceeding')
             return self.p(value, "Art des Konkursverfahrens")
         else:
-            return ''
+            return Markup('')
 
     @property
-    def creditor_meeting(self) -> str:
+    def creditor_meeting(self) -> Markup:
         value_date = self.get('content/creditorMeeting/dateFrom', parse)
         value_time = self.get('content/creditorMeeting/time', parse)
         value_location = self.get('content/creditorMeeting/location')
         if not value_date:
-            return ""
+            return Markup('')
 
         value = f"{value_date:%d.%m.%Y}"
         if value_time:
             value = f"{value_date:%d.%m.%Y} um {value_time:%H:%M}"
         if value_location:
-            value = f"{value}<br>{value_location}"
+            value = Markup("{}<br>{}").format(value, value_location)
 
         return self.p(value, "Gläubigerversammlung")
 
     @property
-    def text(self) -> str:
-        return self.dedent(f"""
-        {self.debtor}
-        {self.proceeding}
-        {self.resolution_date}
-        {self.creditor_meeting}
-        {self.days_after_publication}
-        {self.entry_deadline}
-        {self.registration_office}
-        {self.addition}
-        {self.legal}
-        {self.remarks}
-        """)
+    def text(self) -> Markup:
+        return Markup("").join((
+            self.debtor,
+            self.proceeding,
+            self.resolution_date,
+            self.creditor_meeting,
+            self.days_after_publication,
+            self.entry_deadline,
+            self.registration_office,
+            self.addition,
+            self.legal,
+            self.remarks,
+        ))
 
 
 class KK03(KK):
 
     @property
-    def cessation_date(self) -> str:
+    def cessation_date(self) -> Markup:
         return self.p(
             self.get('content/cessationDate', parse),
             "Datum der Einstellung",
@@ -390,7 +396,7 @@ class KK03(KK):
         )
 
     @property
-    def advance_amount(self) -> str:
+    def advance_amount(self) -> Markup:
         return self.p(
             self.get('content/advanceAmount', float),
             "Betrag des Kostenvorschusses",
@@ -399,24 +405,24 @@ class KK03(KK):
 
     @property
     def text(self) -> str:
-        return self.dedent(f"""
-        {self.debtor}
-        {self.resolution_date}
-        {self.cessation_date}
-        {self.advance_amount}
-        {self.days_after_publication}
-        {self.entry_deadline}
-        {self.registration_office}
-        {self.addition}
-        {self.legal}
-        {self.remarks}
-        """)
+        return Markup("").join((
+            self.debtor,
+            self.resolution_date,
+            self.cessation_date,
+            self.advance_amount,
+            self.days_after_publication,
+            self.entry_deadline,
+            self.registration_office,
+            self.addition,
+            self.legal,
+            self.remarks,
+        ))
 
 
 class KK04(KK):
 
     @property
-    def claim_of_creditors(self) -> str:
+    def claim_of_creditors(self) -> Markup:
         result = self.p(
             self.get('content/claimOfCreditors/daysAfterPublication', int),
             "Auflagefrist Kollokationsplan nach Publikation",
@@ -434,7 +440,7 @@ class KK04(KK):
         return result
 
     @property
-    def inventory(self) -> str:
+    def inventory(self) -> Markup:
         result = self.p(
             self.get('content/inventory/daysAfterPublication', int),
             "Auflagefrist Inventar nach Publikation",
@@ -452,44 +458,44 @@ class KK04(KK):
         return result
 
     @property
-    def text(self) -> str:
-        return self.dedent(f"""
-        {self.debtor}
-        {self.claim_of_creditors}
-        {self.inventory}
-        {self.registration_office}
-        {self.addition}
-        {self.legal}
-        {self.remarks}
-        """)
+    def text(self) -> Markup:
+        return Markup("").join((
+            self.debtor,
+            self.claim_of_creditors,
+            self.inventory,
+            self.registration_office,
+            self.addition,
+            self.legal,
+            self.remarks,
+        ))
 
 
 class KK05(KK):
 
     @property
-    def location_circulation_authority(self) -> str:
+    def location_circulation_authority(self) -> Markup:
         return self.p(
             self.get('content/locationCirculationAuthority'),
             "Angaben zur Auflage"
         )
 
     @property
-    def text(self) -> str:
-        return self.dedent(f"""
-        {self.debtor}
-        {self.location_circulation_authority}
-        {self.days_after_publication}
-        {self.entry_deadline}
-        {self.registration_office}
-        {self.legal}
-        {self.remarks}
-        """)
+    def text(self) -> Markup:
+        return Markup("").join((
+            self.debtor,
+            self.location_circulation_authority,
+            self.days_after_publication,
+            self.entry_deadline,
+            self.registration_office,
+            self.legal,
+            self.remarks,
+        ))
 
 
 class KK06(KK):
 
     @property
-    def proceeding_end_date(self) -> str:
+    def proceeding_end_date(self) -> Markup:
         return self.p(
             self.get('content/proceedingEndDate', parse),
             "Datum des Schlusses",
@@ -497,20 +503,20 @@ class KK06(KK):
         )
 
     @property
-    def text(self) -> str:
-        return self.dedent(f"""
-        {self.debtor}
-        {self.proceeding_end_date}
-        {self.addition}
-        {self.legal}
-        {self.remarks}
-        """)
+    def text(self) -> Markup:
+        return Markup("").join((
+            self.debtor,
+            self.proceeding_end_date,
+            self.addition,
+            self.legal,
+            self.remarks,
+        ))
 
 
 class KK07(KK):
 
     @property
-    def proceeding_revocation_date(self) -> str:
+    def proceeding_revocation_date(self) -> Markup:
         return self.p(
             self.get('content/proceedingRevocationDate', parse),
             "Datum des Widerrufs",
@@ -518,42 +524,42 @@ class KK07(KK):
         )
 
     @property
-    def text(self) -> str:
-        return self.dedent(f"""
-        {self.debtor}
-        {self.proceeding_revocation_date}
-        {self.legal}
-        {self.remarks}
-        """)
+    def text(self) -> Markup:
+        return Markup("").join((
+            self.debtor,
+            self.proceeding_revocation_date,
+            self.legal,
+            self.remarks,
+        ))
 
 
 class KK08(KK):
 
     @property
-    def auction(self) -> str:
+    def auction(self) -> Markup:
         value_date = self.get('content/auction/date', parse)
         value_time = self.get('content/auction/time', parse)
         value_location = self.get('content/auction/location')
         if not value_date:
-            return ""
+            return Markup("")
 
         value = f"{value_date:%d.%m.%Y}"
         if value_time:
             value = f"{value_date:%d.%m.%Y} um {value_time:%H:%M}"
         if value_location:
-            value = f"{value}<br>{value_location}"
+            value = Markup("{}<br>{}").format(value, value_location)
 
         return self.p(value, "Steigerung")
 
     @property
-    def auction_objects(self) -> str:
+    def auction_objects(self) -> Markup:
         return self.p(
             self.get('content/auctionObjects'),
             "Steigerungsobjekte"
         )
 
     @property
-    def entry_start(self) -> str:
+    def entry_start(self) -> Markup:
         return self.p(
             self.get('content/entryStart', parse),
             "Beginn der Frist",
@@ -561,32 +567,32 @@ class KK08(KK):
         )
 
     @property
-    def text(self) -> str:
-        return self.dedent(f"""
-        {self.debtor}
-        {self.auction}
-        {self.auction_objects}
-        {self.information_about_edition}
-        {self.entry_start}
-        {self.entry_deadline}
-        {self.registration_office}
-        {self.addition}
-        {self.legal}
-        {self.remarks}
-        """)
+    def text(self) -> Markup:
+        return Markup("").join((
+            self.debtor,
+            self.auction,
+            self.auction_objects,
+            self.information_about_edition,
+            self.entry_start,
+            self.entry_deadline,
+            self.registration_office,
+            self.addition,
+            self.legal,
+            self.remarks,
+        ))
 
 
 class KK09(KK):
 
     @property
-    def affected_land(self) -> str:
+    def affected_land(self) -> Markup:
         return self.p(
             self.get('content/affectedLand'),
             "Betroffenes Grundstück"
         )
 
     @property
-    def appeal(self) -> str:
+    def appeal(self) -> Markup:
         result = self.p(
             self.get('content/appeal/daysAfterPublication', int),
             "Klage- und Beschwerdefrist",
@@ -604,14 +610,14 @@ class KK09(KK):
         return result
 
     @property
-    def location_circulation_authority(self) -> str:
+    def location_circulation_authority(self) -> Markup:
         return self.p(
             self.get('content/locationCirculationAuthority'),
             "Weitere Angaben"
         )
 
     @property
-    def registration_office(self) -> str:
+    def registration_office(self) -> Markup:
         result = self.p(
             self.get('content/registrationOfficeComplain'),
             "Anmeldestelle für Klagen"
@@ -623,35 +629,35 @@ class KK09(KK):
         return result
 
     @property
-    def text(self) -> str:
-        return self.dedent(f"""
-        {self.debtor}
-        {self.affected_land}
-        {self.location_circulation_authority}
-        {self.information_about_edition}
-        {self.days_after_publication}
-        {self.entry_deadline}
-        {self.appeal}
-        {self.registration_office}
-        {self.legal}
-        {self.remarks}
-        """)
+    def text(self) -> Markup:
+        return Markup("").join((
+            self.debtor,
+            self.affected_land,
+            self.location_circulation_authority,
+            self.information_about_edition,
+            self.days_after_publication,
+            self.entry_deadline,
+            self.appeal,
+            self.registration_office,
+            self.legal,
+            self.remarks,
+        ))
 
 
 class KK10(KK):
 
     @property
     def title(self) -> str:
-        return self.get('content/title') or self.get('meta/title/de')
+        return self.get_line('content/title') or self.get_line('meta/title/de')
 
     @property
-    def publication(self) -> str:
+    def publication(self) -> Markup:
         return self.p(self.get('content/publication'))
 
     @property
-    def text(self) -> str:
-        return self.dedent(f"""
-        {self.publication}
-        {self.legal}
-        {self.remarks}
-        """)
+    def text(self) -> Markup:
+        return Markup("").join((
+            self.publication,
+            self.legal,
+            self.remarks,
+        ))

--- a/src/onegov/notice/collections.py
+++ b/src/onegov/notice/collections.py
@@ -17,13 +17,19 @@ from sqlalchemy_utils.functions import escape_like
 from typing import Any, Literal, TypeVar, TYPE_CHECKING
 if TYPE_CHECKING:
     from collections.abc import Collection
+    from markupsafe import Markup
     from onegov.notice.models import NoticeState
     from sqlalchemy.orm import Query, Session
     from sqlalchemy.sql import ColumnElement
-    from typing_extensions import Self
+    from typing_extensions import Self, TypeAlias
     from uuid import UUID
 
-    _StrColumnLike = ColumnElement[str] | ColumnElement[str | None]
+    _StrColumnLike: TypeAlias = (
+        ColumnElement[str]
+        | ColumnElement[str | None]
+        | ColumnElement[Markup]
+        | ColumnElement[Markup | None]
+    )
 
 
 _N = TypeVar('_N', bound=OfficialNotice)

--- a/src/onegov/notice/models.py
+++ b/src/onegov/notice/models.py
@@ -1,6 +1,7 @@
 from onegov.core.orm import Base
 from onegov.core.orm.mixins import ContentMixin
 from onegov.core.orm.mixins import TimestampMixin
+from onegov.core.orm.types import MarkupText
 from onegov.core.orm.types import UTCDateTime
 from onegov.core.orm.types import UUID
 from onegov.user import User
@@ -22,6 +23,7 @@ if TYPE_CHECKING:
     import uuid
     from collections.abc import Iterable
     from datetime import datetime
+    from markupsafe import Markup
 
 NoticeState = Literal[
     'drafted',
@@ -101,7 +103,7 @@ class OfficialNotice(Base, ContentMixin, TimestampMixin):
     title: 'Column[str]' = Column(Text, nullable=False)
 
     #: The text of the notice.
-    text: 'Column[str | None]' = Column(Text, nullable=True)
+    text: 'Column[Markup | None]' = Column(MarkupText, nullable=True)
 
     #: The author of the notice.
     author_name: 'Column[str | None]' = Column(Text, nullable=True)

--- a/src/onegov/quill/fields.py
+++ b/src/onegov/quill/fields.py
@@ -1,4 +1,5 @@
 from bleach.sanitizer import Cleaner
+from markupsafe import Markup
 from onegov.quill.widgets import QuillInput
 from onegov.quill.widgets import TAGS
 from wtforms.fields import TextAreaField
@@ -30,7 +31,7 @@ class QuillField(TextAreaField):
         else:
             tags = list(set(tags) & set(TAGS))
 
-        super(TextAreaField, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
         self.widget = QuillInput(tags=tags)
 
@@ -46,3 +47,16 @@ class QuillField(TextAreaField):
 
     def pre_validate(self, form: 'BaseForm') -> None:
         self.data = self.cleaner.clean(self.data or '')
+
+
+class QuillMarkupField(QuillField):
+    """ Same as QuillField, except it stores the data as `markupsafe.Markup`
+
+    This should become the default implementation eventually.
+
+    """
+
+    data: Markup | None
+
+    def pre_validate(self, form: 'BaseForm') -> None:
+        self.data = Markup(self.cleaner.clean(self.data or ''))  # noqa: MS001

--- a/tests/onegov/gazette/test_utils.py
+++ b/tests/onegov/gazette/test_utils.py
@@ -272,7 +272,11 @@ def test_sogc_converter_KK02(gazette_app, xml):
         "<p><strong>Ablauf der Frist</strong><br>02.08.2018</p>"
         "<p><strong>Kommentar zur Frist</strong><br>test_commentaire_delai</p>"
         "<p><strong>Anmeldestelle</strong><br>"
-        "Office des poursuites et faillites de l'Etat Genève - Faillites<br>"
+        # NOTE: MarkupSafe eagerly escapes `'` here, which is fine, but
+        #       not strictly necessary. If this comes back to haunt us
+        #       we may need to change how we escape things slightly
+        "Office des poursuites et faillites de l&#39;Etat Genève - Faillites"
+        "<br>"
         "Rue du Stand 46<br>1204 Genève</p>"
         "<p><strong>Rechtliche Hinweise und Fristen</strong><br>"
         "Notification selon LP 231, 232; ORFI, du 23 avril 1920, "

--- a/tests/onegov/notice/test_collections.py
+++ b/tests/onegov/notice/test_collections.py
@@ -1,8 +1,8 @@
-from datetime import datetime
-from datetime import timezone
-
 import pytest
 
+from datetime import datetime
+from datetime import timezone
+from markupsafe import Markup
 from onegov.notice import OfficialNoticeCollection
 from onegov.user import UserCollection
 from onegov.user import UserGroupCollection
@@ -15,7 +15,7 @@ def test_notice_collection(session):
 
     notice_1 = notices.add(
         title='Important Announcement',
-        text='<em>Important</em> things happened!',
+        text=Markup('<em>Important</em> things happened!'),
         category='important',
         organization='onegov'
     )
@@ -33,7 +33,7 @@ def test_notice_collection(session):
 
     notice_2 = notices.add(
         title='Important Announcement',
-        text='<em>Important</em> things happened!'
+        text=Markup('<em>Important</em> things happened!')
     )
     notice_2.submit()
 

--- a/tests/onegov/notice/test_models.py
+++ b/tests/onegov/notice/test_models.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 from datetime import timezone
 from freezegun import freeze_time
+from markupsafe import Markup
 from onegov.notice import OfficialNotice
 from onegov.user import UserCollection
 from onegov.user import UserGroupCollection
@@ -11,7 +12,7 @@ def test_notice_create(session):
     notice = OfficialNotice()
     notice.state = 'drafted'
     notice.title = 'Very Important Official Announcement'
-    notice.text = '<em>Important</em> things happened!'
+    notice.text = Markup('<em>Important</em> things happened!')
     notice.author_name = 'Renward Cysat'
     notice.author_place = 'Wynmärkt'
     notice.author_date = datetime(1545, 1, 1, 0, 0, tzinfo=timezone.utc)

--- a/tests/onegov/quill/test_fields.py
+++ b/tests/onegov/quill/test_fields.py
@@ -1,5 +1,7 @@
+from markupsafe import Markup
 from onegov.form import Form
 from onegov.quill.fields import QuillField
+from onegov.quill.fields import QuillMarkupField
 
 
 def test_field_clean():
@@ -115,5 +117,123 @@ def test_field_clean():
     field.data = test_data
     assert field.validate(form)
     assert field.data.replace(' ', '').replace('\n', '') == (
+        'ABCY<p>DEF<br>XXXX</p>123123'
+    )
+
+
+def test_field_clean_markup():
+    form = Form()
+
+    field = QuillMarkupField(tags=[])
+    field = field.bind(form, 'html')
+    field.data = None
+    assert field.validate(form)
+
+    test_data = """
+        <h2>
+            <span class="">A<strong>B</strong><b>C</b></span>
+        </h2>
+        <blockquote>Y</blockquote>
+        <p>
+            <span class="md-line md-end-block">
+                <span class=""><em>D</em><i>E</i></span>
+                <a href="xx" target="_blank">F</a>
+                <br>
+            </span>
+            <span class="md-line md-end-block">
+                <script>XXXX</script>
+            </span>
+        </p>
+            <ul>
+                <li>1</li>
+                <li>2</li>
+                <li>3</li>
+            </ul>
+            <ol>
+                <li>1</li>
+                <li>2</li>
+                <li>3</li>
+            </ol>
+    """
+
+    field = QuillMarkupField(tags=[])
+    field = field.bind(form, 'html')
+    field.data = test_data
+    assert field.validate(form)
+    assert isinstance(field.data, Markup)
+    assert field.data.replace(' ', '').replace('\n', '') == Markup(
+        'ABCY<p>DEF<br>XXXX</p>123123'
+    )
+
+    field = QuillMarkupField(tags=['strong'])
+    field = field.bind(form, 'html')
+    field.data = test_data
+    assert field.validate(form)
+    assert field.data.replace(' ', '').replace('\n', '') == Markup(
+        'A<strong>B</strong>CY<p>DEF<br>XXXX</p>123123'
+    )
+
+    field = QuillMarkupField(tags=['em', 'ol', 'ul'])
+    field = field.bind(form, 'html')
+    field.data = test_data
+    assert field.validate(form)
+    assert field.data.replace(' ', '').replace('\n', '') == Markup(
+        'ABCY<p><em>D</em>EF<br>XXXX</p>'
+        '<ul><li>1</li><li>2</li><li>3</li></ul>'
+        '<ol><li>1</li><li>2</li><li>3</li></ol>'
+    )
+
+    field = QuillMarkupField(tags=['ol'])
+    field = field.bind(form, 'html')
+    field.data = test_data
+    assert field.validate(form)
+    assert field.data.replace(' ', '').replace('\n', '') == Markup(
+        'ABCY<p>DEF<br>XXXX</p>'
+        '<li>1</li><li>2</li><li>3</li>'
+        '<ol><li>1</li><li>2</li><li>3</li></ol>'
+    )
+
+    field = QuillMarkupField(tags=['strong', 'ul'])
+    field = field.bind(form, 'html')
+    field.data = test_data
+    assert field.validate(form)
+    assert field.data.replace(' ', '').replace('\n', '') == Markup(
+        'A<strong>B</strong>CY<p>DEF<br>XXXX</p>'
+        '<ul><li>1</li><li>2</li><li>3</li></ul>'
+        '<li>1</li><li>2</li><li>3</li>'
+    )
+
+    field = QuillMarkupField(tags=['blockquote'])
+    field = field.bind(form, 'html')
+    field.data = test_data
+    assert field.validate(form)
+    assert field.data.replace(' ', '').replace('\n', '') == Markup(
+        'ABC<blockquote>Y</blockquote><p>DEF<br>XXXX</p>123123'
+    )
+
+    field = QuillMarkupField(tags=['h2'])
+    field = field.bind(form, 'html')
+    field.data = test_data
+    assert field.validate(form)
+    assert field.data.replace(' ', '').replace('\n', '') == Markup(
+        '<h2>ABC</h2>Y<p>DEF<br>XXXX</p>123123'
+    )
+
+    field = QuillMarkupField()
+    field = field.bind(form, 'html')
+    field.data = test_data
+    assert field.validate(form)
+    assert field.data.replace(' ', '').replace('\n', '') == Markup(
+        '<h2>A<strong>B</strong>C</h2><blockquote>Y</blockquote>'
+        '<p><em>D</em>E<ahref="xx">F</a><br>XXXX</p>'
+        '<ul><li>1</li><li>2</li><li>3</li></ul>'
+        '<ol><li>1</li><li>2</li><li>3</li></ol>'
+    )
+
+    field = QuillMarkupField(tags=['i', 'b'])
+    field = field.bind(form, 'html')
+    field.data = test_data
+    assert field.validate(form)
+    assert field.data.replace(' ', '').replace('\n', '') == Markup(
         'ABCY<p>DEF<br>XXXX</p>123123'
     )


### PR DESCRIPTION
## Commit message

Gazette: Removes uses of structure keyword in templates

This also adds `MarkupText` as a new column type

TYPE: Bugfix
LINK: OGC-1715

## Checklist

- [x] I have performed a self-review of my code
