### PR TITLE
Don't linkify the leads in the form and survey overview

### DIFF
--- a/src/onegov/org/views/form_collection.py
+++ b/src/onegov/org/views/form_collection.py
@@ -96,7 +96,6 @@ def view_form_collection(
         lead = model.meta.get('lead')
         if not lead:
             lead = ''
-        lead = layout.linkify(lead)
         return lead
 
     # FIXME: Should the hint function be able to deal with ExternalLink?
@@ -152,7 +151,6 @@ def view_survey_collection(
         lead = model.meta.get('lead')
         if not lead:
             lead = ''
-        lead = layout.linkify(lead)
         return lead
 
     return {


### PR DESCRIPTION
Please fill in the commit message below and work through the checklist. You can delete parts that are not needed, e.g. the optional description, the link to a ticket or irrelevant options of the checklist.

## Commit message

Town6: Don't linkify the leads in the form and survey overview

TYPE: Bugfix
LINK: OGC-1818