### PR TITLE
Form: Fixes `ExpectedExtensions` not working with `.mp3` file ending.

### DIFF
--- a/src/onegov/form/validators.py
+++ b/src/onegov/form/validators.py
@@ -38,6 +38,13 @@ if TYPE_CHECKING:
     from wtforms.form import BaseForm
 
 
+# HACK: We extend the default type map with additional entries for file endings
+#       that sometimes don't have a single agreed upon mimetype, we may need
+#       to do something more clever in the future and map single file endings
+#       to multiple mime types.
+types_map.setdefault('.mp3', 'audio/mpeg')
+
+
 class If(Generic[BaseFormT, FieldT]):
     """ Wraps a single validator or a list of validators, which will
     only be executed if the supplied condition callback returns `True`.

--- a/tests/onegov/form/test_validators.py
+++ b/tests/onegov/form/test_validators.py
@@ -1,6 +1,7 @@
 from onegov.core.orm import SessionManager
-from onegov.form.validators import (
-    InputRequiredIf, ValidSwissSocialSecurityNumber)
+from onegov.form.validators import ExpectedExtensions
+from onegov.form.validators import InputRequiredIf
+from onegov.form.validators import ValidSwissSocialSecurityNumber
 from onegov.form.validators import UniqueColumnValue
 from onegov.form.validators import ValidPhoneNumber
 from pytest import raises
@@ -182,3 +183,8 @@ def test_swiss_ssn_validator():
 
     with raises(ValidationError):
         validator(None, Field('756.1234.5678.7 '))
+
+
+def test_mp3_extension_nonempty_whitelist():
+    validator = ExpectedExtensions(['.mp3'])
+    assert validator.whitelist


### PR DESCRIPTION
## Commit message

Form: Fixes `ExpectedExtensions` not working with `.mp3` file ending.

TYPE: Bugfix
LINK: OGC-1795


## Checklist

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes/features
