### PR TITLE
Add direct phone or mobile number in people overview

### DIFF
--- a/src/onegov/town6/templates/macros.pt
+++ b/src/onegov/town6/templates/macros.pt
@@ -1041,6 +1041,9 @@
             <li tal:condition="person.phone and 'phone' not in exclude" class="person-card-phone">
                 <a href="tel:${person.phone}">${person.phone}</a>
             </li>
+            <li tal:condition="person.phone_direct and 'phone_direct' not in exclude" class="person-card-phone_direct">
+                <a href="tel:${person.phone_direct}">${person.phone_direct}</a>
+            </li>
         </ul>
         <a href="${link}"><i class="fa fa-chevron-right"></i></a>
     </div>


### PR DESCRIPTION
Please fill in the commit message below and work through the checklist. You can delete parts that are not needed, e.g. the optional description, the link to a ticket or irrelevant options of the checklist.

## Commit message

Town6: Add direct phone or mobile number in people overview

TYPE: Feature
LINK: OGC-1938