### PR TITLE
Fix space between slider and content

### DIFF
--- a/src/onegov/town6/theme/styles/widgets.scss
+++ b/src/onegov/town6/theme/styles/widgets.scss
@@ -122,6 +122,7 @@ article.content .side-panel {
     .grid-container.full {
         &:first-of-type {
             padding-top: 0;
+            padding-bottom: 0;
         }
     }
 


### PR DESCRIPTION
Town6: No padding after slider on homepage

TYPE: Feature
LINK: ogc-1810

Have manually checked all instances on `aether` with the fix.
For one customer we need a slite css adjustment, see details in ticket.