### PR TITLE
External Link Form: Make lead non-mandatory

### DIFF
--- a/src/onegov/org/forms/external_link.py
+++ b/src/onegov/org/forms/external_link.py
@@ -18,7 +18,7 @@ class ExternalLinkForm(Form):
     lead = TextAreaField(
         label=_('Lead'),
         description=_('Describes briefly what this entry is about'),
-        validators=[InputRequired()],
+        validators=[],
         render_kw={'rows': 4})
 
     url = URLField(


### PR DESCRIPTION
Town6: Lead is no longer a mandatory field in `ExternalLinkForm`

TYPE: Feature
LINK: ogc-1941