### PR TITLE
Make it possible to change attendee info without current period

### DIFF
--- a/src/onegov/feriennet/forms/attendee.py
+++ b/src/onegov/feriennet/forms/attendee.py
@@ -50,16 +50,16 @@ class AttendeeBase(Form):
         model.name = self.name
 
         # Update name changes on invoice items of current period
-        assert self.request.app.active_period is not None
-        invoice_collection = InvoiceCollection(
-            session=self.request.session,
-            period_id=self.request.app.active_period.id)
+        if self.request.app.active_period is not None:
+            invoice_collection = InvoiceCollection(
+                session=self.request.session,
+                period_id=self.request.app.active_period.id)
 
-        invoice_items = invoice_collection.query_items()
+            invoice_items = invoice_collection.query_items()
 
-        for item in invoice_items:
-            if item.attendee_id == self.model.id:
-                item.group = self.name
+            for item in invoice_items:
+                if item.attendee_id == self.model.id:
+                    item.group = self.name
 
     def process_obj(self, model: Attendee) -> None:  # type:ignore[override]
         super().process_obj(model)


### PR DESCRIPTION
Please fill in the commit message below and work through the checklist. You can delete parts that are not needed, e.g. the optional description, the link to a ticket or irrelevant options of the checklist.

## Commit message

Feriennet: Make it possible to change attendee info without active period

TYPE: Bugfix
LINK: PRO-1341

## Checklist

- [x] I have performed a self-review of my code
- [x] I considered adding a reviewer
- [x] I have tested my code thoroughly by hand