### PR TITLE
Rearrange condition so enable_submissions gets checked

### DIFF
--- a/src/onegov/town6/templates/directory.pt
+++ b/src/onegov/town6/templates/directory.pt
@@ -132,8 +132,7 @@
                             </li>
                         </ul>
                     </div>
-
-                    <div class="side-panel" tal:condition="directory.enable_update_notifications|False or directory.enable_submissions">
+                    <div class="side-panel" tal:condition="directory.enable_submissions or directory.enable_update_notifications|False">
                         <h3 i18n:translate>Actions</h3>
                         <div class="side-panel-with-bg">
                             <ul class="more-list">
@@ -144,7 +143,7 @@
                                     </a>
                                 </li>
                                 <li class="icon-item" tal:condition="directory.enable_submissions">
-                                    <a class="list-link multi-line" href="${submit}">
+                                    <a class="list-link" href="${submit}">
                                         <i class="fa fa-folder-plus"></i>
                                         <span class="list-title" i18n:translate>Propose a new entry</span>
                                     </a>

--- a/src/onegov/town6/theme/styles/town6.scss
+++ b/src/onegov/town6/theme/styles/town6.scss
@@ -726,6 +726,7 @@ $pageref-color-hover: $iron;
         .list-title::after {
             opacity: 0;
             transition: all 200ms linear;
+            position: absolute;
         }
 
         &:hover .list-link::after,


### PR DESCRIPTION
Please fill in the commit message below and work through the checklist. You can delete parts that are not needed, e.g. the optional description, the link to a ticket or irrelevant options of the checklist.

## Commit message

Town6: Submissions for new entries

Rearrange condition so enable_submissions gets checked

TYPE: Bugfix
LINK: OGC-1929