### PR TITLE
Core: Improves performance of `orm_cached` with an in-memory cache

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,7 +6,7 @@ Please fill in the commit message below and work through the checklist. You can 
 
 <Optional Description>
 
-TYPE: <Feature|Bugfix>
+TYPE: <Feature|Performance|Bugfix>
 LINK: <Ticket-Number>
 HINT: <Optional upgrade hint>
 

--- a/do/changes
+++ b/do/changes
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
     from git.objects.tag import TagObject
     from git.repo import Repo
     from git.types import PathLike
-    from typing_extensions import Self
+    from typing import Self
 
 
 COMMIT_HEADER = re.compile(r'^[A-Z]{1}[A-Za-z6_\- ]{2,18}: ')
@@ -160,22 +160,22 @@ class ChangelogCommit:
             )
 
         if link.startswith('STAKA-'):
-            return f"https://ogc-ar.atlassian.net/projects/STAKA/issues/{link}"
+            return f'https://ogc-ar.atlassian.net/projects/STAKA/issues/{link}'
 
         if link.startswith('STAKABS-'):
-            return f"https://kt-bs.atlassian.net/browse/{link}"
+            return f'https://kt-bs.atlassian.net/browse/{link}'
 
         if link.startswith('SEA-'):
-            return f"https://linear.app/seantis/issue/{link}"
+            return f'https://linear.app/seantis/issue/{link}'
 
         if link.startswith('OGC-'):
-            return f"https://linear.app/onegovcloud/issue/{link}"
+            return f'https://linear.app/onegovcloud/issue/{link}'
 
         if link.startswith('SWI-'):
-            return f"https://linear.app/swissvotes/issue/{link}"
+            return f'https://linear.app/swissvotes/issue/{link}'
 
         if link.startswith('PRO-'):
-            return f"https://linear.app/projuventute/issue/{link}"
+            return f'https://linear.app/projuventute/issue/{link}'
 
         # default to a non-functioning link (they can be added later)
         return f'#{self.link}'
@@ -217,7 +217,7 @@ def release_date(tag: 'TagObject') -> 'datetime':
 
 
 def format_datetime(dt: 'date | datetime') -> str:
-    return dt.strftime("%Y-%m-%d")
+    return dt.strftime('%Y-%m-%d')
 
 
 def changelog(folder: 'PathLike', new: str) -> None:
@@ -230,22 +230,22 @@ def changelog(folder: 'PathLike', new: str) -> None:
     )
 
     # header
-    print("# Changes")
-    print("")
+    print('# Changes')
+    print('')
 
     # not yet released
     if new == 'Unreleased':
-        print("## Unreleased")
+        print('## Unreleased')
     else:
         print(f"## {new.rsplit('-', 1)[-1]}")
-    print("")
+    print('')
     changelog_commits(new, repository, repository.head.commit, tags[0].commit,
                       date.today())
 
     # last 50 releases (the last version is not included by design)
     for newer, older in pairwise(tags[:50]):
-        print(f"## {release_number(newer)}")
-        print("")
+        print(f'## {release_number(newer)}')
+        print('')
 
         changelog_commits(newer.name, repository, newer.commit, older.commit,
                           release_date(newer))
@@ -263,16 +263,16 @@ def changelog_commits(
 
     # quit if there are no commits
     if not commit_objs:
-        print("No changes since last release")
-        print("")
+        print('No changes since last release')
+        print('')
         return
 
     # print the release overview
     lo = commit_objs[0].hexsha[:10]
     hi = commit_objs[-1].hexsha[:10]
     url = f'https://github.com/OneGov/onegov-cloud/compare/{lo}^...{hi}'
-    print(f"`{format_datetime(release_date)}` | [{lo}...{hi}]({url})")
-    print("")
+    print(f'`{format_datetime(release_date)}` | [{lo}...{hi}]({url})')
+    print('')
 
     # parse the commit messages
     commits = [
@@ -282,38 +282,38 @@ def changelog_commits(
 
     hints = [commit.hint for commit in commits if commit.hint]
     if hints:
-        print("**Upgrade hints**")
+        print('**Upgrade hints**')
         for hint in hints:
-            print(f"- {hint}")
+            print(f'- {hint}')
 
     # sort the result by name and type
     commits.sort(key=lambda k: (k.module, k.type_order))
 
     # print the resulting information
     for module, commit in groupby(commits, key=attrgetter('module')):
-        print(f"### {module}")
-        print("")
+        print(f'### {module}')
+        print('')
 
         for c in commit:
-            print(f"##### {c.title}")
-            print("")
+            print(f'##### {c.title}')
+            print('')
 
             if c.note:
                 print(c.note)
-                print("")
+                print('')
 
-            print(f"`{c.type}`", end='')
+            print(f'`{c.type}`', end='')
 
             if c.link:
-                print(f" | [{c.link}]({c.link_url})", end='')
+                print(f' | [{c.link}]({c.link_url})', end='')
 
-            print(f" | [{c.short}]({c.url})")
-            print("")
+            print(f' | [{c.short}]({c.url})')
+            print('')
 
 
 if __name__ == '__main__':
     if len(sys.argv) == 1:
-        new = "Unreleased"
+        new = 'Unreleased'
     else:
         new = sys.argv[1]
 

--- a/src/onegov/core/framework.py
+++ b/src/onegov/core/framework.py
@@ -131,6 +131,11 @@ class Framework(
 
     #: the schema cache stays around for the entire runtime of the
     #: application, but is switched, each time the schema changes
+    # NOTE: This cache should never be used to store ORM objects
+    #       In addition this should generally be backed by a Redis
+    #       cache to make sure the cache is synchronized between
+    #       all processes. Although there may be some cases where
+    #       it makes sense to use this cache on its own
     schema_cache: dict[str, Any]
     _all_schema_caches: dict[str, Any]
 

--- a/src/onegov/core/framework.py
+++ b/src/onegov/core/framework.py
@@ -129,6 +129,11 @@ class Framework(
     #: the request cache is initialised/emptied before each request
     request_cache: dict[str, Any]
 
+    #: the schema cache stays around for the entire runtime of the
+    #: application, but is switched, each time the schema changes
+    schema_cache: dict[str, Any]
+    _all_schema_caches: dict[str, Any]
+
     @property
     def version(self) -> str:
         from onegov.core import __version__
@@ -666,6 +671,10 @@ class Framework(
         # then, replace the '/' with a '-' so the only dash left will be
         # the dash between namespace and id
         self.schema = application_id.replace('-', '_').replace('/', '-')
+        if not hasattr(self, '_all_schema_caches'):
+            self._all_schema_caches = {}
+
+        self.schema_cache = self._all_schema_caches.setdefault(self.schema, {})
 
         if self.has_database_connection:
             ScopedPropertyObserver.enter_scope(self)

--- a/src/onegov/core/orm/cache.py
+++ b/src/onegov/core/orm/cache.py
@@ -323,6 +323,14 @@ class OrmCacheDescriptor(Generic[_T]):
         # we use a secondary in-memory cache for more lookup speed
         ts, obj = app.schema_cache.get(cache_key, (float('-Inf'), unset))
         if obj is unset or ts != app.cache.get(key=ts_key):
+            # NOTE: Ideally we would create these values as a pair
+            #       but then we would have to start circumventing
+            #       most of dogpile's API, at which point we may
+            #       as well just use raw Redis, which would give us
+            #       even better possibilities.
+            #       A data race isn't really harmful here, but it is
+            #       kind of inefficient that we're sending two separate
+            #       Redis commands, when one would suffice.
             obj = app.cache.get_or_create(
                 key=cache_key,
                 creator=lambda: self.create(instance)

--- a/src/onegov/core/orm/cache.py
+++ b/src/onegov/core/orm/cache.py
@@ -27,6 +27,7 @@ from functools import wraps
 from libres.db.models import ORMBase
 from onegov.core.orm.utils import maybe_merge
 from sqlalchemy.orm.query import Query
+from time import time
 
 
 from typing import cast, overload, Any, Generic, TypeVar, TYPE_CHECKING
@@ -83,6 +84,7 @@ if TYPE_CHECKING:
 
 _T = TypeVar('_T')
 _QT = TypeVar('_QT')
+unset = object()
 
 
 class OrmCacheApp:
@@ -103,6 +105,7 @@ class OrmCacheApp:
         def cache(self) -> RedisCacheRegion: ...
         request_cache: dict[str, Any]
         request_class: type[Request]
+        schema_cache: dict[str, Any]
 
     def configure_orm_cache(self, **cfg: Any) -> None:
         self.is_orm_cache_setup = getattr(self, 'is_orm_cache_setup', False)
@@ -163,6 +166,13 @@ class OrmCacheApp:
                 assert self.schema == schema
                 for cache_key in descriptor.used_cache_keys:
                     self.cache.delete(cache_key)
+                    # NOTE: We also need to delete the timestamp, so we don't
+                    #       get stuck on an old timestamp forever, we use
+                    #       get_or_create for the timestamp below in order to
+                    #       avoid data races in cache invalidation
+                    self.cache.delete(f'{cache_key}_ts')
+                    if cache_key in self.schema_cache:
+                        del self.schema_cache[cache_key]
                     if cache_key in self.request_cache:
                         del self.request_cache[cache_key]
 
@@ -297,17 +307,37 @@ class OrmCacheDescriptor(Generic[_T]):
         cache_key = self.cache_key(instance)
         self.used_cache_keys.add(cache_key)
 
-        # we use a secondary request cache for even more lookup speed and to
+        # we use a tertiary request cache for even more lookup speed and to
         # make sure that inside a request we always get the exact same instance
         # (otherwise we don't see changes reflected)
         if cache_key in app.request_cache:
             return app.request_cache[cache_key]
 
-        else:
+        # we separately store when the redis cache was last populated
+        # so we can detect when we need to invalidate the memory cache
+        # dogpile has its own time metadata, but we can't retrieve it
+        # without paying the deserialization overhead, defeating the
+        # entire purpose of this secondary cache
+        ts_key = f'{cache_key}_ts'
+
+        # we use a secondary in-memory cache for more lookup speed
+        ts, obj = app.schema_cache.get(cache_key, (float('-Inf'), unset))
+        if obj is unset or ts != app.cache.get(key=ts_key):
             obj = app.cache.get_or_create(
                 key=cache_key,
                 creator=lambda: self.create(instance)
             )
+            ts = app.cache.get_or_create(
+                key=ts_key,
+                # NOTE: There are some corner-cases where time can lead
+                #       to incorrect cache-invalidation, but we can't use
+                #       monotonic, since that will not lead to a meaningful
+                #       comparison between different processes, dogpile
+                #       also uses time for its own cache invalidation, so
+                #       we should be fine
+                creator=time
+            )
+            app.schema_cache[cache_key] = (ts, obj)
 
         app.request_cache[cache_key] = obj
 


### PR DESCRIPTION
## Commit message

Core: Improves performance of `orm_cached` with an in-memory cache

This avoid deserialization overhead for potentially very large nested structures, such as the pages tree. While still properly invalidating the cache between multiple processes.

TYPE: Performance
LINK: OGC-1827

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes/features
