### PR TITLE
Org: Avoids storing ORM objects in `orm_cached` properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,7 +64,10 @@ eggs/
 .tmontmp
 
 # mypy
-.mypy_cache/*
+.mypy_cache/
+
+# ruff
+.ruff_cache/
 
 # sublime
 *.sublime-workspace

--- a/src/onegov/activity/__init__.py
+++ b/src/onegov/activity/__init__.py
@@ -13,6 +13,7 @@ from onegov.activity.models import (
     OccasionDate,
     OccasionNeed,
     Period,
+    PeriodMeta,
     PublicationRequest,
     Volunteer
 )
@@ -41,6 +42,7 @@ __all__ = (
     'OccasionDate',
     'OccasionNeed',
     'Period',
+    'PeriodMeta',
     'ActivityCollection',
     'AttendeeCollection',
     'BookingCollection',

--- a/src/onegov/activity/collections/activity.py
+++ b/src/onegov/activity/collections/activity.py
@@ -32,6 +32,7 @@ if TYPE_CHECKING:
     from collections.abc import Collection, Iterable, Iterator
     from datetime import date
     from markupsafe import Markup
+    from onegov.activity.models import PeriodMeta
     from onegov.activity.models.activity import ActivityState
     from onegov.user import User
     from sqlalchemy.orm import Query, Session
@@ -578,7 +579,7 @@ class ActivityCollection(RangedPagination[ActivityT]):
 
     def available_weeks(
         self,
-        period: Period | None
+        period: 'Period | PeriodMeta | None'
     ) -> 'Iterator[tuple[date, date]]':
         if not period:
             return

--- a/src/onegov/activity/collections/volunteer.py
+++ b/src/onegov/activity/collections/volunteer.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from collections.abc import Sequence
     from datetime import date, datetime
-    from onegov.activity.models import Period
+    from onegov.activity.models import Period, PeriodMeta
     from onegov.activity.models.volunteer import VolunteerState
     from sqlalchemy.orm import Query, Session
     from uuid import UUID
@@ -73,7 +73,11 @@ if TYPE_CHECKING:
 
 class VolunteerCollection(GenericCollection[Volunteer]):
 
-    def __init__(self, session: 'Session', period: 'Period | None') -> None:
+    def __init__(
+        self,
+        session: 'Session',
+        period: 'Period | PeriodMeta | None'
+    ) -> None:
         super().__init__(session)
         self.period = period
 
@@ -93,5 +97,5 @@ class VolunteerCollection(GenericCollection[Volunteer]):
 
         return self.session.execute(query)
 
-    def for_period(self, period: 'Period | None') -> 'Self':
+    def for_period(self, period: 'Period | PeriodMeta | None') -> 'Self':
         return self.__class__(self.session, period)

--- a/src/onegov/activity/models/__init__.py
+++ b/src/onegov/activity/models/__init__.py
@@ -7,7 +7,7 @@ from onegov.activity.models.invoice_reference import InvoiceReference
 from onegov.activity.models.occasion import Occasion
 from onegov.activity.models.occasion_date import OccasionDate, DAYS
 from onegov.activity.models.occasion_need import OccasionNeed
-from onegov.activity.models.period import Period
+from onegov.activity.models.period import Period, PeriodMeta
 from onegov.activity.models.publication_request import PublicationRequest
 from onegov.activity.models.volunteer import Volunteer
 
@@ -22,6 +22,7 @@ __all__ = (
     'OccasionDate',
     'OccasionNeed',
     'Period',
+    'PeriodMeta',
     'PublicationRequest',
     'Volunteer',
     'ACTIVITY_STATES',

--- a/src/onegov/activity/models/activity.py
+++ b/src/onegov/activity/models/activity.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
     import uuid
     from collections.abc import Iterable
     from onegov.activity.collections import PublicationRequestCollection
-    from onegov.activity.models import PublicationRequest
+    from onegov.activity.models import PeriodMeta, PublicationRequest
     from onegov.core.orm.mixins import dict_property
     from typing import Literal
     from typing import Self, TypeAlias
@@ -218,7 +218,7 @@ class Activity(Base, ContentMixin, TimestampMixin):
 
     def request_by_period(
         self,
-        period: Period | None
+        period: 'Period | PeriodMeta | None'
     ) -> 'PublicationRequest | None':
 
         if not period:
@@ -228,7 +228,7 @@ class Activity(Base, ContentMixin, TimestampMixin):
 
         return q.first()
 
-    def has_occasion_in_period(self, period: Period) -> bool:
+    def has_occasion_in_period(self, period: 'Period | PeriodMeta') -> bool:
         q = object_session(self).query(
             exists().where(and_(
                 Occasion.activity_id == self.id,

--- a/src/onegov/activity/models/period.py
+++ b/src/onegov/activity/models/period.py
@@ -236,6 +236,9 @@ class PeriodMetaBase(NamedTuple):
     alignment: str | None
     deadline_days: int | None
     book_finalized: bool
+    cancellation_date: date | None
+    cancellation_days: int | None
+    age_barrier_type: str
 
 
 class PeriodMeta(PeriodMetaBase, PeriodMixin):

--- a/src/onegov/activity/models/period.py
+++ b/src/onegov/activity/models/period.py
@@ -1,6 +1,7 @@
 import sedate
 
 from datetime import date, datetime
+from functools import cached_property
 from onegov.activity.models.age_barrier import AgeBarrier
 from onegov.activity.models.booking import Booking
 from onegov.activity.models.occasion import Occasion
@@ -22,16 +23,236 @@ from sqlalchemy.orm import validates
 from uuid import uuid4
 
 
-from typing import Any, ClassVar, TYPE_CHECKING
+from typing import Any, ClassVar, NamedTuple, TYPE_CHECKING
 if TYPE_CHECKING:
     import uuid
     from collections.abc import Iterator
     from decimal import Decimal
     from onegov.activity.matching.score import Scoring
     from onegov.activity.models import Invoice, PublicationRequest
+    from sqlalchemy.orm import Session
 
 
-class Period(Base, TimestampMixin):
+class PeriodMixin:
+
+    if TYPE_CHECKING:
+        # forward declare required attributes
+        @property
+        def timezone(self) -> str: ...
+        @property
+        def active(self) -> Column[bool] | bool: ...
+        @property
+        def confirmed(self) -> Column[bool] | bool: ...
+        @property
+        def finalized(self) -> Column[bool] | bool: ...
+        @property
+        def prebooking_start(self) -> Column[date] | date: ...
+        @property
+        def prebooking_end(self) -> Column[date] | date: ...
+        @property
+        def booking_start(self) -> Column[date] | date: ...
+        @property
+        def booking_end(self) -> Column[date] | date: ...
+        @property
+        def execution_start(self) -> Column[date] | date: ...
+        @property
+        def execution_end(self) -> Column[date] | date: ...
+        @property
+        def book_finalized(self) -> Column[bool] | bool: ...
+        @property
+        def max_bookings_per_attendee(
+            self
+        ) -> Column[int | None] | int | None: ...
+
+    def as_local_datetime(
+        self,
+        day: date | datetime,
+        end_of_day: bool = False
+    ) -> datetime:
+        """ Returns the moment of midnight in terms of the timezone it UTC """
+        return sedate.standardize_date(
+            datetime(
+                day.year,
+                day.month,
+                day.day,
+                23 if end_of_day else 0,
+                59 if end_of_day else 0,
+                59 if end_of_day else 0
+            ),
+            self.timezone
+        )
+
+    @property
+    def phase(self) -> str | None:
+        local = self.as_local_datetime
+        now = sedate.utcnow()
+
+        if not self.active or now < local(self.prebooking_start):
+            return 'inactive'
+
+        if not self.confirmed:
+            return 'wishlist'
+
+        if now < local(self.booking_start):
+            return 'inactive'
+
+        if not self.finalized and local(self.booking_end, True) < now:
+            return 'inactive'
+
+        if not self.finalized:
+            return 'booking'
+
+        local_execution_start = local(self.execution_start)
+        if now < local_execution_start:
+            return 'payment'
+
+        local_execution_end = local(self.execution_end, end_of_day=True)
+        if local_execution_start <= now <= local_execution_end:
+            return 'execution'
+
+        if now > local_execution_end:
+            return 'archive'
+
+        # FIXME: Is this allowed?
+        return None
+
+    @property
+    def wishlist_phase(self) -> bool:
+        return self.phase == 'wishlist'
+
+    @property
+    def booking_phase(self) -> bool:
+        return self.phase == 'booking'
+
+    @property
+    def payment_phase(self) -> bool:
+        return self.phase == 'payment'
+
+    @property
+    def execution_phase(self) -> bool:
+        return self.phase == 'execution'
+
+    @property
+    def archive_phase(self) -> bool:
+        return self.phase == 'archive'
+
+    @property
+    def is_prebooking_in_future(self) -> bool:
+        now = sedate.utcnow()
+        start = self.as_local_datetime(self.prebooking_start)
+
+        return now < start
+
+    @property
+    def is_currently_prebooking(self) -> bool:
+        if not self.wishlist_phase:
+            return False
+
+        now = sedate.utcnow()
+        start = self.as_local_datetime(self.prebooking_start)
+        end = self.as_local_datetime(self.prebooking_end, end_of_day=True)
+
+        return start <= now <= end
+
+    @property
+    def is_prebooking_in_past(self) -> bool:
+        """Returns true if current date is after start of booking phase or if
+        current date is after prebooking end. """
+        now = sedate.utcnow()
+        start = self.as_local_datetime(self.prebooking_start)
+        end = self.as_local_datetime(self.prebooking_end, end_of_day=True)
+
+        if now > end:
+            return True
+
+        return start <= now and not self.wishlist_phase
+
+    @property
+    def is_booking_in_future(self) -> bool:
+        now = sedate.utcnow()
+        start = self.as_local_datetime(self.booking_start)
+
+        return now < start
+
+    @property
+    def is_currently_booking(self) -> bool:
+        if not self.booking_phase:
+            return False
+
+        now = sedate.utcnow()
+        start = self.as_local_datetime(self.booking_start)
+        end = self.as_local_datetime(self.booking_end, end_of_day=True)
+
+        return start <= now <= end
+
+    @property
+    def is_booking_in_past(self) -> bool:
+        now = sedate.utcnow()
+        start = self.as_local_datetime(self.booking_start)
+        end = self.as_local_datetime(self.booking_end, end_of_day=True)
+
+        if now > end:
+            return True
+
+        return start <= now and not (
+            self.booking_phase
+            or self.book_finalized)
+
+    @property
+    def is_execution_in_past(self) -> bool:
+        now = sedate.utcnow()
+        end = self.as_local_datetime(self.execution_end, end_of_day=True)
+
+        return now > end
+
+    @property
+    def booking_limit(self) -> int | None:
+        """ Returns the max_bookings_per_attendee limit if it applies. """
+        return self.max_bookings_per_attendee
+
+
+class PeriodMetaBase(NamedTuple):
+    id: 'uuid.UUID'
+    title: str
+    active: bool
+    confirmed: bool
+    confirmable: bool
+    finalized: bool
+    finalizable: bool
+    archived: bool
+    timezone: str
+    prebooking_start: date
+    prebooking_end: date
+    booking_start: date
+    booking_end: date
+    execution_start: date
+    execution_end: date
+    max_bookings_per_attendee: int | None
+    booking_cost: 'Decimal | None'
+    all_inclusive: bool
+    pay_organiser_directly: bool
+    minutes_between: int | None
+    alignment: str | None
+    deadline_days: int | None
+    book_finalized: bool
+
+
+class PeriodMeta(PeriodMetaBase, PeriodMixin):
+    # NOTE: With PeriodMeta we can safely cache all properties from
+    #       PeriodMixin, the way we do this is a bit hacky, but it
+    #       is better than duplicating the code
+    for name, value in PeriodMixin.__dict__.items():
+        if not name.startswith('_') and isinstance(value, property):
+            assert value.fget is not None
+            locals()[name] = cached_property(value.fget)
+
+    def materialize(self, session: 'Session') -> 'Period':
+        period = session.query(Period).get(self.id)
+        assert period is not None
+        return period
+
+
+class Period(Base, PeriodMixin, TimestampMixin):
 
     __tablename__ = 'periods'
 
@@ -342,63 +563,6 @@ class Period(Base, TimestampMixin):
         for activity in a:
             activity.archive()
 
-    @property
-    def booking_limit(self) -> int | None:
-        """ Returns the max_bookings_per_attendee limit if it applies. """
-        return self.max_bookings_per_attendee
-
-    def as_local_datetime(
-        self,
-        day: date | datetime,
-        end_of_day: bool = False
-    ) -> datetime:
-        """ Returns the moment of midnight in terms of the timezone it UTC """
-        return sedate.standardize_date(
-            datetime(
-                day.year,
-                day.month,
-                day.day,
-                23 if end_of_day else 0,
-                59 if end_of_day else 0,
-                59 if end_of_day else 0
-            ),
-            self.timezone
-        )
-
-    @property
-    def phase(self) -> str | None:
-        local = self.as_local_datetime
-        now = sedate.utcnow()
-
-        if not self.active or now < local(self.prebooking_start):
-            return 'inactive'
-
-        if not self.confirmed:
-            return 'wishlist'
-
-        if now < local(self.booking_start):
-            return 'inactive'
-
-        if not self.finalized and local(self.booking_end, True) < now:
-            return 'inactive'
-
-        if not self.finalized:
-            return 'booking'
-
-        local_execution_start = local(self.execution_start)
-        if now < local_execution_start:
-            return 'payment'
-
-        local_execution_end = local(self.execution_end, end_of_day=True)
-        if local_execution_start <= now <= local_execution_end:
-            return 'execution'
-
-        if now > local_execution_end:
-            return 'archive'
-
-        # FIXME: Is this allowed?
-        return None
-
     def confirm_and_start_booking_phase(self) -> None:
         """ Confirms the period and sets the booking phase to now.
 
@@ -412,95 +576,6 @@ class Period(Base, TimestampMixin):
         self.booking_start = date.today()
 
     @property
-    def wishlist_phase(self) -> bool:
-        return self.phase == 'wishlist'
-
-    @property
-    def booking_phase(self) -> bool:
-        return self.phase == 'booking'
-
-    @property
-    def payment_phase(self) -> bool:
-        return self.phase == 'payment'
-
-    @property
-    def execution_phase(self) -> bool:
-        return self.phase == 'execution'
-
-    @property
-    def archive_phase(self) -> bool:
-        return self.phase == 'archive'
-
-    @property
-    def is_prebooking_in_future(self) -> bool:
-        now = sedate.utcnow()
-        start = self.as_local_datetime(self.prebooking_start)
-
-        return now < start
-
-    @property
-    def is_currently_prebooking(self) -> bool:
-        if not self.wishlist_phase:
-            return False
-
-        now = sedate.utcnow()
-        start = self.as_local_datetime(self.prebooking_start)
-        end = self.as_local_datetime(self.prebooking_end, end_of_day=True)
-
-        return start <= now <= end
-
-    @property
-    def is_prebooking_in_past(self) -> bool:
-        """Returns true if current date is after start of booking phase or if
-        current date is after prebooking end. """
-        now = sedate.utcnow()
-        start = self.as_local_datetime(self.prebooking_start)
-        end = self.as_local_datetime(self.prebooking_end, end_of_day=True)
-
-        if now > end:
-            return True
-
-        return start <= now and not self.wishlist_phase
-
-    @property
-    def is_booking_in_future(self) -> bool:
-        now = sedate.utcnow()
-        start = self.as_local_datetime(self.booking_start)
-
-        return now < start
-
-    @property
-    def is_currently_booking(self) -> bool:
-        if not self.booking_phase:
-            return False
-
-        now = sedate.utcnow()
-        start = self.as_local_datetime(self.booking_start)
-        end = self.as_local_datetime(self.booking_end, end_of_day=True)
-
-        return start <= now <= end
-
-    @property
-    def is_booking_in_past(self) -> bool:
-        now = sedate.utcnow()
-        start = self.as_local_datetime(self.booking_start)
-        end = self.as_local_datetime(self.booking_end, end_of_day=True)
-
-        if now > end:
-            return True
-
-        return start <= now and not (
-            self.booking_phase
-            or self.book_finalized)
-
-    @property
-    def is_execution_in_past(self) -> bool:
-        now = sedate.utcnow()
-        end = self.as_local_datetime(self.execution_end, end_of_day=True)
-
-        return now > end
-
-    @property
     def scoring(self) -> 'Scoring':
         # circular import
         from onegov.activity.matching.score import Scoring
@@ -512,3 +587,6 @@ class Period(Base, TimestampMixin):
     @scoring.setter
     def scoring(self, scoring: 'Scoring') -> None:
         self.data['match-settings'] = scoring.settings
+
+    def materialize(self, session: 'Session') -> 'Period':
+        return self

--- a/src/onegov/activity/models/period.py
+++ b/src/onegov/activity/models/period.py
@@ -35,10 +35,12 @@ if TYPE_CHECKING:
 
 class PeriodMixin:
 
+    # It's doubtful that the Ferienpass would ever run anywhere else but
+    # in Switzerland ;)
+    timezone: ClassVar[str] = 'Europe/Zurich'
+
     if TYPE_CHECKING:
         # forward declare required attributes
-        @property
-        def timezone(self) -> str: ...
         @property
         def active(self) -> Column[bool] | bool: ...
         @property
@@ -220,7 +222,6 @@ class PeriodMetaBase(NamedTuple):
     finalized: bool
     finalizable: bool
     archived: bool
-    timezone: str
     prebooking_start: date
     prebooking_end: date
     booking_start: date
@@ -255,10 +256,6 @@ class PeriodMeta(PeriodMetaBase, PeriodMixin):
 class Period(Base, PeriodMixin, TimestampMixin):
 
     __tablename__ = 'periods'
-
-    # It's doubtful that the Ferienpass would ever run anywhere else but
-    # in Switzerland ;)
-    timezone: ClassVar[str] = 'Europe/Zurich'
 
     #: The public id of this period
     id: 'Column[uuid.UUID]' = Column(

--- a/src/onegov/api/token.py
+++ b/src/onegov/api/token.py
@@ -4,6 +4,7 @@ from base64 import b64decode
 from datetime import timedelta
 from onegov.api.models import ApiKey
 from sedate import utcnow
+from webob.exc import HTTPBadRequest
 
 
 from typing import Any, TYPE_CHECKING
@@ -51,4 +52,4 @@ def try_get_encoded_token(request: 'CoreRequest') -> str:
     elif request.authorization.authtype == 'Bearer':
         return request.authorization.params
     else:
-        raise ValueError('Unsupported authorization scheme')
+        raise HTTPBadRequest('Unsupported authorization scheme')

--- a/src/onegov/core/cache.py
+++ b/src/onegov/core/cache.py
@@ -42,7 +42,6 @@ from functools import cached_property
 from functools import lru_cache
 from functools import partial
 from functools import update_wrapper
-from functools import wraps
 from redis import ConnectionPool
 
 
@@ -50,27 +49,8 @@ from typing import overload, Any, TypeVar, TYPE_CHECKING
 if TYPE_CHECKING:
     from collections.abc import Callable
     from dogpile.cache.api import NoValue
-    from onegov.core.framework import Framework
-    from typing import Protocol
 
-    _T = TypeVar('_T')
-    _T_co = TypeVar('_T_co', covariant=True)
     _F = TypeVar('_F', bound=Callable[..., Any])
-    _FrameworkT = TypeVar('_FrameworkT', bound=Framework, contravariant=True)
-
-    class _RequestCached(Protocol[_FrameworkT, _T_co]):
-        @overload
-        def __get__(
-            self,
-            instance: None,
-            owner: type[_FrameworkT]
-        ) -> property: ...
-        @overload
-        def __get__(
-            self,
-            instance: _FrameworkT,
-            owner: type[_FrameworkT]
-        ) -> _T_co: ...
 
 
 @overload
@@ -112,23 +92,6 @@ def instance_lru_cache(
         return cached_property(wrapper)  # type:ignore[return-value]
 
     return decorator if method is None else decorator(method)
-
-
-def request_cached(
-    appmethod: 'Callable[[_FrameworkT], _T]'
-) -> '_RequestCached[_FrameworkT, _T]':
-
-    cache_key = appmethod.__qualname__
-
-    @wraps(appmethod)
-    def wrapper(self: '_FrameworkT') -> '_T':
-        if cache_key in self.request_cache:
-            return self.request_cache[cache_key]
-
-        self.request_cache[cache_key] = value = appmethod(self)
-        return value
-
-    return property(wrapper)
 
 
 def dill_serialize(value: Any) -> bytes:

--- a/src/onegov/core/orm/__init__.py
+++ b/src/onegov/core/orm/__init__.py
@@ -1,7 +1,7 @@
 import psycopg2
 
 from markupsafe import escape, Markup
-from onegov.core.orm.cache import orm_cached
+from onegov.core.orm.cache import orm_cached, request_cached
 from onegov.core.orm.observer import observes
 from onegov.core.orm.session_manager import SessionManager, query_schemas
 from onegov.core.orm.sql import as_selectable, as_selectable_from_path
@@ -221,5 +221,6 @@ __all__ = [
     'find_models',
     'observes',
     'orm_cached',
-    'query_schemas'
+    'query_schemas',
+    'request_cached'
 ]

--- a/src/onegov/core/orm/cache.py
+++ b/src/onegov/core/orm/cache.py
@@ -139,8 +139,8 @@ class OrmCacheApp:
                 #
                 # Still, trust but verify:
                 assert self.schema == schema
-                self.cache.delete_multi(list(descriptor.used_cache_keys))
                 for cache_key in descriptor.used_cache_keys:
+                    self.cache.delete(cache_key)
                     if cache_key in self.request_cache:
                         del self.request_cache[cache_key]
 

--- a/src/onegov/core/orm/utils.py
+++ b/src/onegov/core/orm/utils.py
@@ -1,8 +1,11 @@
+import sqlalchemy
+
 from sqlalchemy_utils import QueryChain as QueryChainBase
 
 
 from typing import TypeVar, TYPE_CHECKING
 if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
     from typing import Self
 
     _T = TypeVar('_T')
@@ -26,3 +29,33 @@ class QueryChain(QueryChainBase):  # type:ignore
 
     def all(self) -> tuple['_T', ...]:
         return tuple(self)
+
+
+def maybe_merge(session: 'Session', obj: '_T') -> '_T':
+    """ Merges the given obj into the given session, *if* this is possible.
+    That is it acts like more forgiving session.merge().
+    """
+    if requires_merge(obj):
+        obj = session.merge(obj, load=False)
+        obj.is_cached = True  # type:ignore[attr-defined]
+
+    return obj
+
+
+def requires_merge(obj: object) -> bool:
+    """ Returns true if the given object requires a merge, which is the
+    case if the object is detached.
+
+
+    """
+
+    # no need for an expensive sqlalchemy.inspect call for these
+    if isinstance(obj, (int, str, bool, float, tuple, list, dict, set)):
+        return False
+
+    info = sqlalchemy.inspect(obj, raiseerr=False)
+
+    if not info:
+        return False
+
+    return info.detached

--- a/src/onegov/feriennet/app.py
+++ b/src/onegov/feriennet/app.py
@@ -1,6 +1,7 @@
 from functools import cached_property
 from markupsafe import Markup
-from onegov.activity import Period, PeriodCollection, InvoiceCollection
+from onegov.activity import (
+    Period, PeriodCollection, PeriodMeta, InvoiceCollection)
 from onegov.activity.models.invoice_reference import Schema
 from onegov.core import utils
 from onegov.core.orm import orm_cached
@@ -59,20 +60,50 @@ class FeriennetApp(OrgApp):
         return request.is_admin
 
     @orm_cached(policy='on-table-change:periods')
-    def active_period(self) -> Period | None:
-        return PeriodCollection(self.session()).active()
+    def active_period(self) -> PeriodMeta | None:
+        for period in self.periods:
+            if period.active:
+                return period
+        return None
 
     @orm_cached(policy='on-table-change:periods')
-    def periods(self) -> 'Query[Period]':
-        p = PeriodCollection(self.session()).query()
-        p = p.order_by(Period.execution_start)
-
-        return p
+    def periods(self) -> tuple[PeriodMeta, ...]:
+        query: Query[PeriodMeta] = (
+            PeriodCollection(self.session())
+            .query()
+            .order_by(Period.execution_start)
+            .with_entities(
+                Period.id,
+                Period.title,
+                Period.active,
+                Period.confirmed,
+                Period.confirmable,
+                Period.finalized,
+                Period.finalizable,
+                Period.archived,
+                Period.timezone,
+                Period.prebooking_start,
+                Period.prebooking_end,
+                Period.booking_start,
+                Period.booking_end,
+                Period.execution_start,
+                Period.execution_end,
+                Period.max_bookings_per_attendee,
+                Period.booking_cost,
+                Period.all_inclusive,
+                Period.pay_organiser_directly,
+                Period.minutes_between,
+                Period.alignment,
+                Period.deadline_days,
+                Period.book_finalized,
+            )
+        )
+        return tuple(PeriodMeta(*row) for row in query)
 
     @orm_cached(policy='on-table-change:periods')
-    def periods_by_id(self) -> dict[str, Period]:
+    def periods_by_id(self) -> dict[str, PeriodMeta]:
         return {
-            p.id.hex: p for p in PeriodCollection(self.session()).query()
+            p.id.hex: p for p in self.periods
         }
 
     @orm_cached(policy='on-table-change:users')
@@ -102,7 +133,7 @@ class FeriennetApp(OrgApp):
         return sponsors
 
     @property
-    def default_period(self) -> Period | None:
+    def default_period(self) -> PeriodMeta | None:
         if self.active_period:
             return self.active_period
         return self.periods[0] if self.periods else None

--- a/src/onegov/feriennet/app.py
+++ b/src/onegov/feriennet/app.py
@@ -81,7 +81,6 @@ class FeriennetApp(OrgApp):
                 Period.finalized,
                 Period.finalizable,
                 Period.archived,
-                Period.timezone,
                 Period.prebooking_start,
                 Period.prebooking_end,
                 Period.booking_start,

--- a/src/onegov/feriennet/app.py
+++ b/src/onegov/feriennet/app.py
@@ -95,6 +95,9 @@ class FeriennetApp(OrgApp):
                 Period.alignment,
                 Period.deadline_days,
                 Period.book_finalized,
+                Period.cancellation_date,
+                Period.cancellation_days,
+                Period.age_barrier_type,
             )
         )
         return tuple(PeriodMeta(*row) for row in query)

--- a/src/onegov/feriennet/boardlets.py
+++ b/src/onegov/feriennet/boardlets.py
@@ -13,7 +13,7 @@ from sqlalchemy import func
 from typing import Literal, TYPE_CHECKING
 if TYPE_CHECKING:
     from collections.abc import Iterator
-    from onegov.activity.models import Period
+    from onegov.activity.models import PeriodMeta
     from onegov.activity.models.booking import BookingState
     from onegov.feriennet.collections.match import OccasionState
     from onegov.feriennet.request import FeriennetRequest
@@ -29,7 +29,7 @@ class FeriennetBoardlet(Boardlet):
         return self.request.session
 
     @cached_property
-    def period(self) -> 'Period | None':
+    def period(self) -> 'PeriodMeta | None':
         return self.request.app.active_period
 
     @cached_property

--- a/src/onegov/feriennet/collections/billing.py
+++ b/src/onegov/feriennet/collections/billing.py
@@ -16,7 +16,7 @@ from ulid import ULID
 from typing import Any, Literal, NamedTuple, TYPE_CHECKING
 if TYPE_CHECKING:
     from collections.abc import Collection, Iterator
-    from onegov.activity.models import Period
+    from onegov.activity.models import Period, PeriodMeta
     from onegov.feriennet.request import FeriennetRequest
     from sqlalchemy.orm import Query, Session
     from sqlalchemy.sql.selectable import Alias
@@ -52,7 +52,7 @@ class BillingCollection:
     def __init__(
         self,
         request: 'FeriennetRequest',
-        period: 'Period',
+        period: 'Period | PeriodMeta',
         username: str | None = None,
         expand: bool = False,
         state: Literal['paid', 'unpaid'] | None = None
@@ -333,7 +333,11 @@ class BookingInvoiceBridge:
     processed_attendees: set['UUID']
     billed_attendees: set['UUID']
 
-    def __init__(self, session: 'Session', period: 'Period') -> None:
+    def __init__(
+        self,
+        session: 'Session',
+        period: 'Period | PeriodMeta'
+    ) -> None:
         # tracks attendees which had at least one booking added through the
         # bridge (even if said booking was free)
         self.processed_attendees = set()

--- a/src/onegov/feriennet/collections/match.py
+++ b/src/onegov/feriennet/collections/match.py
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
     from collections.abc import Collection
     from datetime import datetime
     from onegov.activity.models import Period
+    from onegov.feriennet.app import PeriodMeta
     from sqlalchemy.orm import Query, Session
     from sqlalchemy.sql.selectable import Alias
     from typing import Self, TypeAlias
@@ -47,7 +48,7 @@ class MatchCollection:
     def __init__(
         self,
         session: 'Session',
-        period: 'Period',
+        period: 'Period | PeriodMeta',
         states: 'Collection[OccasionState] | None' = None
     ) -> None:
         self.session = session
@@ -58,7 +59,7 @@ class MatchCollection:
     def period_id(self) -> 'UUID':
         return self.period.id
 
-    def for_period(self, period: 'Period') -> 'Self':
+    def for_period(self, period: 'Period | PeriodMeta') -> 'Self':
         return self.__class__(self.session, period)
 
     def for_filter(self, state: OccasionState | None = None) -> 'Self':

--- a/src/onegov/feriennet/collections/occasion_attendees.py
+++ b/src/onegov/feriennet/collections/occasion_attendees.py
@@ -5,7 +5,7 @@ from onegov.user import User
 
 from typing import NamedTuple, TYPE_CHECKING
 if TYPE_CHECKING:
-    from onegov.activity.models import Period
+    from onegov.activity.models import Period, PeriodMeta
     from sqlalchemy.orm import Query, Session
     from typing import TypedDict, Self
     from uuid import UUID
@@ -27,7 +27,7 @@ class OccasionAttendeeCollection(OccasionCollection):
     def __init__(
         self,
         session: 'Session',
-        period: 'Period',
+        period: 'Period | PeriodMeta',
         activity: Activity,
         username: str | None = None
     ) -> None:
@@ -44,7 +44,7 @@ class OccasionAttendeeCollection(OccasionCollection):
     def activity_name(self) -> str:
         return self.activity.name
 
-    def for_period(self, period: 'Period') -> 'Self':
+    def for_period(self, period: 'Period | PeriodMeta') -> 'Self':
         return self.__class__(
             self.session, period, self.activity, self.username)
 

--- a/src/onegov/feriennet/exports/unlucky.py
+++ b/src/onegov/feriennet/exports/unlucky.py
@@ -11,7 +11,7 @@ from sqlalchemy import and_, not_
 from typing import Any, TYPE_CHECKING
 if TYPE_CHECKING:
     from collections.abc import Iterator
-    from onegov.activity.models import Period
+    from onegov.activity.models import Period, PeriodMeta
     from sqlalchemy.orm import Query, Session
 
 
@@ -33,7 +33,11 @@ class UnluckyExport(FeriennetExport):
         assert form.selected_period is not None
         return self.rows(session, form.selected_period)
 
-    def query(self, session: 'Session', period: 'Period') -> 'Query[Attendee]':
+    def query(
+        self,
+        session: 'Session',
+        period: 'Period | PeriodMeta'
+    ) -> 'Query[Attendee]':
 
         with_any_bookings = session.query(Booking.attendee_id).filter(
             Booking.period_id == period.id).subquery()
@@ -51,7 +55,7 @@ class UnluckyExport(FeriennetExport):
     def rows(
         self,
         session: 'Session',
-        period: 'Period'
+        period: 'Period | PeriodMeta'
     ) -> 'Iterator[Iterator[tuple[str, Any]]]':
 
         for user in self.query(session, period):

--- a/src/onegov/feriennet/forms/notification_template.py
+++ b/src/onegov/feriennet/forms/notification_template.py
@@ -22,7 +22,7 @@ from wtforms.validators import InputRequired, ValidationError
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from collections.abc import Collection, Iterator
-    from onegov.activity.models import Period
+    from onegov.activity.models import PeriodMeta
     from onegov.feriennet.request import FeriennetRequest
     from sqlalchemy.orm import Query
 
@@ -127,7 +127,7 @@ class NotificationTemplateSendForm(Form):
         self.occasion.choices = list(self.occasion_choices)
 
     @cached_property
-    def period(self) -> 'Period':
+    def period(self) -> 'PeriodMeta':
         for period in self.request.app.periods:
             if period.id == self.model.period_id:
                 return period

--- a/src/onegov/feriennet/forms/period.py
+++ b/src/onegov/feriennet/forms/period.py
@@ -20,6 +20,7 @@ from wtforms.validators import InputRequired, Optional, NumberRange
 
 from typing import Any, TYPE_CHECKING
 if TYPE_CHECKING:
+    from onegov.activity.models import PeriodMeta
     from onegov.feriennet.request import FeriennetRequest
     from wtforms.fields.choices import _Choice
 
@@ -47,7 +48,7 @@ class PeriodSelectForm(Form):
             self.period.data)
 
     @property
-    def active_period(self) -> Period | None:
+    def active_period(self) -> 'PeriodMeta | None':
         return self.request.app.active_period
 
     def on_request(self) -> None:

--- a/src/onegov/feriennet/models/activity.py
+++ b/src/onegov/feriennet/models/activity.py
@@ -80,12 +80,13 @@ class VacationActivity(Activity, CoordinatesExtension, SearchableContent):
         tags = [request.translate(_(tag)) for tag in self.tags]
 
         if durations is None:
+            period = request.app.active_period
             durations = sum(o.duration for o in (
                 request.session.query(Occasion)
                 .with_entities(Occasion.duration)
                 .distinct()
                 .filter_by(activity_id=self.id)
-                .filter_by(period=request.app.active_period)
+                .filter_by(period_id=period.id if period else None)
             ))
 
         if DAYS.has(durations, DAYS.half):

--- a/src/onegov/feriennet/models/message.py
+++ b/src/onegov/feriennet/models/message.py
@@ -5,6 +5,7 @@ from onegov.org.models.message import TicketMessageMixin
 
 from typing import Any, TYPE_CHECKING
 if TYPE_CHECKING:
+    from onegov.activity.models import PeriodMeta
     from onegov.feriennet.request import FeriennetRequest
     from onegov.ticket import Ticket
     from typing import Self
@@ -22,7 +23,7 @@ class PeriodMessage(Message):
     @classmethod
     def create(
         cls,
-        period: Period,
+        period: 'Period | PeriodMeta',
         request: 'FeriennetRequest',
         action: str
     ) -> 'Self':

--- a/src/onegov/feriennet/path.py
+++ b/src/onegov/feriennet/path.py
@@ -26,6 +26,7 @@ from uuid import UUID
 
 from typing import Literal, TYPE_CHECKING
 if TYPE_CHECKING:
+    from onegov.activity.models import PeriodMeta
     from onegov.feriennet.request import FeriennetRequest
 
 
@@ -156,6 +157,7 @@ def get_matches(
 ) -> MatchCollection | None:
 
     # the default period is the active period or the first we can find
+    period: Period | PeriodMeta | None
     if not period_id:
         period = app.default_period
     else:
@@ -186,6 +188,7 @@ def get_billing(
 ) -> BillingCollection | None:
 
     # the default period is the active period or the first we can find
+    period: Period | PeriodMeta | None
     if not period_id:
         period = app.default_period
     else:
@@ -290,6 +293,7 @@ def get_occasion_attendee_collection(
         return None
 
     # the default period is the active period or the first we can find
+    period: Period | PeriodMeta | None
     if not period_id:
         period = app.default_period
     else:

--- a/src/onegov/feriennet/views/activity.py
+++ b/src/onegov/feriennet/views/activity.py
@@ -611,10 +611,11 @@ def view_activities_as_json(
 
     def tags(activity: VacationActivity) -> 'JSON_ro':
         period = request.app.active_period
+        period_id = period.id if period else None
         durations = sum({
             o.duration
             for o in activity.occasions
-            if o.period == period and o.duration is not None
+            if o.period.id == period_id and o.duration is not None
         })
         return activity.ordered_tags(request, durations)
 
@@ -1018,7 +1019,7 @@ def propose_activity(
         self.propose()
 
         publication_request = self.create_publication_request(
-            request.app.active_period)
+            request.app.active_period.materialize(request.session))
 
         ticket = TicketCollection(session).open_ticket(
             handler_code='FER',

--- a/src/onegov/feriennet/views/activity.py
+++ b/src/onegov/feriennet/views/activity.py
@@ -615,7 +615,7 @@ def view_activities_as_json(
         durations = sum({
             o.duration
             for o in activity.occasions
-            if o.period.id == period_id and o.duration is not None
+            if o.period_id == period_id and o.duration is not None
         })
         return activity.ordered_tags(request, durations)
 

--- a/src/onegov/feriennet/views/billing.py
+++ b/src/onegov/feriennet/views/billing.py
@@ -60,6 +60,7 @@ def view_billing(
             all_inclusive_booking_text=request.translate(_('Passport')))
 
         if form.finalize_period:
+            self.period = self.period.materialize(request.session)
             PeriodMessage.create(self.period, request, 'finalized')
             self.period.finalized = True
 

--- a/src/onegov/feriennet/views/booking.py
+++ b/src/onegov/feriennet/views/booking.py
@@ -34,7 +34,7 @@ from uuid import UUID
 from typing import Literal, TYPE_CHECKING
 if TYPE_CHECKING:
     from collections.abc import Collection, Iterable
-    from onegov.activity.models import Period
+    from onegov.activity.models import Period, PeriodMeta
     from onegov.activity.models.booking import BookingState
     from onegov.core.elements import Trait
     from onegov.core.types import RenderData
@@ -83,7 +83,7 @@ def all_bookings(collection: BookingCollection) -> list[Booking]:
 
 
 def group_bookings(
-    period: 'Period',
+    period: 'Period | PeriodMeta',
     bookings: 'Iterable[Booking]'
 ) -> dict[Attendee, dict['BookingState', SortedList[Booking]]]:
     """ Takes a (small) list of bookings and groups them by attendee and state
@@ -125,7 +125,7 @@ def group_bookings(
 
 
 def total_by_bookings(
-    period: 'Period | None',
+    period: 'Period | PeriodMeta | None',
     bookings: 'Collection[Booking]'
 ) -> Decimal:
 
@@ -194,7 +194,7 @@ def get_booking_title(layout: DefaultLayout, booking: Booking) -> str:
 
 def actions_by_booking(
     layout: DefaultLayout,
-    period: 'Period | None',
+    period: 'Period | PeriodMeta | None',
     booking: Booking
 ) -> list[Link]:
 

--- a/src/onegov/feriennet/views/match.py
+++ b/src/onegov/feriennet/views/match.py
@@ -68,6 +68,7 @@ def handle_matches(
             period_id=self.period_id,
             score_function=form.scoring(request.session))
 
+        self.period = self.period.materialize(request.session)
         self.period.scoring = form.scoring(request.session)
 
         if form.confirm_period:
@@ -80,6 +81,7 @@ def handle_matches(
         self.session.flush()
 
     elif not request.POST:
+        self.period = self.period.materialize(request.session)
         form.process_scoring(self.period.scoring)
 
     def activity_link(oid: 'UUID') -> str:

--- a/src/onegov/org/app.py
+++ b/src/onegov/org/app.py
@@ -6,7 +6,6 @@ import yaml
 import base64
 import hashlib
 import morepath
-from collections import defaultdict
 from dectate import directive
 from email.headerregistry import Address
 from functools import wraps
@@ -14,6 +13,7 @@ from more.content_security import SELF
 from more.content_security import NONE
 from more.content_security.core import content_security_policy_tween_factory
 from onegov.core import Framework, utils
+from onegov.core.cache import request_cached
 from onegov.core.framework import default_content_security_policy
 from onegov.core.i18n import default_locale_negotiator
 from onegov.core.orm import orm_cached
@@ -25,11 +25,9 @@ from onegov.gis import MapboxApp
 from onegov.org import directives
 from onegov.org.auth import MTANAuth
 from onegov.org.initial_content import create_new_organisation
-from onegov.org.models import Dashboard
-from onegov.org.models import Topic, Organisation, PublicationCollection
+from onegov.org.models import Dashboard, Organisation, PublicationCollection
 from onegov.org.request import OrgRequest
 from onegov.org.theme import OrgTheme
-from onegov.page import Page, PageCollection
 from onegov.pay import PayApp
 from onegov.reservation import LibresIntegration
 from onegov.search import ElasticsearchApp
@@ -38,8 +36,6 @@ from onegov.ticket import TicketPermission
 from onegov.user import UserApp
 from onegov.websockets import WebsocketsApp
 from purl import URL
-from sqlalchemy.orm import noload, undefer
-from sqlalchemy.orm.attributes import set_committed_value
 from types import MethodType
 from webob.exc import WSGIHTTPException, HTTPTooManyRequests
 
@@ -177,72 +173,17 @@ class OrgApp(Framework, LibresIntegration, ElasticsearchApp, MapboxApp,
                 dispatch.key_lookup = get_view.key_lookup
                 dispatch._mtan_hook_configured = True
 
-    @orm_cached(policy='on-table-change:organisations')
+    # NOTE: Organisation is probably the one model we could get away with
+    #       caching long-term without causing too many issues, but we
+    #       would first have to prove that we actually save a significant
+    #       amount of resources by skipping this query
+    @request_cached
     def org(self) -> Organisation:
         # even though this could return no Organisation, this can only
         # occur during setup, until after we added an Organisation, so
         # outside of this very narrow use-case this should always return
         # an organisation, so we pretend that it always does
         return self.session().query(Organisation).first()  # type:ignore
-
-    @orm_cached(policy='on-table-change:pages')
-    def root_pages(self) -> tuple[Page, ...]:
-
-        def include(page: Page) -> bool:
-            if page.type != 'news':
-                return True
-
-            return True if page.children else False
-
-        return tuple(p for p in self.pages_tree if include(p))
-
-    @orm_cached(policy='on-table-change:pages')
-    def pages_tree(self) -> tuple[Page, ...]:
-        """
-        This is the entire pages tree preloaded into the individual
-        parent/children attributes. We optimize this as much as possible
-        by performing the recursive join in Python, rather than SQL.
-
-        """
-        query = PageCollection(self.session()).query(ordered=False)
-        query = query.options(
-            # we populate these relationship ourselves
-            noload(Page.parent),
-            noload(Page.children),
-            # since we cache this result we should undefer loading the
-            # page meta, so we don't need to deserialize it every time
-            # this causes a fairly substantial overhead on uncached
-            # loads of pages_tree, but it's also a fairly big win
-            # once it is cached. There may be call-sites other than
-            # homepage_pages that benefit from this. If there aren't
-            # we can always go back on this decision
-            undefer(Page.meta)
-        )
-        query = query.order_by(Page.order)
-
-        # first we build a map from parent_ids to their children
-        parent_to_child = defaultdict(list)
-        for page in query:
-            parent_to_child[page.parent_id].append(page)
-
-        # then we populate the children and parent based on this information
-        # this should result in no pending modifications, because we use
-        # set_committed_value to set them
-        for page in (
-            page
-            for pages in parent_to_child.values()
-            for page in pages
-        ):
-            # even though this is a defaultdict, we need to use get()
-            # since otherwise we modifiy the dictionary
-            children = parent_to_child.get(page.id, [])
-            for child in children:
-                set_committed_value(child, 'parent', page)
-            set_committed_value(page, 'children', children)
-
-        # we return the root pages which should contain references to all
-        # the child pages
-        return tuple(p for p in parent_to_child.get(None, []))
 
     @orm_cached(policy='on-table-change:organisations')
     def homepage_template(self) -> PageTemplate:
@@ -260,38 +201,14 @@ class OrgApp(Framework, LibresIntegration, ElasticsearchApp, MapboxApp,
     @orm_cached(policy='on-table-change:ticket_permissions')
     def ticket_permissions(self) -> dict[str, dict[str | None, list[str]]]:
         result: dict[str, dict[str | None, list[str]]] = {}
-        for permission in self.session().query(TicketPermission):
+        for permission in self.session().query(TicketPermission).with_entities(
+            TicketPermission.handler_code,
+            TicketPermission.group,
+            TicketPermission.user_group_id
+        ):
             handler = result.setdefault(permission.handler_code, {})
             group = handler.setdefault(permission.group, [])
             group.append(permission.user_group_id.hex)
-        return result
-
-    @orm_cached(policy='on-table-change:pages')
-    def homepage_pages(self) -> dict[int, list[Topic]]:
-
-        def visit_topics(
-            pages: 'Iterable[Page]',
-            root_id: int | None = None
-        ) -> 'Iterator[tuple[int, Topic]]':
-            for page in pages:
-                if isinstance(page, Topic):
-                    yield root_id or page.id, page
-
-                yield from visit_topics(
-                    page.children,
-                    root_id=root_id or page.id
-                )
-
-        result = defaultdict(list)
-        for root_id, topic in visit_topics(self.root_pages):
-            if topic.is_visible_on_homepage:
-                result[root_id].append(topic)
-
-        for topics in result.values():
-            topics.sort(
-                key=lambda p: utils.normalize_for_url(p.title)
-            )
-
         return result
 
     @orm_cached(policy='on-table-change:files')

--- a/src/onegov/org/app.py
+++ b/src/onegov/org/app.py
@@ -13,10 +13,9 @@ from more.content_security import SELF
 from more.content_security import NONE
 from more.content_security.core import content_security_policy_tween_factory
 from onegov.core import Framework, utils
-from onegov.core.cache import request_cached
 from onegov.core.framework import default_content_security_policy
 from onegov.core.i18n import default_locale_negotiator
-from onegov.core.orm import orm_cached
+from onegov.core.orm.cache import orm_cached, request_cached
 from onegov.core.templates import PageTemplate
 from onegov.core.widgets import transform_structure
 from onegov.file import DepotApp

--- a/src/onegov/org/homepage_widgets.py
+++ b/src/onegov/org/homepage_widgets.py
@@ -329,7 +329,7 @@ class TilesWidget:
                             # it's not the actual page model
                             model=child,
                         )
-                        for child in homepage_pages[page.id]
+                        for child in homepage_pages.get(page.id, ())
                     )
                 )
 

--- a/src/onegov/org/homepage_widgets.py
+++ b/src/onegov/org/homepage_widgets.py
@@ -15,7 +15,6 @@ if TYPE_CHECKING:
     from onegov.core.types import RenderData
     from onegov.org.layout import DefaultLayout
     from onegov.org.models import ExtendedDirectory
-    from onegov.page import Page
 
 
 def get_lead(
@@ -181,27 +180,34 @@ class NewsWidget:
 
     def get_variables(self, layout: 'DefaultLayout') -> 'RenderData':
 
-        if not layout.root_pages:
+        root_pages = layout.root_pages
+        if not root_pages:
             return {'news': ()}
 
         news_index: int | None = None
-        for index, page in enumerate(layout.root_pages):
-            if isinstance(page, News):
-                news_index = index
+        for index, page in enumerate(root_pages):
+            if page.type == 'news':
+                if page.children:
+                    # only bother doing the query if there are children
+                    news_index = index
                 break
 
         if news_index is None:
             return {'news': ()}
 
+        # FIXME: We probably don't need full fat News objects for this
+        #        and could instead just use children on the root news page
+        #        if we need additional attributes, we can just add them
+        #        to PageMeta, then we can also get rid of `news_query_for`
+        #        and refactor it back into a pure instance method
+
         # request more than the required amount of news to account for hidden
         # items which might be in front of the queue
         news_limit = layout.org.news_limit_homepage
         news = layout.request.exclude_invisible(
-            # FIXME: This may indicate that we want root_pages to return
-            #        `News | Topic` rather than `Page`, which is not really
-            #        guaranteed at runtime right now, it just so happens that
-            #        those are the only two types of pages we use in org
-            layout.root_pages[news_index].news_query(  # type:ignore
+            News.news_query_for(
+                root_pages[news_index],
+                session=layout.request.session,
                 limit=news_limit + 2,
                 published_only=not layout.request.is_manager
             ).all()
@@ -303,28 +309,27 @@ class TilesWidget:
 
     def get_tiles(self, layout: 'DefaultLayout') -> 'Iterator[Tile]':
 
-        homepage_pages = layout.request.app.homepage_pages
         request = layout.request
-        link = request.link
+        homepage_pages = request.homepage_pages
         classes = ('tile-sub-link', )
 
         for ix, page in enumerate(layout.root_pages):
             if page.type == 'topic':
 
-                children: Iterable[Page] = homepage_pages[page.id]
-
-                if not request.is_manager:
-                    children = (
-                        child for child in children
-                        if getattr(child, 'access', '') == 'public'
-                    )
-
                 yield self.Tile(
-                    page=Link(page.title, link(page)),
+                    page=Link(page.title, page.link(request)),
                     number=ix + 1,
                     links=tuple(
-                        Link(c.title, link(c), classes=classes, model=c)
-                        for c in children
+                        Link(
+                            child.title,
+                            child.link(request),
+                            classes=classes,
+                            # this only accesses the `access` attribute
+                            # which we have, so this is safe, even though
+                            # it's not the actual page model
+                            model=child,
+                        )
+                        for child in homepage_pages[page.id]
                     )
                 )
 

--- a/src/onegov/org/layout.py
+++ b/src/onegov/org/layout.py
@@ -75,8 +75,7 @@ if TYPE_CHECKING:
     from onegov.org.models import (
         ExtendedDirectory, ExtendedDirectoryEntry, ImageSet, Organisation)
     from onegov.org.app import OrgApp
-    from onegov.org.request import OrgRequest
-    from onegov.page import Page
+    from onegov.org.request import OrgRequest, PageMeta
     from onegov.reservation import Resource
     from onegov.ticket import Ticket
     from onegov.user import User, UserGroup
@@ -806,14 +805,14 @@ class DefaultLayout(Layout, DefaultLayoutMixin):
             return tuple(i for i in items if getattr(i, 'published', True))
         return items
 
-    @cached_property
-    def root_pages(self) -> 'Sequence[Page]':
-        return self.exclude_invisible(self.app.root_pages)
+    @property
+    def root_pages(self) -> tuple['PageMeta', ...]:
+        return self.request.root_pages
 
     @cached_property
     def top_navigation(self) -> 'Sequence[Link] | None':
         return tuple(
-            Link(r.title, self.request.link(r)) for r in self.root_pages
+            Link(r.title, r.link(self.request)) for r in self.root_pages
         )
 
     @cached_property

--- a/src/onegov/org/models/page.py
+++ b/src/onegov/org/models/page.py
@@ -273,7 +273,12 @@ class News(Page, TraitInfo, SearchableContent, NewsletterExtension,
             session = object_session(self)
 
         news = session.query(News)
-        news = news.filter(Page.parent_id == self.id)
+        if isinstance(self, News):
+            # avoid a redundant relationship load when we can
+            news = news.filter(Page.parent == self)
+        else:
+            news = news.filter(Page.parent_id == self.id)
+
         if published_only:
             news = news.filter(
                 News.publication_started == True,

--- a/src/onegov/org/models/page.py
+++ b/src/onegov/org/models/page.py
@@ -28,8 +28,8 @@ from sqlalchemy.orm import undefer, object_session
 
 from typing import Any, TYPE_CHECKING
 if TYPE_CHECKING:
-    from onegov.org.request import OrgRequest
-    from sqlalchemy.orm import Query
+    from onegov.org.request import OrgRequest, PageMeta
+    from sqlalchemy.orm import Query, Session
 
 
 class Topic(Page, TraitInfo, SearchableContent, AccessExtension,
@@ -260,37 +260,41 @@ class News(Page, TraitInfo, SearchableContent, NewsletterExtension,
             filter_tags=sorted(tags)
         )
 
-    def news_query(
-        self,
+    @classmethod
+    def news_query_for(
+        cls,
+        self: 'News | PageMeta',
         limit: int | None = 2,
-        published_only: bool = True
+        published_only: bool = True,
+        session: 'Session | None' = None,
     ) -> 'Query[News]':
 
-        news = object_session(self).query(News)
-        news = news.filter(Page.parent == self)
+        if session is None:
+            session = object_session(self)
+
+        news = session.query(News)
+        news = news.filter(Page.parent_id == self.id)
         if published_only:
             news = news.filter(
                 News.publication_started == True,
                 News.publication_ended == False
             )
 
-        filter = []
-        for year in self.filter_years:
+        year_filters = []
+        for year in getattr(self, 'filter_years', ()):
             start = replace_timezone(datetime(year, 1, 1), 'UTC')
-            filter.append(
+            year_filters.append(
                 and_(
                     News.published_or_created >= start,
                     News.published_or_created < start.replace(year=year + 1)
                 )
             )
-        if filter:
-            news = news.filter(or_(*filter))
+        if year_filters:
+            news = news.filter(or_(*year_filters))
 
-        if self.filter_tags:
+        if filter_tags := getattr(self, 'filter_tags', None):
             news = news.filter(
-                News.meta['hashtags'].has_any(
-                    array(self.filter_tags)  # type:ignore[call-overload]
-                )
+                News.meta['hashtags'].has_any(array(filter_tags))
             )
 
         news = news.order_by(desc(News.published_or_created))
@@ -306,6 +310,14 @@ class News(Page, TraitInfo, SearchableContent, NewsletterExtension,
 
         return news.union(sticky_news).order_by(
             desc(News.published_or_created))
+
+    def news_query(
+        self,
+        limit: int | None = 2,
+        published_only: bool = True
+    ) -> 'Query[News]':
+
+        return self.news_query_for(self, limit, published_only)
 
     @property
     def all_years(self) -> list[int]:

--- a/src/onegov/org/request.py
+++ b/src/onegov/org/request.py
@@ -155,7 +155,7 @@ class OrgRequest(CoreRequest):
             return self.has_role(*roles)
         return ticket.handler_code in (self.app.org.ticket_auto_accepts or ())
 
-    @orm_cached(policy='on-table-change:pages')
+    @orm_cached(policy='on-table-change:pages', by_role=True)
     def pages_tree(self) -> tuple[PageMeta, ...]:
         """
         This is the entire pages tree preloaded into the individual
@@ -205,7 +205,7 @@ class OrgRequest(CoreRequest):
         # the child pages
         return generate_subtree(None, None)
 
-    @orm_cached(policy='on-table-change:pages')
+    @orm_cached(policy='on-table-change:pages', by_role=True)
     def root_pages(self) -> tuple[PageMeta, ...]:
 
         def include(page: PageMeta) -> bool:
@@ -216,7 +216,7 @@ class OrgRequest(CoreRequest):
 
         return tuple(p for p in self.pages_tree if include(p))
 
-    @orm_cached(policy='on-table-change:pages')
+    @orm_cached(policy='on-table-change:pages', by_role=True)
     def homepage_pages(self) -> dict[int, list[PageMeta]]:
 
         def visit_topics(

--- a/src/onegov/org/request.py
+++ b/src/onegov/org/request.py
@@ -1,15 +1,41 @@
 from functools import cached_property
+from onegov.core.orm import orm_cached
 from onegov.core.request import CoreRequest
 from onegov.core.security import Private
-from onegov.org.models import TANAccessCollection
+from onegov.core.utils import normalize_for_url
+from onegov.org.models import News, TANAccessCollection, Topic
+from onegov.page import Page, PageCollection
 from onegov.user import User
 from sedate import utcnow
+from sqlalchemy.orm import noload
 
 
-from typing import TYPE_CHECKING
+from typing import Any, NamedTuple, TYPE_CHECKING
 if TYPE_CHECKING:
+    from collections.abc import Generator, Iterable
     from onegov.org.app import OrgApp
     from onegov.ticket import Ticket
+
+
+class PageMeta(NamedTuple):
+    id: int
+    type: str
+    title: str
+    access: str
+    is_visible_on_homepage: bool | None
+    children: tuple['PageMeta', ...]
+
+    def link(
+        self,
+        request: 'OrgRequest',
+        variables: dict[str, Any] | None = None,
+        name: str = '',
+    ) -> str:
+        return request.class_link(
+            Topic if self.type == 'topic' else News,
+            variables,
+            name
+        )
 
 
 class OrgRequest(CoreRequest):
@@ -122,3 +148,85 @@ class OrgRequest(CoreRequest):
                 return False
             return self.has_role(*roles)
         return ticket.handler_code in (self.app.org.ticket_auto_accepts or ())
+
+    @orm_cached(policy='on-table-change:pages')
+    def pages_tree(self) -> tuple[PageMeta, ...]:
+        """
+        This is the entire pages tree preloaded into the individual
+        parent/children attributes. We optimize this as much as possible
+        by performing the recursive join in Python, rather than SQL.
+
+        """
+        query = PageCollection(self.session).query(ordered=False)
+        query = query.options(
+            # we populate these relationship ourselves
+            noload(Page.parent),
+            noload(Page.children),
+        )
+        query = query.order_by(Page.order)
+
+        # first we build a map from parent_ids to their children
+        parent_to_child: dict[int | None, list[Page]] = {}
+        for page in query:
+            parent_to_child.setdefault(page.parent_id, []).append(page)
+
+
+        def generate_subtree(parent_id: int | None) -> tuple[PageMeta, ...]:
+            return tuple(
+                PageMeta(
+                    id=page.id,
+                    type=page.type,
+                    title=page.title,
+                    access=page.meta.get('access', 'public'),
+                    is_visible_on_homepage=page.meta.get('is_visible_on_homepage'),
+                    children=tuple(generate_subtree(page.id))
+                )
+                for page in parent_to_child.get(parent_id, ())
+                if self.is_visible(page)
+                if self.is_manager or getattr(page, 'published', True)
+            )
+
+        # we return the root pages which should contain references to all
+        # the child pages
+        return generate_subtree(None)
+
+    @orm_cached(policy='on-table-change:pages')
+    def root_pages(self) -> tuple[PageMeta, ...]:
+
+        def include(page: PageMeta) -> bool:
+            if page.type != 'news':
+                return True
+
+            return True if page.children else False
+
+        return tuple(p for p in self.pages_tree if include(p))
+
+    @orm_cached(policy='on-table-change:pages')
+    def homepage_pages(self) -> dict[int, list[PageMeta]]:
+
+        def visit_topics(
+            pages: 'Iterable[PageMeta]',
+            root_id: int | None = None
+        ) -> 'Generator[tuple[int, PageMeta]]':
+            for page in pages:
+                if page.type != 'topic':
+                    continue
+
+                if root_id is not None and page.is_visible_on_homepage:
+                    yield root_id, page
+
+                yield from visit_topics(
+                    page.children,
+                    root_id=root_id or page.id
+                )
+
+        result: dict[int, list[PageMeta]] = {}
+        for root_id, meta in visit_topics(self.root_pages):
+            result.setdefault(root_id, []).append(meta)
+
+        for topics in result.values():
+            topics.sort(
+                key=lambda p: normalize_for_url(p.title)
+            )
+
+        return result

--- a/src/onegov/org/request.py
+++ b/src/onegov/org/request.py
@@ -22,6 +22,7 @@ class PageMeta(NamedTuple):
     type: str
     title: str
     access: str
+    published: bool
     is_visible_on_homepage: bool | None
     path: str
     children: tuple['PageMeta', ...]
@@ -186,6 +187,7 @@ class OrgRequest(CoreRequest):
                     type=page.type,
                     title=page.title,
                     access=page.meta.get('access', 'public'),
+                    published=published,
                     path=(
                         subpath := page.name
                         if path is None else f'{path}/{page.name}'
@@ -195,7 +197,8 @@ class OrgRequest(CoreRequest):
                 )
                 for page in parent_to_child.get(parent_id, ())
                 if self.is_visible(page)
-                if self.is_manager or getattr(page, 'published', True)
+                if (published := getattr(page, 'published', True))
+                or self.is_manager
             )
 
         # we return the root pages which should contain references to all

--- a/src/onegov/org/views/editor.py
+++ b/src/onegov/org/views/editor.py
@@ -268,14 +268,10 @@ def handle_change_page_url(
             #        a change in the pages tables, which in turn
             #        will clear these caches. But I suppose it doesn't
             #        hurt to clear them twice...
-            request.app.cache.delete_multi([
-                getattr(request.__class__, prop_name).used_cache_keys
-                for prop_name in (
-                    'root_pages',
-                    'pages_tree',
-                    'homepage_pages'
-                )
-            ])
+            for prop_name in ('root_pages', 'pages_tree', 'homepage_pages'):
+                prop = getattr(request.__class__, prop_name)
+                for cache_key in prop.used_cache_keys:
+                    request.app.cache.delete(cache_key)
             request.success(_('Your changes were saved'))
 
             @request.after

--- a/src/onegov/org/views/editor.py
+++ b/src/onegov/org/views/editor.py
@@ -263,9 +263,19 @@ def handle_change_page_url(
         migration = PageNameChange.from_form(page, form)
         link_count = migration.execute(test=form['test'].data)
         if not form['test'].data:
-            request.app.cache.delete(
-                f'{request.app.application_id}.root_pages'
-            )
+            # FIXME: I am not sure this is actually necessary
+            #        the execution of the migration should cause
+            #        a change in the pages tables, which in turn
+            #        will clear these caches. But I suppose it doesn't
+            #        hurt to clear them twice...
+            request.app.cache.delete_multi([
+                getattr(request.__class__, prop_name).used_cache_keys
+                for prop_name in (
+                    'root_pages',
+                    'pages_tree',
+                    'homepage_pages'
+                )
+            ])
             request.success(_('Your changes were saved'))
 
             @request.after

--- a/src/onegov/pay/integration.py
+++ b/src/onegov/pay/integration.py
@@ -1,6 +1,6 @@
 from enum import IntEnum
 from more.webassets import WebassetsApp
-from onegov.core.orm import orm_cached
+from onegov.core.cache import request_cached
 from onegov.pay import log
 from onegov.pay import PaymentProvider
 from onegov.pay.errors import CARD_ERRORS
@@ -64,7 +64,9 @@ class PayApp(WebassetsApp):
 
         self.payment_provider_defaults = payment_provider_defaults or {}
 
-    @orm_cached(policy='on-table-change:payment_providers')
+    # NOTE: This is another model where we could probably get away with a
+    #       more long-term cache, but again, we have to prove it's worth it
+    @request_cached  # type:ignore[type-var]
     def default_payment_provider(self) -> PaymentProvider[Any] | None:
         return self.session().query(PaymentProvider).filter(
             PaymentProvider.default.is_(True),

--- a/src/onegov/pay/integration.py
+++ b/src/onegov/pay/integration.py
@@ -1,6 +1,6 @@
 from enum import IntEnum
 from more.webassets import WebassetsApp
-from onegov.core.cache import request_cached
+from onegov.core.orm.cache import request_cached
 from onegov.pay import log
 from onegov.pay import PaymentProvider
 from onegov.pay.errors import CARD_ERRORS

--- a/src/onegov/town6/layout.py
+++ b/src/onegov/town6/layout.py
@@ -63,7 +63,7 @@ from onegov.org.layout import (
     UserGroupLayout as OrgUserGroupLayout,
     UserGroupCollectionLayout as OrgUserGroupCollectionLayout,
     UserManagementLayout as OrgUserManagementLayout)
-from onegov.org.models import News, PageMove
+from onegov.org.models import PageMove
 from onegov.org.models.directory import ExtendedDirectoryEntryCollection
 from onegov.page import PageCollection
 from onegov.stepsequence import step_sequences
@@ -80,6 +80,7 @@ if TYPE_CHECKING:
     from onegov.form.models.definition import SurveyDefinition
     from onegov.form.models.submission import SurveySubmission
     from onegov.org.models import ExtendedDirectoryEntry
+    from onegov.org.request import PageMeta
     from onegov.page import Page
     from onegov.reservation import Resource
     from onegov.ticket import Ticket
@@ -88,7 +89,7 @@ if TYPE_CHECKING:
     from typing import TypeAlias
 
     NavigationEntry: TypeAlias = tuple[
-        Page,
+        PageMeta,
         Link,
         tuple['NavigationEntry', ...]
     ]
@@ -195,19 +196,20 @@ class DefaultLayout(OrgDefaultLayout, Layout):
         request: TownRequest
         def __init__(self, model: Any, request: TownRequest) -> None: ...
 
-    @property
+    @cached_property
     def top_navigation(self) -> tuple['NavigationEntry', ...]:  # type:ignore
 
-        def yield_children(page: 'Page') -> 'NavigationEntry':
-            if not isinstance(page, News):
+        def yield_children(page: 'PageMeta') -> 'NavigationEntry':
+            if page.type != 'news':
                 children = tuple(
                     yield_children(p)
-                    for p in self.exclude_invisible(page.children)
+                    for p in page.children
                 )
             else:
                 children = ()
             return (
-                page, Link(page.title, self.request.link(page)),
+                page,
+                Link(page.title, page.link(self.request)),
                 children
             )
 

--- a/tests/onegov/agency/test_app.py
+++ b/tests/onegov/agency/test_app.py
@@ -13,6 +13,7 @@ class DummyRequest():
     is_logged_in = False
     is_manager = False
     is_admin = False
+    root_pages = ()
     current_user = Bunch(id=Bunch(hex='abcd'))
     path = ''
     url = ''
@@ -30,7 +31,7 @@ class DummyRequest():
         pass
 
     def exclude_invisible(self, items):
-        return []
+        return
 
 
 def test_app_custom(agency_app):

--- a/tests/onegov/core/test_orm.py
+++ b/tests/onegov/core/test_orm.py
@@ -22,7 +22,7 @@ from onegov.core.orm.mixins import dict_property
 from onegov.core.orm.mixins import dict_markup_property
 from onegov.core.orm.mixins import ContentMixin
 from onegov.core.orm.mixins import TimestampMixin
-from onegov.core.orm import orm_cached
+from onegov.core.orm import orm_cached, request_cached
 from onegov.core.orm.types import HSTORE, JSON, UTCDateTime, UUID
 from onegov.core.orm.types import LowercaseText, MarkupText
 from onegov.core.security import Private
@@ -1458,7 +1458,10 @@ def test_orm_cache(postgres_dsn, redis_url):
 
         @orm_cached(policy='on-table-change:documents')
         def documents(self):
-            return self.session().query(Document)
+            return self.session().query(Document).with_entities(
+                Document.id,
+                Document.title
+            )
 
         @orm_cached(policy='on-table-change:documents')
         def untitled_documents(self):
@@ -1478,12 +1481,11 @@ def test_orm_cache(postgres_dsn, redis_url):
         @orm_cached(policy=lambda o: o.title == 'Secret')
         def secret_document(self):
             q = self.session().query(Document)
+            q = q.with_entities(Document.id)
             q = q.filter(Document.title == 'Secret')
 
-            return q.first()
-
-    # get dill to pickle the following inline class
-    global Document
+            doc = q.first()
+            return doc.id if doc else None
 
     class Document(Base):
         __tablename__ = 'documents'
@@ -1545,35 +1547,174 @@ def test_orm_cache(postgres_dsn, redis_url):
     assert app.secret_document is None
     assert app.first_document.title == 'Public'
     assert app.untitled_documents == []
-    assert app.documents[0].body == 'Lorem Ipsum'
+    assert app.documents[0].title == 'Public'
 
     # if we add a secret document all caches change
     app.session().add(Document(id=2, title='Secret', body='Geheim'))
     transaction.commit()
 
     assert app.request_cache == {}
-    assert app.secret_document.body == "Geheim"
+    assert app.secret_document == 2
     assert app.first_document.title == 'Public'
     assert app.untitled_documents == []
     assert len(app.documents) == 2
 
+
+def test_orm_cache_flush(postgres_dsn, redis_url):
+
+    Base = declarative_base(cls=ModelBase)
+
+    class App(Framework):
+
+        @property
+        def foo(self):
+            return self.session().query(Document).one()
+
+        @orm_cached(policy='on-table-change:documents')
+        def bar(self):
+            return self.session().query(Document)\
+                .with_entities(Document.title).one()
+
+    class Document(Base):
+        __tablename__ = 'documents'
+
+        id = Column(Integer, primary_key=True)
+        title = Column(Text, nullable=True)
+
+    scan_morepath_modules(App)
+
+    app = App()
+    app.namespace = 'foo'
+    app.configure_application(
+        dsn=postgres_dsn,
+        base=Base,
+        redis_url=redis_url
+    )
+    # remove ORMBase
+    app.session_manager.bases.pop()
+    app.set_application_id('foo/bar')
+    app.clear_request_cache()
+
+    app.session().add(Document(id=1, title='Yo'))
+    transaction.commit()
+
+    # both instances get cached
+    assert app.foo.title == 'Yo'
+    assert app.bar.title == 'Yo'
+
+    # one instance changes without an explicit flush
+    app.foo.title = 'Sup'
+
+    # accessing the bar instance *first* fetches it from the cache which at
+    # this point would contain stale entries because we didn't flush explicitly
+    # but thanks to our autoflush mechanism this doesn't happen
+    assert app.session().dirty
+    assert app.bar.title == 'Sup'
+    assert app.foo.title == 'Sup'
+
+
+def test_request_cache(postgres_dsn, redis_url):
+
+    Base = declarative_base(cls=ModelBase)
+
+    class App(Framework):
+
+        @request_cached
+        def untitled_documents(self):
+            q = self.session().query(Document)
+            q = q.with_entities(Document.id, Document.title)
+            q = q.filter(Document.title == None)
+
+            return q.all()
+
+        @request_cached
+        def first_document(self):
+            q = self.session().query(Document)
+            q = q.with_entities(Document.id, Document.title)
+
+            return q.first()
+
+        @request_cached
+        def secret_document(self):
+            q = self.session().query(Document)
+            q = q.filter(Document.title == 'Secret')
+
+            return q.first()
+
+    # get dill to pickle the following inline class
+    global Document
+
+    class Document(Base):
+        __tablename__ = 'documents'
+
+        id = Column(Integer, primary_key=True)
+        title = Column(Text, nullable=True)
+        body = Column(Text, nullable=True)
+
+    # this is required for the transactions to actually work, usually this
+    # would be onegov.server's job
+    scan_morepath_modules(App)
+
+    app = App()
+    app.namespace = 'foo'
+    app.configure_application(
+        dsn=postgres_dsn,
+        base=Base,
+        redis_url=redis_url
+    )
+    # remove ORMBase
+    app.session_manager.bases.pop()
+    app.set_application_id('foo/bar')
+
+    # ensure that no results work
+    app.clear_request_cache()
+    assert app.untitled_documents == []
+    assert app.first_document is None
+    assert app.secret_document is None
+
+    assert app.request_cache == {
+        'test_request_cache.<locals>.App.first_document': None,
+        'test_request_cache.<locals>.App.secret_document': None,
+        'test_request_cache.<locals>.App.untitled_documents': []
+    }
+
+    app.session().add(Document(id=1, title='Public', body='Lorem Ipsum'))
+    app.session().add(Document(id=2, title='Secret', body='Geheim'))
+    transaction.commit()
+    # no influence on same request
+    assert app.request_cache == {
+        'test_request_cache.<locals>.App.first_document': None,
+        'test_request_cache.<locals>.App.secret_document': None,
+        'test_request_cache.<locals>.App.untitled_documents': []
+    }
+    assert app.untitled_documents == []
+    assert app.first_document is None
+    assert app.secret_document is None
+    app.clear_request_cache()
+
+    assert app.request_cache == {}
+    assert app.secret_document.body == "Geheim"
+    assert app.first_document.title == 'Public'
+    assert app.untitled_documents == []
+
     # if we change something in a cached object it is reflected
+    # in the next request
     app.secret_document.title = None
     transaction.commit()
 
-    assert 'test_orm_cache.<locals>.App.secret_document' in app.request_cache
-    assert app.untitled_documents[0].title is None
-
     # the object in the request cache is now detached
     with pytest.raises(DetachedInstanceError):
-        key = 'test_orm_cache.<locals>.App.secret_document'
+        key = 'test_request_cache.<locals>.App.secret_document'
         assert app.request_cache[key].title
 
     # which we transparently undo
     assert app.secret_document.title is None
 
+    app.clear_request_cache()
+    assert app.untitled_documents[0].title is None
 
-def test_orm_cache_flush(postgres_dsn, redis_url):
+
+def test_request_cache_flush(postgres_dsn, redis_url):
 
     Base = declarative_base(cls=ModelBase)
 
@@ -1622,7 +1763,7 @@ def test_orm_cache_flush(postgres_dsn, redis_url):
     app.foo.title = 'Sup'
 
     # accessing the bar instance *first* fetches it from the cache which at
-    # this point would contain stale entries because we didn't flush eplicitly,
+    # this point would contain stale entries because we didn't flush explicitly
     # but thanks to our autoflush mechanism this doesn't happen
     assert app.session().dirty
     assert app.bar.title == 'Sup'

--- a/tests/onegov/org/test_cronjobs.py
+++ b/tests/onegov/org/test_cronjobs.py
@@ -1262,8 +1262,10 @@ def test_delete_content_marked_deletable__events_occurrences(org_app,
 
         # switch setting and see if past events and past occurrences are
         # deleted
+        transaction.begin()
         org_app.org.delete_past_events = True
-        assert org_app.org.delete_past_events is True
+        transaction.commit()
+        close_all_sessions()
 
         client.get(get_cronjob_url(job))
         assert count_events() == 1

--- a/tests/onegov/org/test_cronjobs.py
+++ b/tests/onegov/org/test_cronjobs.py
@@ -23,6 +23,7 @@ from onegov.newsletter import NewsletterCollection, RecipientCollection
 from onegov.reservation import ResourceCollection
 from onegov.user.collections import TANCollection
 from sedate import ensure_timezone, utcnow
+from sqlalchemy.orm import close_all_sessions
 from tests.onegov.org.common import get_cronjob_by_name, get_cronjob_url
 from tests.shared import Client
 from tests.shared.utils import add_reservation
@@ -796,17 +797,15 @@ def test_auto_archive_tickets_and_delete(org_app, handlers):
             t.accept_ticket(user)
             t.close_ticket()
 
-        transaction.commit()
-
-    # now we go forward a month for archival
-    with freeze_time('2022-09-17 04:30'):
         org_app.org.auto_archive_timespan = 30  # days
         org_app.org.auto_delete_timespan = 30  # days
 
-        session.flush()
-        # without this assert, the values are somehow not set?
-        assert org_app.org.auto_archive_timespan
-        assert org_app.org.auto_delete_timespan
+        transaction.commit()
+
+        close_all_sessions()
+
+    # now we go forward a month for archival
+    with freeze_time('2022-09-17 04:30'):
 
         query = session.query(Ticket)
         query = query.filter_by(state='closed')
@@ -816,6 +815,10 @@ def test_auto_archive_tickets_and_delete(org_app, handlers):
         job.app = org_app
         client = Client(org_app)
         client.get(get_cronjob_url(job))
+
+        query = session.query(Ticket)
+        query = query.filter(Ticket.state == 'archived')
+        assert query.count() == 2
 
         # this delete cronjob should have no effect (yet), since archiving
         # resets the `last_change`
@@ -895,17 +898,15 @@ def test_respect_recent_reservation_for_archive(org_app, handlers):
             ticket.accept_ticket(user)
             ticket.close_ticket()
 
+        org_app.org.auto_archive_timespan = 365  # days
+        org_app.org.auto_delete_timespan = 365  # days
+
         transaction.commit()
+
+        close_all_sessions()
 
     # now go forward a year
     with freeze_time('2023-06-06 02:00'):
-        org_app.org.auto_archive_timespan = 365  # days
-        org_app.org.auto_delete_timespan = 365  # days
-        org_app.session().flush()
-
-        # without this assert, the values are somehow not set?
-        assert org_app.org.auto_archive_timespan
-        assert org_app.org.auto_delete_timespan
 
         q = TicketCollection(org_app.session()).query()
         assert q.filter_by(state='open').count() == 0
@@ -1103,6 +1104,7 @@ def test_delete_content_marked_deletable__directory_entries(org_app, handlers):
     event.delete_when_expired = True
 
     transaction.commit()
+    close_all_sessions()
 
     def count_publications(directories):
         applications = directories.by_name('offentliche-planauflage')
@@ -1173,6 +1175,7 @@ def test_delete_content_marked_deletable__news(org_app, handlers):
     two.delete_when_expired = True
 
     transaction.commit()
+    close_all_sessions()
 
     def count_news():
         c = PageCollection(org_app.session()).query()
@@ -1230,6 +1233,7 @@ def test_delete_content_marked_deletable__events_occurrences(org_app,
     event.publish()
 
     transaction.commit()
+    close_all_sessions()
 
     def count_events():
         return (EventCollection(org_app.session()).query()

--- a/tests/onegov/town6/test_views_news.py
+++ b/tests/onegov/town6/test_views_news.py
@@ -193,19 +193,19 @@ def test_news_overview_detail(client):
     page.form['title'] = "Bar"
     page.form['lead'] = "Lorem"
     page.form['publication_start'] = '2020-04-01T00:00'
-    page.form.submit()
+    page.form.submit().follow()
 
     page = news_list.click('Nachricht')
     page.form['title'] = "Zap"
     page.form['lead'] = "Lorem"
     page.form['publication_start'] = '2020-03-01T00:00'
-    page.form.submit()
+    page.form.submit().follow()
 
     page = news_list.click('Nachricht')
     page.form['title'] = "One"
     page.form['lead'] = "Lorem"
     page.form['publication_start'] = '2020-02-01T00:00'
-    page.form.submit()
+    page.form.submit().follow()
 
     news_list = client.get('/news')
     news_detail = news_list.click('Foo')


### PR DESCRIPTION
## Commit message

Org: Avoids storing ORM objects in `orm_cached` properties

This should improve reliability and should introduce less flaky behavior caused by incorrect merges of objects into the session.

TYPE: Bugfix
LINK: OGC-1813

## Checklist

- [x] I have performed a self-review of my code
- [x] I have tested my code thoroughly by hand
- [x] I have added tests for my changes/features
