### PR TITLE
Ogc 1668 timestamp via js

### DIFF
--- a/src/onegov/landsgemeinde/assets/js/agenda_items.js
+++ b/src/onegov/landsgemeinde/assets/js/agenda_items.js
@@ -1,11 +1,21 @@
 if ($('#current').length) {
-    const positionCurrent = $('#current').position().top - $('.agenda-item-list').position().top;
-    const listHeight = $('.agenda-item-list').height();
-    const currentHeight = $('#current').height();
+    if ($('#offCanvasSidebar').css('display') == 'none') {
+        const positionCurrent = $('.sidebar #current').position().top - $('.sidebar .agenda-item-list').position().top;
+        const listHeight = $('.sidebar .agenda-item-list').height();
+        const currentHeight = $('.sidebar #current').height();
 
-    $('.agenda-item-list').animate({
-    scrollTop: positionCurrent - listHeight/2 + currentHeight/2
-    })
+        $('.agenda-item-list').animate({
+            scrollTop: positionCurrent - listHeight/2 + currentHeight/2
+        });
+    } else {
+        const positionCurrent = $('#offCanvasSidebar #current').position().top - $('#offCanvasSidebar .agenda-item-list').position().top;
+        const listHeight = $('#offCanvasSidebar .agenda-item-list').height();
+        const currentHeight = $('#offCanvasSidebar #current').height();
+
+        $('.agenda-item-list').animate({
+            scrollTop: positionCurrent - listHeight/2 + currentHeight/2
+        });
+    }
 }
 
 $('.video-link a').on('click', function() {

--- a/src/onegov/landsgemeinde/assets/js/agenda_items.js
+++ b/src/onegov/landsgemeinde/assets/js/agenda_items.js
@@ -7,3 +7,11 @@ if ($('#current').length) {
     scrollTop: positionCurrent - listHeight/2 + currentHeight/2
     })
 }
+
+$('.video-link a').on('click', function() {
+    const timestamp = $(this).data('timestamp');
+    const iframe = document.querySelector('#assembly-video-iframe iframe');
+    var new_url = iframe.src.replace(/start=\d+/, `start=${timestamp}`);
+    new_url = new_url + '&autoplay=1&allow=autoplay&mute=0';
+    iframe.src = new_url;
+});

--- a/src/onegov/landsgemeinde/templates/agenda_item.pt
+++ b/src/onegov/landsgemeinde/templates/agenda_item.pt
@@ -11,7 +11,7 @@
             <div class="medium-7 cell main-content content">
                 <div class="video" tal:condition="video_url">
                     <h2 i18n:translate="" class="visually-hidden">Video</h2>
-                    <div class="videowrapper">
+                    <div class="videowrapper" id="assembly-video-iframe">
                         <iframe allow="fullscreen" width="100%" frameborder="0" src="${video_url}"></iframe>
                     </div>
                 </div>

--- a/src/onegov/landsgemeinde/templates/macros.pt
+++ b/src/onegov/landsgemeinde/templates/macros.pt
@@ -100,7 +100,7 @@
                 </ul>
             </div>
             <div class="video-link" tal:define="votum_timestamp (votum.video_timestamp or votum.calculated_timestamp)">
-                <a tal:condition="votum_timestamp" href="${append_query_param(request.url, 'start', timestamp_to_seconds(votum_timestamp))}">
+                <a tal:condition="votum_timestamp" data-timestamp="${timestamp_to_seconds(votum_timestamp)}" href="#content">
                     <i class="far fa-play-circle"></i>
                     <tal:b i18n:translate="">${votum_timestamp}</tal:b>
                 </a>

--- a/tests/onegov/landsgemeinde/test_views.py
+++ b/tests/onegov/landsgemeinde/test_views.py
@@ -117,7 +117,7 @@ def test_views(client_with_es):
     assert '<p>Nisi ut aliquip.</p>' in page
     assert '<p>Ex ea commodo consequat.</p>' in page
     assert '2m3s' in page
-    assert 'start=123' in page
+    assert 'data-timestamp="123"' in page
     assert_last_modified()
 
     # edit votum
@@ -128,7 +128,7 @@ def test_views(client_with_es):
         page = page.form.submit().follow()
     assert 'Joe Quimby' in page
     assert '1h2m5s' in page
-    assert 'start=3725' in page
+    assert 'data-timestamp="3725"' in page
     assert_last_modified()
 
     # open data


### PR DESCRIPTION
Please fill in the commit message below and work through the checklist. You can delete parts that are not needed, e.g. the optional description, the link to a ticket or irrelevant options of the checklist.

## Commit message

Landsgemeinde: Update timestamp in iframe via js

We now update the timestamp in the iframe video via js, which enables us to turn on autoplay without muting in certrain browsers.

TYPE: Feature
LINK: OGC-1668

## Checklist

- [x] I have performed a self-review of my code
- [x] I considered adding a reviewer
- [x] I have tested my code thoroughly by hand
    - [x] I have tested javascript changes/features on different browsers
- [ ] I have added tests for my changes/features
    - [ ] I considered using browser tests für javascript changes/features