### PR TITLE
Only check validity of prebooking dates, if there is a prebooking phase

### DIFF
--- a/src/onegov/activity/collections/period.py
+++ b/src/onegov/activity/collections/period.py
@@ -16,7 +16,7 @@ class PeriodCollection(GenericCollection[Period]):
     def add(  # type:ignore[override]
         self,
         title: str,
-        prebooking: tuple['date', 'date'],
+        prebooking: tuple['date | None', 'date | None'],
         booking: tuple['date', 'date'],
         execution: tuple['date', 'date'],
         active: bool = False,

--- a/src/onegov/feriennet/templates/period_form.pt
+++ b/src/onegov/feriennet/templates/period_form.pt
@@ -18,7 +18,7 @@
         </tal:b>
         <div class="row">
             <div class="small-12 medium-7 large-5 columns">
-                <div metal:use-macro="layout.macros['form']" />
+                <div metal:use-macro="layout.macros['form']" tal:define="form_id 'main-form'"/>
             </div>
         </div>
     </tal:b>

--- a/src/onegov/feriennet/views/period.py
+++ b/src/onegov/feriennet/views/period.py
@@ -181,7 +181,8 @@ def new_period(
         assert form.title.data is not None
         # NOTE: We can't put these assertions into the properties, because
         #       they need to be optional for the tests to pass
-        assert is_date_range(form.prebooking)
+        if form.prebooking != (None, None):
+            assert is_date_range(form.prebooking)
         assert is_date_range(form.booking)
         assert is_date_range(form.execution)
         period = self.add(


### PR DESCRIPTION
Please fill in the commit message below and work through the checklist. You can delete parts that are not needed, e.g. the optional description, the link to a ticket or irrelevant options of the checklist.

## Commit message

Feriennet: Fix bug when there is no prebooking phase

TYPE: Bugfix
LINK: PRO-1296