### PR TITLE
Fix typo in timeline state

### DIFF
--- a/src/onegov/org/templates/message_ticket.pt
+++ b/src/onegov/org/templates/message_ticket.pt
@@ -29,10 +29,10 @@
                 <tal:b case="'change-net-amount'" i18n:translate>
                     Payment amount changed.
                 </tal:b>
-                <tal:b case="'archive'" i18n:translate>
+                <tal:b case="'archived'" i18n:translate>
                     Ticket archived.
                 </tal:b>
-                <tal:b case="'unarchive'" i18n:translate>
+                <tal:b case="'unarchived'" i18n:translate>
                     Ticket recovered from archive.
                 </tal:b>
             </tal:b>

--- a/src/onegov/town6/templates/message_ticket.pt
+++ b/src/onegov/town6/templates/message_ticket.pt
@@ -26,10 +26,10 @@
                 <tal:b case="'change-net-amount'" i18n:translate>
                     Payment amount changed.
                 </tal:b>
-                <tal:b case="'archive'" i18n:translate>
+                <tal:b case="'archived'" i18n:translate>
                     Ticket archived.
                 </tal:b>
-                <tal:b case="'unarchive'" i18n:translate>
+                <tal:b case="'unarchived'" i18n:translate>
                     Ticket recovered from archive.
                 </tal:b>
                 <tal:b case="'uploaded'" i18n:translate>

--- a/src/onegov/town6/templates/message_ticket.pt
+++ b/src/onegov/town6/templates/message_ticket.pt
@@ -17,6 +17,9 @@
                 <tal:b case="'reopened'" i18n:translate>
                     Ticket reopened.
                 </tal:b>
+                <tal:b case="'assigned'" define="old model.meta.get('old_owner')">
+                    <tal:b i18n:translate>Ticket assigned</tal:b> (<tal:b condition="old">${old} → </tal:b>${model.meta.get('new_owner')}).
+                </tal:b>
                 <tal:b case="'muted'" i18n:translate>
                     Ticket e-mails disabled.
                 </tal:b>


### PR DESCRIPTION
Ticket: Timeline misses state changes 'archived', 'recovered from archive' and 'assigned'

TYPE: Bugfix
LINK: ogc-1779

## Checklist

- [x] I have performed a self-review of my code
- [x] I considered adding a reviewer
- [x] I made changes/features for both org and town6
- [x] I have tested my code thoroughly by hand
- [x] I have added tests for my changes/features
