### PR TITLE
Org: Moves contact inherit functionality to base `ContactExtension`

### DIFF
--- a/src/onegov/org/models/extensions.py
+++ b/src/onegov/org/models/extensions.py
@@ -239,7 +239,7 @@ class VisibleOnHomepageExtension(ContentExtension):
         return VisibleOnHomepageForm
 
 
-class ContactExtension:
+class ContactExtension(ContentExtension):
     """ Extends any class that has a content dictionary field with a simple
     contacts field, that can optionally be inherited from another topic.
 
@@ -249,7 +249,7 @@ class ContactExtension:
 
     @contact.setter  # type:ignore[no-redef]
     def contact(self, value: str | None) -> None:
-        self.content['contact'] = value  # type:ignore[attr-defined]
+        self.content['contact'] = value
         if self.inherit_contact:
             # no need to update the cache
             return
@@ -263,7 +263,7 @@ class ContactExtension:
 
     @inherit_contact.setter  # type:ignore[no-redef]
     def inherit_contact(self, value: bool) -> None:
-        self.content['inherit_contact'] = value  # type:ignore[attr-defined]
+        self.content['inherit_contact'] = value
 
         # clear cache (don't update eagerly since it involves a query)
         if 'contact_html' in self.__dict__:
@@ -273,7 +273,7 @@ class ContactExtension:
 
     @contact_inherited_from.setter  # type:ignore[no-redef]
     def contact_inherited_from(self, value: int | None) -> None:
-        self.content['contact_inherited_from'] = value  # type:ignore[attr-defined]
+        self.content['contact_inherited_from'] = value
         if not self.inherit_contact:
             # no need to clear the cache
             return

--- a/src/onegov/org/models/page.py
+++ b/src/onegov/org/models/page.py
@@ -9,7 +9,7 @@ from onegov.org import _
 from onegov.org.forms import LinkForm, PageForm, IframeForm
 from onegov.org.models.atoz import AtoZ
 from onegov.org.models.extensions import (
-    InheritableContactExtension, ContactHiddenOnPageExtension,
+    ContactExtension, ContactHiddenOnPageExtension,
     PeopleShownOnMainPageExtension, ImageExtension,
     NewsletterExtension, PublicationExtension, DeletableContentExtension,
     InlinePhotoAlbumExtension
@@ -40,7 +40,7 @@ if TYPE_CHECKING:
 
 class Topic(Page, TraitInfo, SearchableContent, AccessExtension,
             PublicationExtension, VisibleOnHomepageExtension,
-            InheritableContactExtension, ContactHiddenOnPageExtension,
+            ContactExtension, ContactHiddenOnPageExtension,
             PeopleShownOnMainPageExtension, PersonLinkExtension,
             CoordinatesExtension, ImageExtension,
             GeneralFileLinkExtension, SidebarLinksExtension,
@@ -143,7 +143,7 @@ class Topic(Page, TraitInfo, SearchableContent, AccessExtension,
 
 class News(Page, TraitInfo, SearchableContent, NewsletterExtension,
            AccessExtension, PublicationExtension, VisibleOnHomepageExtension,
-           InheritableContactExtension, ContactHiddenOnPageExtension,
+           ContactExtension, ContactHiddenOnPageExtension,
            PeopleShownOnMainPageExtension, PersonLinkExtension,
            CoordinatesExtension, ImageExtension, GeneralFileLinkExtension,
            DeletableContentExtension, InlinePhotoAlbumExtension):
@@ -207,7 +207,7 @@ class News(Page, TraitInfo, SearchableContent, NewsletterExtension,
     def get_root_page_form_class(self, request: OrgRequest) -> type[Form]:
         return self.with_content_extensions(
             Form, request, extensions=(
-                InheritableContactExtension, ContactHiddenOnPageExtension,
+                ContactExtension, ContactHiddenOnPageExtension,
                 PersonLinkExtension, AccessExtension
             )
         )

--- a/src/onegov/org/templates/news.pt
+++ b/src/onegov/org/templates/news.pt
@@ -35,6 +35,6 @@
         </div>
 
         <tal:b metal:use-macro="layout.macros.page_content"
-         tal:define="lead page.content.get('lead');text page.text|None; people page.people; contact page.get_contact_html(request); coordinates page.coordinates; files page.files; sidepanel_links page.sidepanel_links|False;" />
+         tal:define="lead page.content.get('lead');text page.text|None; people page.people; contact page.contact_html; coordinates page.coordinates; files page.files; sidepanel_links page.sidepanel_links|False;" />
     </tal:b>
 </div>

--- a/src/onegov/org/templates/topic.pt
+++ b/src/onegov/org/templates/topic.pt
@@ -11,7 +11,7 @@
         <tal:b condition="page.trait == 'page'">
 
             <tal:b metal:use-macro="layout.macros.page_content"
-             tal:define="lead layout.linkify(page.content.get('lead'));text page.text|None; people page.people; contact page.get_contact_html(request); coordinates page.coordinates; files page.files; sidepanel_links page.sidepanel_links;">
+             tal:define="lead layout.linkify(page.content.get('lead'));text page.text|None; people page.people; contact page.contact_html; coordinates page.coordinates; files page.files; sidepanel_links page.sidepanel_links;">
                 <tal:b metal:fill-slot="after-text">
                      <div class="row" tal:condition="children">
                         <div class="small-12 columns">

--- a/src/onegov/town6/layout.py
+++ b/src/onegov/town6/layout.py
@@ -258,7 +258,7 @@ class PageLayout(OrgPageLayout, AdjacencyListLayout):
 
     @cached_property
     def contact_html(self) -> str:
-        return self.model.get_contact_html(self.request) or to_html_ul(
+        return self.model.contact_html or to_html_ul(
             self.org.contact
         )
 
@@ -270,7 +270,7 @@ class NewsLayout(OrgNewsLayout, AdjacencyListLayout):
 
     @cached_property
     def contact_html(self) -> str:
-        return self.model.get_contact_html(self.request) or to_html_ul(
+        return self.model.contact_html or to_html_ul(
             self.org.contact, convert_dashes=False
         )
 

--- a/tests/onegov/org/test_extensions.py
+++ b/tests/onegov/org/test_extensions.py
@@ -339,19 +339,22 @@ def test_person_link_move_function():
     ]
 
 
-def test_contact_extension():
-    class Topic(ContactExtension):
-        content = {}
+def test_contact_extension(org_app):
+    from onegov.org.models import Topic
 
     class TopicForm(Form):
         pass
 
-    topic = Topic()
+    topic = Topic('test')
     assert topic.contact is None
     assert topic.contact_html is None
 
-    request = Bunch(**{'app.settings.org.disabled_extensions': []})
-    form_class = topic.with_content_extensions(TopicForm, request=request)
+    request = Bunch(app=org_app, session=org_app.session())
+    form_class = topic.with_content_extensions(
+        TopicForm,
+        request=request,
+        extensions=(ContactExtension,)
+    )
     form = form_class()
 
     assert 'contact' in form._fields
@@ -379,7 +382,11 @@ def test_contact_extension():
         '</p>'
     )
 
-    form_class = topic.with_content_extensions(TopicForm, request=request)
+    form_class = topic.with_content_extensions(
+        TopicForm,
+        request=request,
+        extensions=(ContactExtension,)
+    )
     form = form_class()
 
     form.process(obj=topic)
@@ -391,21 +398,25 @@ def test_contact_extension():
     )
 
 
-def test_contact_extension_with_top_level_domain_agency():
-    class Topic(ContactExtension):
-        content = {}
+def test_contact_extension_with_top_level_domain_agency(org_app):
+    from onegov.org.models import Topic
 
     class TopicForm(Form):
         pass
 
-    topic = Topic()
+    topic = Topic('test')
 
     assert topic.contact is None
     assert topic.contact_html is None
 
-    request = Bunch(**{'app.settings.org.disabled_extensions': []})
-    form_class = topic.with_content_extensions(TopicForm, request=request)
+    request = Bunch(app=org_app, session=org_app.session())
+    form_class = topic.with_content_extensions(
+        TopicForm,
+        request=request,
+        extensions=(ContactExtension,)
+    )
     form = form_class()
+    form.request = request
 
     assert 'contact' in form._fields
 


### PR DESCRIPTION
## Commit message

Org: Moves contact inherit functionality to base `ContactExtension`

This means resources, forms and directories can now inherit their contact information from a topic as well.

TYPE: Feature
LINK: OGC-2049


## Checklist

- [x] I have performed a self-review of my code
- [x] I have tested my code thoroughly by hand
