### PR TITLE
Feature/ogc 1760 shpol adjust accrediation form v2

### DIFF
--- a/src/onegov/org/app.py
+++ b/src/onegov/org/app.py
@@ -362,6 +362,21 @@ class OrgApp(Framework, LibresIntegration, ElasticsearchApp, MapboxApp,
             return yaml.safe_load(f).get('event_tags', None)
 
     @property
+    def custom_texts(self) -> dict[str, str] | None:
+        return self.cache.get_or_create(
+            'custom_texts', self.load_custom_texts
+        )
+
+    def load_custom_texts(self) -> dict[str, str] | None:
+        fs = self.filestorage
+        assert fs is not None
+        if not fs.exists('customtexts.yml'):
+            return {}
+
+        with fs.open('customtexts.yml', 'r') as f:
+            return yaml.safe_load(f).get('custom texts', {})
+
+    @property
     def allowed_iframe_domains(self) -> list[str]:
         return self.cache.get_or_create(
             'allowed_iframe_domains', self.load_allowed_iframe_domains

--- a/src/onegov/org/app.py
+++ b/src/onegov/org/app.py
@@ -372,6 +372,17 @@ class OrgApp(Framework, LibresIntegration, ElasticsearchApp, MapboxApp,
         Customer specific texts are specified in `puppet` repo, see loxo
         https://gitea.seantis.ch/operations/puppet/src/branch/master/nodes/loxo.seantis.ch.yaml#L183,193
 
+        Remember to create customtexts.yml in your local dev setup
+        `/usr/local/var/onegov/files/<org>/customtexts.yml`
+
+        Example customtexts.yml:
+        ```yaml
+        custom texts:
+          Custom admission course agreement: Ich erkläre mich bereit, den
+          Zulassungskurs des Obergerichts des Kantons Zürich zu absolvieren
+          (Kostenbeteiligung Dolmetscher:in CHF 300).
+        ```
+
         """
         fs = self.filestorage
         assert fs is not None

--- a/src/onegov/org/app.py
+++ b/src/onegov/org/app.py
@@ -368,6 +368,11 @@ class OrgApp(Framework, LibresIntegration, ElasticsearchApp, MapboxApp,
         )
 
     def load_custom_texts(self) -> dict[str, str] | None:
+        """
+        Customer specific texts are specified in `puppet` repo, see loxo
+        https://gitea.seantis.ch/operations/puppet/src/branch/master/nodes/loxo.seantis.ch.yaml#L183,193
+
+        """
         fs = self.filestorage
         assert fs is not None
         if not fs.exists('customtexts.yml'):

--- a/src/onegov/translator_directory/forms/accreditation.py
+++ b/src/onegov/translator_directory/forms/accreditation.py
@@ -329,10 +329,7 @@ class RequestAccreditationForm(Form, DrivingDistanceMixin):
     )
 
     admission_course_agreement = BooleanField(
-        label=_(
-            "I agree to attend the admission course of the high court of the "
-            "Canton of Zürich at my own expense CHF 1'100.00."
-        ),
+        label='',  # will be set in on_request
         fieldset=_('Admission course'),
         default=False,
         depends_on=('admission_course_completed', '!y'),
@@ -629,6 +626,10 @@ class RequestAccreditationForm(Form, DrivingDistanceMixin):
 
         self.hide(self.drive_distance)
 
+        # populate custom texts
+        self.admission_course_agreement.label.text = (
+            self.get_custom_text('Custom admission course agreement'))
+
     def get_translator_data(self) -> dict[str, Any]:
         data = self.get_useful_data()
         result = {
@@ -721,6 +722,15 @@ class RequestAccreditationForm(Form, DrivingDistanceMixin):
                 'remarks',
             )
         }
+
+    def get_custom_text(self, key: str) -> str:
+        custom_texts = self.request.app.custom_texts
+
+        if not custom_texts:
+            return 'No custom texts found'
+
+        return custom_texts.get(
+            key, f'No custom text found for \'{key}\'')
 
 
 class GrantAccreditationForm(Form):

--- a/src/onegov/translator_directory/locale/de_CH/LC_MESSAGES/onegov.translator_directory.po
+++ b/src/onegov/translator_directory/locale/de_CH/LC_MESSAGES/onegov.translator_directory.po
@@ -308,13 +308,6 @@ msgid "Admission course"
 msgstr "Zulassungskurs"
 
 msgid ""
-"I agree to attend the admission course of the high court of the Canton of "
-"Zürich at my own expense CHF 1'100.00."
-msgstr ""
-"Ich erkläre mich bereit, den Zulassungskurs des Obergerichts des Kantons "
-"Zürich auf eigenen Kosten CHF 1'100.00 zu absolvieren."
-
-msgid ""
 "If a German C2 certificate is required, an additional CHF 100.00 will be "
 "charged. The admission course is a basic requirement for an application. "
 "Administration is carried out by the Translation Coordination Office of the "

--- a/src/onegov/translator_directory/models/ticket.py
+++ b/src/onegov/translator_directory/models/ticket.py
@@ -18,7 +18,8 @@ from onegov.translator_directory.models.mutation import TranslatorMutation
 from onegov.translator_directory.models.translator import Translator
 
 
-from typing import Any, TYPE_CHECKING
+from typing import Any, TYPE_CHECKING, Callable
+
 if TYPE_CHECKING:
     from onegov.org.request import OrgRequest
     from onegov.translator_directory.request import TranslatorAppRequest
@@ -209,6 +210,18 @@ class AccreditationHandler(Handler):
     def group(self) -> str:
         return _('Accreditation')
 
+    def get_custom_text(self, request: 'OrgRequest') -> Callable[[str], str]:
+
+        def wrapper(text_key: str) -> str:
+            custom_texts = request.app.custom_texts
+            if not custom_texts:
+                return 'No custom texts found'
+
+            return custom_texts.get(
+                text_key, f'No custom text found for \'{text_key}\'')
+
+        return wrapper
+
     def get_summary(
         self,
         request: 'TranslatorAppRequest'  # type:ignore[override]
@@ -220,7 +233,8 @@ class AccreditationHandler(Handler):
             {
                 'translator': self.translator,
                 'ticket_data': self.data['handler_data'],
-                'layout': layout
+                'layout': layout,
+                'get_custom_text': self.get_custom_text(request)
             }
         )
 

--- a/src/onegov/translator_directory/templates/macros.pt
+++ b/src/onegov/translator_directory/templates/macros.pt
@@ -210,7 +210,7 @@
             <dt i18n:translate>Admission course of the high court of the Canton of Zurich available</dt>
             <dd class="admission-course-completed">${layout.format_boolean(ticket_data.get('admission_course_completed'))}</dd>
 
-            <dt i18n:translate>I agree to attend the admission course of the high court of the Canton of Zürich at my own expense CHF 1'100.00.</dt>
+            <dt>${get_custom_text('Custom admission course agreement')}</dt>
             <dd class="admission-course-agreement">${layout.format_boolean(ticket_data.get('admission_course_agreement'))}</dd>
         </dl>
 


### PR DESCRIPTION
Translator Directory: Enable custom texts per tenant

TYPE: Feature
LINK: ogc-1760

Link to change on `puppet` repo: https://gitea.seantis.ch/operations/puppet/commit/024ec4c4be9b1c831465a890347cccf8f7938c22


## Checklist

- [x] I have performed a self-review of my code
- [x] I considered adding a reviewer
- [x] I have updated the PO files
- [x] I have tested my code thoroughly by hand
