### PR TITLE
Moves user default active filter from path to navigation

### DIFF
--- a/src/onegov/org/custom.py
+++ b/src/onegov/org/custom.py
@@ -119,7 +119,9 @@ def get_global_tools(request: 'OrgRequest') -> 'Iterator[Link | LinkGroup]':
 
             links.append(
                 Link(
-                    _("Users"), request.class_link(UserCollection),
+                    _("Users"), request.class_link(
+                        UserCollection,
+                        variables={'active': [True]}),
                     attrs={'class': 'user'}
                 )
             )

--- a/src/onegov/org/path.py
+++ b/src/onegov/org/path.py
@@ -141,7 +141,7 @@ def get_users(
 ) -> UserCollection:
     return UserCollection(
         app.session(),
-        active=active or {True}, role=role, tag=tag, provider=provider,
+        active=active, role=role, tag=tag, provider=provider,
         source=source
     )
 

--- a/tests/onegov/agency/test_app.py
+++ b/tests/onegov/agency/test_app.py
@@ -17,7 +17,7 @@ class DummyRequest():
     path = ''
     url = ''
 
-    def class_link(self, cls, name=''):
+    def class_link(self, cls, name='', variables: dict = None):
         return f'{cls.__name__}/{name}'
 
     def link(self, target, name=None):

--- a/tests/onegov/org/test_views_user.py
+++ b/tests/onegov/org/test_views_user.py
@@ -208,7 +208,7 @@ def test_filters(client):
     add_user('emilia@example.org', 'admin', 'active')
     add_user('frank@example.org', 'admin', 'inactive')
 
-    users = client.get('/usermanagement')
+    users = client.get('/').click('Benutzer', index=1)
     # ensure 'active' filter is selected by default
     assert users.pyquery('.filter-active .active a').text() == 'Aktiv'
     assert 'arno' in users
@@ -240,6 +240,7 @@ def test_filters(client):
 
     # show 'active' and 'inactive' 'member' users
     users = client.get('/usermanagement')
+    users = users.click('Aktiv', index=1)
     users = users.click('Inaktiv')
     users = users.click('Editor')
     assert 'arno' not in users


### PR DESCRIPTION
User Admin: Show 'active' users by default 

Move implementation from path to navigation

TYPE: Feature
LINK: ogc-1710

