### PR TITLE
Bugfix/pro 1295 support 26 character reference in booking text for pofi

### DIFF
--- a/src/onegov/activity/iso20022.py
+++ b/src/onegov/activity/iso20022.py
@@ -129,17 +129,37 @@ def transaction_entries(root: 'etree._Element') -> 'Iterator[etree._Element]':
 
 
 def get_esr(booking_text: str) -> str | None:
-    """ Extracts the number from the given text.
+
+    """
+    Extracts the QR-bill reference number from the given text.
+    QR-bill reference numbers can be 26 or 27 characters long.
+    The 26-character version doesn't include the check digit.
 
     For example:
 
     input: 'Gutschrift QRR: 26 99029 05678 18860 27295 3705'
     output: '26990290567818860272953705'
     """
-    pattern = r'\d{2}\s*\d{5}\s*\d{5}\s*\d{5}\s*\d{5}\s*\d{4}'
-    match = re.search(pattern, booking_text)
+
+    # Pattern for 26-digit ESR numbers
+    pattern_26 = \
+        r'\b(\d{2}[\s]?\d{5}[\s]?\d{5}[\s]?\d{5}[\s]?\d{5}[\s]?\d{4})\b'
+
+    # Pattern for 27-digit ESR numbers
+    pattern_27 = \
+        r'\b(\d{2}[\s]?\d{5}[\s]?\d{5}[\s]?\d{5}[\s]?\d{5}[\s]?\d{5})\b'
+
+    # Try matching 27-digit pattern first
+    match = re.search(pattern_27, booking_text)
     if match:
-        return re.sub(r'\s', '', match.group())
+        return re.sub(r'\s', '', match.group(1))
+
+    # If no 27-digit match, try 26-digit pattern
+    match = re.search(pattern_26, booking_text)
+    if match:
+        return re.sub(r'\s', '', match.group(1))
+
+    # If no match found, return None
     return None
 
 

--- a/src/onegov/activity/iso20022.py
+++ b/src/onegov/activity/iso20022.py
@@ -1,5 +1,5 @@
 import re
-import stdnum.ch.esr as esr
+import stdnum.ch.esr as esr  # type: ignore[import-untyped]
 
 from collections import defaultdict
 from functools import cached_property

--- a/src/onegov/activity/iso20022.py
+++ b/src/onegov/activity/iso20022.py
@@ -169,7 +169,8 @@ def get_esr(booking_text: str) -> str | None:
         try:
             esr.validate(esr_ref)
         except esr.InvalidChecksum:
-            check = esr.calc_check_digit(esr_ref[:26])
+            esr_ref = esr_ref[:26]
+            check = esr.calc_check_digit(esr_ref)
             return format_esr(esr_ref + check)
 
     # If no match found, return None

--- a/tests/onegov/activity/fixtures/CAMT053_280324-1.xml
+++ b/tests/onegov/activity/fixtures/CAMT053_280324-1.xml
@@ -138,7 +138,8 @@
                         <CdtDbtInd>CRDT</CdtDbtInd>
                     </Btch>
                 </NtryDtls>
-                <AddtlNtryInf>Gutschrift QRR 094044869197312929630369253</AddtlNtryInf>
+                <AddtlNtryInf>Gutschrift QRR
+                    094044869197312929630369254</AddtlNtryInf>
             </Ntry>
             <Ntry>
                 <Amt Ccy="CHF">168</Amt>
@@ -167,7 +168,7 @@
                         <CdtDbtInd>CRDT</CdtDbtInd>
                     </Btch>
                 </NtryDtls>
-                <AddtlNtryInf>Gutschrift QRR 416717412098789269137325217</AddtlNtryInf>
+                <AddtlNtryInf>Gutschrift QRR 416717412098789269137325213</AddtlNtryInf>
             </Ntry>
         </Stmt>
     </BkToCstmrStmt>

--- a/tests/onegov/activity/test_iso20022.py
+++ b/tests/onegov/activity/test_iso20022.py
@@ -93,18 +93,20 @@ def test_extract_transactions(postfinance_xml):
     ])
 
 
+# tschupre extend?
 def test_extract_transactions_qr(postfinance_qr_xml):
+    # TODO extend xml file with short esr
     transactions = extract_transactions(postfinance_qr_xml, 'feriennet-v1')
 
     # Test reference and tid since this is the only difference to the non-qr
     # entries
     t = next(transactions)
-    assert t.reference == '094044869197312929630369253'
-    assert t.tid == '094044869197312929630369253'
+    assert t.reference == '094044869197312929630369254'
+    assert t.tid == '094044869197312929630369254'
 
     t = next(transactions)
-    assert t.reference == '416717412098789269137325217'
-    assert t.tid == '416717412098789269137325217'
+    assert t.reference == '416717412098789269137325213'
+    assert t.tid == '416717412098789269137325213'
 
 
 def test_unique_transaction_ids(postfinance_xml):

--- a/tests/onegov/activity/test_utils.py
+++ b/tests/onegov/activity/test_utils.py
@@ -31,11 +31,11 @@ def test_extract_municipality():
 
 
 def test_get_esr():
-    # Test case 1: Valid ESR number
+    # Test case 1: Valid 26 character ESR
     input_string = (
         'Gutschrift QRR Instant-Zahlung: 26 99029 05678 18860 27295 3705'
     )
-    expected = '269902905678188602729537054'  # including checksum
+    expected = '269902905678188602729537054'
     assert get_esr(input_string) == expected
 
     # Test case 2: No valid ESR number
@@ -43,36 +43,44 @@ def test_get_esr():
     expected = None
     assert get_esr(input_string) == expected
 
-    # Test case 3: Partial match
-    input_string = 'Partial match: 26 99029 05678 18860'
-    expected = None
-    assert get_esr(input_string) == expected
+    # Test case 3: ESR number with any length
+    input_string = 'Any length: 00 99029 05678 18860 27295 3705'
+    assert get_esr(input_string) == '009902905678188602729537054'
+
+    input_string = 'Any length: 0000 3705'
+    assert get_esr(input_string) == '000000000000000000000037056'
+
+    input_string = 'Any length: 37056'
+    assert get_esr(input_string) == '000000000000000000000037056'
+
+    # matches the first 27 digits
+    input_string = '12345 23456 34567 45678 56789 67  890'
+    assert get_esr(input_string) == '123452345634567456785678969'
+
+    # test case 4: ESR of 27 character
+    input_string = 'max length: 12 34567 89012 34567 89012 34567'
+    assert get_esr(input_string) == '123456789012345678901234567'
 
 
 def test_get_esr_with_different_prefix():
     input_string = 'Different prefix: 12 34567 89012 34567 89012 3456'
-    assert (get_esr(input_string)
-            == '123456789012345678901234567')  # including checksum
+    assert get_esr(input_string) == '123456789012345678901234567'
 
     input_string = 'Different prefix: 12 34567 89012 34567 89012 34567'
-    assert (get_esr(input_string)
-            == '123456789012345678901234567')
+    assert get_esr(input_string) == '123456789012345678901234567'
 
 
 def test_get_esr_with_extra_spaces():
     # Test if string contains more whitespace
     input_string = 'Extra spaces:  26  99029  05678  18860  27295  3705 '
-    assert (get_esr(input_string)
-            == '269902905678188602729537054')  # including checksum
+    assert get_esr(input_string) == '269902905678188602729537054'
 
     input_string = 'Extra newlines:  27  98029   05678  18861    27294  37065 '
-    assert (get_esr(input_string)
-            == '279802905678188612729437065')
+    assert get_esr(input_string) == '279802905678188612729437068'
 
     input_string = ('Instant-Zahlung: 26 99029 05678                      '
                     '18860 27295 3705                  ')
-    assert (get_esr(input_string)
-            == '269902905678188602729537054')  # including checksum
+    assert get_esr(input_string) == '269902905678188602729537054'
 
 
 def test_get_esr_with_extra_newlines():
@@ -82,17 +90,15 @@ def test_get_esr_with_extra_newlines():
                 '
     """
     input_string = 'Extra newlines:  26 98029 05678\n18861 27294 3706\n'
-    assert (get_esr(input_string)
-            == '269802905678188612729437061')  # including checksum
+    assert get_esr(input_string) == '269802905678188612729437061'
 
-    input_string = 'Extra newlines:  27 98029 05678\n18861 27294 37065\n'
-    assert get_esr(input_string) == '279802905678188612729437065'
+    input_string = 'Extra newlines:  27 98029 05678\n18861 27294 37068\n'
+    assert get_esr(input_string) == '279802905678188612729437068'
 
 
 def test_get_esr_no_spaces():
     input_string = 'Gutschrift QRR:  26980290567818861272943706'
-    assert (get_esr(input_string)
-            == '269802905678188612729437061')  # including checksum
+    assert get_esr(input_string) == '269802905678188612729437061'
 
     input_string = 'Gutschrift QRR:  279802905678188612729437065'
-    assert get_esr(input_string) == '279802905678188612729437065'
+    assert get_esr(input_string) == '279802905678188612729437068'

--- a/tests/onegov/activity/test_utils.py
+++ b/tests/onegov/activity/test_utils.py
@@ -1,3 +1,4 @@
+from onegov.activity.iso20022 import get_esr
 from onegov.activity.utils import merge_ranges
 from onegov.activity.utils import extract_municipality
 
@@ -27,3 +28,33 @@ def test_extract_municipality():
 
     assert extract_municipality("0123 invalid plz") is None
     assert extract_municipality("4653 Obergösgen") == (4653, "Obergösgen")
+
+
+def test_get_esr():
+    # Test case 1: Valid ESR number
+    input_string = (
+        'Gutschrift QRR Instant-Zahlung: 26 99029 05678 18860 27295 3705'
+    )
+    expected = '26990290567818860272953705'
+    assert get_esr(input_string) == expected
+
+    # Test case 2: No valid ESR number
+    input_string = "This string doesn't contain a valid ESR number"
+    expected = None
+    assert get_esr(input_string) == expected
+
+    # Test case 3: Partial match
+    input_string = 'Partial match: 26 99029 05678 18860'
+    expected = None
+    assert get_esr(input_string) == expected
+
+
+def test_get_esr_with_different_prefix():
+    input_string = 'Different prefix: 12 34567 89012 34567 89012 3456'
+    assert get_esr(input_string) == '12345678901234567890123456'
+
+
+def test_get_esr_with_extra_spaces():
+    # Test if string contains more whitesapce
+    input_string = 'Extra spaces:  26  99029  05678  18860  27295  3705 '
+    assert get_esr(input_string) == '26990290567818860272953705'

--- a/tests/onegov/activity/test_utils.py
+++ b/tests/onegov/activity/test_utils.py
@@ -35,7 +35,7 @@ def test_get_esr():
     input_string = (
         'Gutschrift QRR Instant-Zahlung: 26 99029 05678 18860 27295 3705'
     )
-    expected = '26990290567818860272953705'
+    expected = '269902905678188602729537054'  # including checksum
     assert get_esr(input_string) == expected
 
     # Test case 2: No valid ESR number
@@ -51,10 +51,48 @@ def test_get_esr():
 
 def test_get_esr_with_different_prefix():
     input_string = 'Different prefix: 12 34567 89012 34567 89012 3456'
-    assert get_esr(input_string) == '12345678901234567890123456'
+    assert (get_esr(input_string)
+            == '123456789012345678901234567')  # including checksum
+
+    input_string = 'Different prefix: 12 34567 89012 34567 89012 34567'
+    assert (get_esr(input_string)
+            == '123456789012345678901234567')
 
 
 def test_get_esr_with_extra_spaces():
-    # Test if string contains more whitesapce
+    # Test if string contains more whitespace
     input_string = 'Extra spaces:  26  99029  05678  18860  27295  3705 '
-    assert get_esr(input_string) == '26990290567818860272953705'
+    assert (get_esr(input_string)
+            == '269902905678188602729537054')  # including checksum
+
+    input_string = 'Extra newlines:  27  98029   05678  18861    27294  37065 '
+    assert (get_esr(input_string)
+            == '279802905678188612729437065')
+
+    input_string = ('Instant-Zahlung: 26 99029 05678                      '
+                    '18860 27295 3705                  ')
+    assert (get_esr(input_string)
+            == '269902905678188602729537054')  # including checksum
+
+
+def test_get_esr_with_extra_newlines():
+    """ Example with newline found in slip (number changed):
+    'Gutschrift QRR Instant-Zahlung: 26 99029 05678
+                    18860 27295 3705
+                '
+    """
+    input_string = 'Extra newlines:  26 98029 05678\n18861 27294 3706\n'
+    assert (get_esr(input_string)
+            == '269802905678188612729437061')  # including checksum
+
+    input_string = 'Extra newlines:  27 98029 05678\n18861 27294 37065\n'
+    assert get_esr(input_string) == '279802905678188612729437065'
+
+
+def test_get_esr_no_spaces():
+    input_string = 'Gutschrift QRR:  26980290567818861272943706'
+    assert (get_esr(input_string)
+            == '269802905678188612729437061')  # including checksum
+
+    input_string = 'Gutschrift QRR:  279802905678188612729437065'
+    assert get_esr(input_string) == '279802905678188612729437065'


### PR DESCRIPTION
Feriennet: Import bank statements now supports 27 character reference number in booking text (POFI)

Also we do not break the import if one entry fails

TYPE: Bugfix
LINK: ogc-1295

Open item:
Add detailed tests later