### PR TITLE
Display people images in sidebar

### DIFF
--- a/src/onegov/org/templates/macros.pt
+++ b/src/onegov/org/templates/macros.pt
@@ -561,7 +561,7 @@
                             </div>
                             <div class="with-lead" style="margin-top: .9rem">
                                 <a href="${request.link(person)}" class="list-title">
-                                    <span tal:condition="western_name_order">${person.first_name} ${person.last_name}</span>
+                                    <b tal:condition="western_name_order">${person.first_name} ${person.last_name}</b>
                                     <span tal:condition="not western_name_order">${person.title}</span>
                                 </a>
                                 <a href="${request.link(person)}">

--- a/src/onegov/town6/templates/macros.pt
+++ b/src/onegov/town6/templates/macros.pt
@@ -710,13 +710,24 @@
                 <h3 i18n:translate>People</h3>
                 <ul class="more-list" data-sortable data-sortable-url="${layout.move_person_url_template}">
                     <li tal:repeat="person people" data-sortable-id="${request.is_manager and person.id}">
-                        <a class="list-link" href="${request.link(person)}">
-                            <span tal:condition="western_name_order" class="list-title">${person.first_name} ${person.last_name}</span>
-                            <span tal:condition="not western_name_order" class="list-title">${person.title}</span>
-                        </a>
-                        <a href="${request.link(person)}">
-                            <p class="list-lead preview">${person.context_specific_function}</p>
-                        </a>
+                        <div class="person-card person-list-card">
+                            <div tal:define="url (person.picture_url and layout.thumbnail_url(person.picture_url))">
+                                <a tal:condition="url" href="${request.link(person)}" aria-hidden="true" >
+                                    <div class="person-card-portrait" style='${"border: 3px solid #DDDDDD;" if not url else ""}'>
+                                        <div class="cover-image" style='background-image: url("${url}");'></div>
+                                    </div>
+                                </a>
+                            </div>
+                            <div>
+                                <a href="${request.link(person)}">
+                                    <b tal:condition="western_name_order" class="list-title">${person.first_name} ${person.last_name}</b>
+                                    <b tal:condition="not western_name_order" class="list-title">${person.title}</b>
+                                </a>
+                                <a href="${request.link(person)}">
+                                    <p class="list-lead preview">${person.context_specific_function}</p>
+                                </a>
+                            </div>
+                        </div>
                     </li>
                 </ul>
             </div>
@@ -807,12 +818,10 @@
                                 </div>
                                 <div>
                                     <a href="${request.link(person)}">
-                                        <span class="list-title" tal:condition="western_name_order">${person.first_name} ${person.last_name}</span>
-                                        <span class="list-title" tal:condition="not western_name_order">${person.title}</span>
+                                        <b class="list-title" tal:condition="western_name_order">${person.first_name} ${person.last_name}</b>
+                                        <b class="list-title" tal:condition="not western_name_order">${person.title}</b>
                                     </a>
-                                    <a href="${request.link(person)}">
                                         <p class="list-lead preview">${person.context_specific_function}</p>
-                                    </a>
                                 </div>
                             </li>
                         </ul>

--- a/src/onegov/town6/theme/styles/person.scss
+++ b/src/onegov/town6/theme/styles/person.scss
@@ -5,7 +5,18 @@ $person-website-icon: '\f0c1';
 $person-phone-icon: '\f095';
 $person-email-icon: '\f0e0';
 
+
+.people-panel ul {
+    margin-left: 0;
+
+    .person-card-portrait {
+        margin-left: 0;
+    }
+}
+
 .person-card {
+
+    padding: .5rem 0;
 
     .person-card-portrait {
         @include circle;
@@ -155,7 +166,7 @@ Person card in lists
 
     .person-card-portrait {
         height: 5rem;
-        margin: 0.7rem 1.4rem 0.2rem 0.5rem;
+        margin-right: 1rem;
         position: relative;
         text-align: center;
         width: 5rem;


### PR DESCRIPTION
Please fill in the commit message below and work through the checklist. You can delete parts that are not needed, e.g. the optional description, the link to a ticket or irrelevant options of the checklist.

## Commit message

Town6: Display people images in sidebar 

TYPE: Feature
LINK: OGC-1600