### PR TITLE
Get rid of special top padding for link group

### DIFF
--- a/src/onegov/town6/theme/styles/header.scss
+++ b/src/onegov/town6/theme/styles/header.scss
@@ -454,7 +454,6 @@ $editbar-fg-color-active: $white;
     margin-top: -2px;
 
     .is-dropdown-submenu-parent > a {
-        padding-top: .9rem !important;
     }
 
     li {


### PR DESCRIPTION
Town6: Fixes style for link groups in edit bar

The link group does not appear on the same level as the single links

TYPE: Bugfix
LINK: ogc-1799