### PR TITLE
Redesign the find your spot icon for better visibility

### DIFF
--- a/src/onegov/town6/templates/macros.pt
+++ b/src/onegov/town6/templates/macros.pt
@@ -2137,13 +2137,13 @@
     <tal:b repeat="group grouped" tal:define="link_func link_func|request.link; add_pagerefs add_pagerefs|False;">
         <tal:b tal:define="find_your_spot grouped[group][0] if grouped[group][0].title == 'Find Your Spot' else None">
             <a class="category-anchor" id="${group}"></a>
-            <h2 tal:condition="len(grouped) > 1">
-                ${group}
-                <metal:b tal:condition="add_pagerefs" use-macro="layout.macros['pageref']" tal:define="pageref_id group" />
-            <span tal:condition="find_your_spot" i18n:attributes="title" class="find-your-spot-link" data-tooltip tabindex="1" title="Find Your Spot">
-            <a tal:attributes="href link_func(find_your_spot)"><i class="fa fa-xs fa-calendar"></i></a>
-            </span>
-            </h2>
+            <div class="group-title align-justify">
+                <h2 tal:condition="len(grouped) > 1">
+                    ${group}
+                    <metal:b tal:condition="add_pagerefs" use-macro="layout.macros['pageref']" tal:define="pageref_id group" />
+                </h2>
+                <a tal:condition="find_your_spot" tal:attributes="href link_func(find_your_spot)" class="button hollow narrow find-your-spot-link"><i class="fa fa-calendar"></i> <span i18n:translate="">Find Your Spot</span></a>
+            </div>
             <ul class="forms-list more-list">
                 <tal:b tal:repeat="record grouped[group]">
                     <li tal:condition="record != find_your_spot">

--- a/src/onegov/town6/theme/styles/town6.scss
+++ b/src/onegov/town6/theme/styles/town6.scss
@@ -434,6 +434,15 @@ input[type="url"] {
         padding: 1rem 2rem !important;
         transition: all 200ms linear;
     }
+
+    &.narrow {
+        padding: .7rem 1rem !important;
+
+        &:hover {
+            padding: .7rem 1.5rem !important;
+        }
+    }
+
 }
 
 // like above, but no border, no hover effect
@@ -898,12 +907,24 @@ section#content th {
     text-align: left;
 }
 
-.find-your-spot-link {
-    border-bottom: 0 !important;
-    margin-left: 1rem;
+.group-title {
+    display: flex;
+    margin-top: 2rem;
+    align-items: center;
+
+    h2 {
+        margin-right: 1.5rem;
+    }
+}
+
+.button.hollow.find-your-spot-link {
+    margin-bottom: .5rem;
+    margin-top: .5rem;
+    height: fit-content;
+    white-space: nowrap;
 
     i {
-        margin-bottom: 2px;
+        margin-right: .5rem;
     }
 }
 


### PR DESCRIPTION
Please fill in the commit message below and work through the checklist. You can delete parts that are not needed, e.g. the optional description, the link to a ticket or irrelevant options of the checklist.

## Commit message

Town6: Redesign the find your spot option

TYPE: Feature
LINK: OGC-1831