### PR TITLE
ElectionDay: Allows defining the publisher URI via `open_data` metadata.

### DIFF
--- a/src/onegov/election_day/views/opendata_swiss.py
+++ b/src/onegov/election_day/views/opendata_swiss.py
@@ -56,6 +56,10 @@ def view_rdf(self: Principal, request: ElectionDayRequest) -> bytes:
     publisher_id = self.open_data.get('id')
     publisher_name = self.open_data.get('name')
     publisher_mail = self.open_data.get('mail')
+    publisher_uri = self.open_data.get(
+        'uri',
+        f'urn:onegov_election_day:publisher:{publisher_id}'
+    )
     if not publisher_id or not publisher_name or not publisher_mail:
         raise HTTPNotImplemented()
 
@@ -253,9 +257,12 @@ def view_rdf(self: Principal, request: ElectionDayRequest) -> bytes:
         # Publisher
         pub = sub(ds, 'dct:publisher')
         pub = sub(pub, 'foaf:Organization', {
-            'rdf:about': f'https://{publisher_id}'
+            'rdf:about': publisher_uri
         })
         sub(pub, 'foaf:name', {}, publisher_name)
+        sub(pub, 'foaf:mbox', {
+            'rdf:resource': 'mailto:{}'.format(publisher_mail)
+        })
 
         #  Contact point
         mail = sub(ds, 'dcat:contactPoint')

--- a/tests/onegov/election_day/views/test_views.py
+++ b/tests/onegov/election_day/views/test_views.py
@@ -571,6 +571,10 @@ def test_view_opendata_catalog(election_day_app_zg):
         for x in root.findall('.//{http://purl.org/dc/terms/}publisher')
     ]) == {'Staatskanzlei Kanton Govikon'}
     assert set([
+        list(x[0].attrib.values())[0]
+        for x in root.findall('.//{http://purl.org/dc/terms/}publisher')
+    ]) == {'urn:onegov_election_day:publisher:kanton-govikon'}
+    assert set([
         list(x.attrib.values())[0]
         for x in root.findall('.//{http://www.w3.org/2006/vcard/ns#}hasEmail')
     ]) == {'mailto:info@govikon'}
@@ -620,6 +624,15 @@ def test_view_opendata_catalog(election_day_app_zg):
         'http://kanton-govikon/election-elections',
         'http://kanton-govikon/vote-vote'
     }
+
+    # explicit publisher URI, rather than implicit based on ID
+    principal.open_data['uri'] = 'https://staatskanzlei.govikon.ch'
+    election_day_app_zg.cache.set('principal', principal)
+    root = fromstring(client.get('/catalog.rdf').text)
+    assert set([
+        list(x[0].attrib.values())[0]
+        for x in root.findall('.//{http://purl.org/dc/terms/}publisher')
+    ]) == {'https://staatskanzlei.govikon.ch'}
 
 
 def test_view_screen(election_day_app_zg):


### PR DESCRIPTION
## Commit message

ElectionDay: Allows defining the publisher URI via `open_data` metadata.

This also ensures that the default URI is a URN, rather than a URL
since we can't compute a URL that will always be valid.

We now also include the publisher's email directly and not only via the
contactPoint.

TYPE: Bugfix
LINK: OGC-2002

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes/features
