### PR TITLE
Bugfix/people vcard

### DIFF
--- a/src/onegov/people/models/person.py
+++ b/src/onegov/people/models/person.py
@@ -174,6 +174,23 @@ class Person(Base, ContentMixin, TimestampMixin, ORMSearchable,
         name.
 
         """
+
+        def split_code_from_city(code_city: str) -> tuple[str, str]:
+            """
+            Splits a postal code and city into two parts. Supported are
+            formats like '1234 City Name' and '12345 City Name'.
+
+            """
+            import re
+
+            match = re.match(r'(\d{4,5})\s+(.*)', code_city)
+            if match:
+                code, city = match.groups()
+            else:
+                # assume no code is present
+                code, city = '', code_city
+            return code, city
+
         exclude = exclude or ['notes']
         result = vCard()
 
@@ -236,7 +253,7 @@ class Person(Base, ContentMixin, TimestampMixin, ORMSearchable,
             and 'postal_code_city' not in exclude and self.postal_code_city
         ):
             line = result.add('adr')
-            code, city = self.postal_code_city.split(' ', 1)
+            code, city = split_code_from_city(self.postal_code_city)
             line.value = Address(street=self.postal_address,
                                  code=code, city=city)
             line.charset_param = 'utf-8'
@@ -246,7 +263,7 @@ class Person(Base, ContentMixin, TimestampMixin, ORMSearchable,
             and 'location_code_city' not in exclude and self.location_code_city
         ):
             line = result.add('adr')
-            code, city = self.location_code_city.split(' ', 1)
+            code, city = split_code_from_city(self.location_code_city)
             line.value = Address(street=self.location_address,
                                  code=code, city=city)
             line.charset_param = 'utf-8'

--- a/tests/onegov/people/test_models.py
+++ b/tests/onegov/people/test_models.py
@@ -140,6 +140,29 @@ def test_vcard(session):
     assert "NOTE;CHARSET=utf-8:" not in vcard
     assert "END:VCARD" in vcard
 
+    # location and postal address no zip code
+    person = Person(
+        salutation="Mr.",
+        first_name="Franz",
+        last_name="Müller",
+        postal_address="Fakestreet 1",
+        postal_code_city="Kappel am Albis",
+        location_address="Fakestreet 2",
+        location_code_city="InIrgendwo",
+    )
+    session.add(person)
+    session.flush()
+    vcard = person.vcard(exclude=(
+        'academic_title',
+        'function',
+        'picture_url',
+        'phone_direct',
+        'website',
+        'notes',
+    ))
+    assert "ADR;CHARSET=utf-8:;;Fakestreet 1;Kappel am Albis;;" in vcard
+    assert "ADR;CHARSET=utf-8:;;Fakestreet 2;InIrgendwo;;" in vcard
+
 
 def test_person_membership_by_agency(session):
     agency_a = Agency(title="A", name="a")


### PR DESCRIPTION
People: vcard export fails if no zip code was provided in fields `location_code_city` or `postal_code_city`

TYPE: Bugfix
LINK: ogc-1826