### PR TITLE
Adds translations Basel poster collection

### DIFF
--- a/src/onegov/swissvotes/locale/de_CH/LC_MESSAGES/onegov.swissvotes.po
+++ b/src/onegov/swissvotes/locale/de_CH/LC_MESSAGES/onegov.swissvotes.po
@@ -153,6 +153,9 @@ msgstr "eMuseum.ch"
 msgid "Social Archives"
 msgstr "Sozialarchiv"
 
+msgid "Basel Poster Collection"
+msgstr "Plakatsammlung Basel"
+
 msgid "No eMuseum API key available."
 msgstr "Kein eMuseum API Schlüssel verfügbar."
 
@@ -1539,6 +1542,9 @@ msgstr "Link eMuseum.ch"
 
 msgid "Link Social Archives"
 msgstr "Link Sozialarchiv"
+
+msgid "Link Basel Poster Collection"
+msgstr "Link Plakatsammlung Basel"
 
 msgid "Swissvotes database"
 msgstr "Swissvotes-Datenbank"

--- a/src/onegov/swissvotes/locale/en_US/LC_MESSAGES/onegov.swissvotes.po
+++ b/src/onegov/swissvotes/locale/en_US/LC_MESSAGES/onegov.swissvotes.po
@@ -150,6 +150,9 @@ msgstr "eMuseum.ch"
 msgid "Social Archives"
 msgstr "Social Archives"
 
+msgid "Basel Poster Collection"
+msgstr "Basel Poster Collection"
+
 msgid "No eMuseum API key available."
 msgstr "No eMuseum API key available."
 
@@ -1586,6 +1589,9 @@ msgstr "Link eMuseum.ch"
 
 msgid "Link Social Archives"
 msgstr "Link Social Archives"
+
+msgid "Link Basel Poster Collection"
+msgstr "Link Basel Poster Collection"
 
 msgid "Swissvotes database"
 msgstr "Swissvotes database"

--- a/src/onegov/swissvotes/locale/fr_CH/LC_MESSAGES/onegov.swissvotes.po
+++ b/src/onegov/swissvotes/locale/fr_CH/LC_MESSAGES/onegov.swissvotes.po
@@ -152,6 +152,9 @@ msgstr "eMuseum.ch"
 msgid "Social Archives"
 msgstr "Archives Sociales"
 
+msgid "Basel Poster Collection"
+msgstr "Lien Plakatsammlung Basel"
+
 msgid "No eMuseum API key available."
 msgstr "Aucune clé API eMuseum n’est disponible."
 
@@ -1544,6 +1547,9 @@ msgstr "Lien eMuseum.ch"
 
 msgid "Link Social Archives"
 msgstr "Lien Archives Sociales"
+
+msgid "Link Basel Poster Collection"
+msgstr "Lien Plakatsammmlung Basel"
 
 msgid "Swissvotes database"
 msgstr "Base de données Swissvotes"

--- a/src/onegov/swissvotes/models/vote.py
+++ b/src/onegov/swissvotes/models/vote.py
@@ -460,8 +460,8 @@ class SwissVote(Base, TimestampMixin, LocalizedFiles, ContentMixin):
         for key, attribute, label in (
             ('yea', 'posters_mfg_yea', _('Link eMuseum.ch')),
             ('nay', 'posters_mfg_nay', _('Link eMuseum.ch')),
-            ('yea', 'posters_bs_yea', _('Link Plakatsammlung Basel')),
-            ('nay', 'posters_bs_nay', _('Link Plakatsammlung Basel')),
+            ('yea', 'posters_bs_yea', _('Link Basel Poster Collection')),
+            ('nay', 'posters_bs_nay', _('Link Basel Poster Collection')),
             ('yea', 'posters_sa_yea', _('Link Social Archives')),
             ('nay', 'posters_sa_nay', _('Link Social Archives')),
         ):

--- a/src/onegov/swissvotes/models/vote.py
+++ b/src/onegov/swissvotes/models/vote.py
@@ -457,13 +457,14 @@ class SwissVote(Base, TimestampMixin, LocalizedFiles, ContentMixin):
     def posters(self, request: 'SwissvotesRequest') -> dict[str, list[Poster]]:
         result: dict[str, list[Poster]] = {'yea': [], 'nay': []}
 
+        # order: MfG, SA, BS
         for key, attribute, label in (
             ('yea', 'posters_mfg_yea', _('Link eMuseum.ch')),
             ('nay', 'posters_mfg_nay', _('Link eMuseum.ch')),
-            ('yea', 'posters_bs_yea', _('Link Basel Poster Collection')),
-            ('nay', 'posters_bs_nay', _('Link Basel Poster Collection')),
             ('yea', 'posters_sa_yea', _('Link Social Archives')),
             ('nay', 'posters_sa_nay', _('Link Social Archives')),
+            ('yea', 'posters_bs_yea', _('Link Basel Poster Collection')),
+            ('nay', 'posters_bs_nay', _('Link Basel Poster Collection')),
         ):
             images = getattr(self, f'{attribute}_imgs')
             urls = (getattr(self, attribute) or '').strip().split(' ')

--- a/tests/onegov/swissvotes/test_models.py
+++ b/tests/onegov/swissvotes/test_models.py
@@ -872,12 +872,6 @@ def test_model_vote_properties(session, sample_vote):
     assert vote.posters(DummyRequest()) == {
         'nay': [
             Poster(
-                thumbnail='https://detail.com/6',
-                image='https://detail.com/6',
-                url='https://no.com/objects/6',
-                label='Link Plakatsammlung Basel'
-            ),
-            Poster(
                 thumbnail='https://detail.com/4',
                 image='https://detail.com/4',
                 url='https://no.com/objects/4',
@@ -888,6 +882,12 @@ def test_model_vote_properties(session, sample_vote):
                 image='https://detail.com/3',
                 url='https://no.com/objects/3',
                 label='Link Social Archives'
+            ),
+            Poster(
+                thumbnail='https://detail.com/6',
+                image='https://detail.com/6',
+                url='https://no.com/objects/6',
+                label='Link Basel Poster Collection'
             )
         ],
         'yea': [
@@ -901,7 +901,7 @@ def test_model_vote_properties(session, sample_vote):
                 thumbnail='https://detail.com/5',
                 image='https://detail.com/5',
                 url='https://yes.com/objects/5',
-                label='Link Plakatsammlung Basel'
+                label='Link Basel Poster Collection'
             )
         ]
     }


### PR DESCRIPTION
Swissvotes: Adds translations for Basel poster collection, adjusts order of poster sources

TYPE: Feature
LINK: swi-42