### PR TITLE
Improvements for external id

### DIFF
--- a/src/onegov/agency/api.py
+++ b/src/onegov/agency/api.py
@@ -6,6 +6,7 @@ from onegov.agency.collections import ExtendedPersonCollection
 from onegov.agency.collections import PaginatedAgencyCollection
 from onegov.agency.collections import PaginatedMembershipCollection
 from onegov.agency.forms import PersonMutationForm
+from onegov.agency.forms.person import AuthenticatedPersonMutationForm
 from onegov.api import ApiEndpoint, ApiInvalidParamException
 from onegov.api.utils import authenticate
 from onegov.gis import Coordinates
@@ -101,7 +102,7 @@ class PersonApiEndpoint(ApiEndpoint['ExtendedPerson'], ApisMixin):
     app: AgencyApp
     endpoint = 'people'
     filters = {'first_name', 'last_name'} | UPDATE_FILTER_PARAMS
-    form_class = PersonMutationForm
+    form_class = AuthenticatedPersonMutationForm
 
     @property
     def collection(self) -> ExtendedPersonCollection:
@@ -157,10 +158,10 @@ class PersonApiEndpoint(ApiEndpoint['ExtendedPerson'], ApisMixin):
             and self.request.authorization
             and authenticate(self.request)
         ):
-            # Authenticated users get all fields including lu_external_id
+            # Authenticated users get all fields including external_user_id
             data = {
                 attribute: getattr(item, attribute, None)
-                for attribute in (*self._public_item_data, 'lu_external_id')
+                for attribute in (*self._public_item_data, 'external_user_id')
             }
         else:
             # Non-authenticated users only get non-hidden fields

--- a/src/onegov/agency/data_import.py
+++ b/src/onegov/agency/data_import.py
@@ -455,7 +455,7 @@ def import_lu_people(
             location_code_city=v_(get_plz_city(line.plz, line.ort)),
             access='public',
             compare_names_only=True,
-            lu_external_id=v_(line.benutzer_id)
+            external_user_id=v_(line.benutzer_id)
         )
         persons.append(person)
         parse_membership(line, person, function)

--- a/src/onegov/agency/forms/mutation.py
+++ b/src/onegov/agency/forms/mutation.py
@@ -241,11 +241,6 @@ class PersonMutationForm(MutationForm):
         render_kw={'rows': 5}
     )
 
-    lu_external_id = StringField(
-        fieldset=_('Proposed changes'),
-        label=_('External ID')
-    )
-
 
 class ApplyMutationForm(Form):
 

--- a/src/onegov/agency/forms/person.py
+++ b/src/onegov/agency/forms/person.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from wtforms.fields.simple import StringField, EmailField
+from wtforms.fields.simple import StringField
 from onegov.agency.forms import PersonMutationForm
 from onegov.agency import _
 from onegov.org.forms import PersonForm

--- a/src/onegov/agency/forms/person.py
+++ b/src/onegov/agency/forms/person.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
+from wtforms.fields.simple import StringField, EmailField
 from onegov.agency.forms import PersonMutationForm
-from onegov.form.parser.core import StringField
 from onegov.agency import _
 from onegov.org.forms import PersonForm
 
 
 class AgencyPersonForm(PersonForm):
 
-    external_user_id = StringField(_('External ID'), required=False)
+    external_user_id = StringField(_('External ID'))
 
 
 class AuthenticatedPersonMutationForm(PersonMutationForm):
@@ -16,5 +16,5 @@ class AuthenticatedPersonMutationForm(PersonMutationForm):
     """
 
     external_user_id = StringField(
-        fieldset=_('Proposed changes'), label=_('External ID'), required=False
+        fieldset=_('Proposed changes'), label=_('External ID')
     )

--- a/src/onegov/agency/forms/person.py
+++ b/src/onegov/agency/forms/person.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+from onegov.agency.forms import PersonMutationForm
+from onegov.form.parser.core import StringField
+from onegov.agency import _
+from onegov.org.forms import PersonForm
+
+
+class AgencyPersonForm(PersonForm):
+
+    external_user_id = StringField(_('External ID'), required=False)
+
+
+class AuthenticatedPersonMutationForm(PersonMutationForm):
+    """ Like PersonMutationForm, but includes fields which shouldn't be
+    public.
+    """
+
+    external_user_id = StringField(
+        fieldset=_('Proposed changes'), label=_('External ID'), required=False
+    )

--- a/src/onegov/agency/locale/de_CH/LC_MESSAGES/onegov.agency.po
+++ b/src/onegov/agency/locale/de_CH/LC_MESSAGES/onegov.agency.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE 1.0\n"
-"POT-Creation-Date: 2025-02-13 13:14+0100\n"
+"POT-Creation-Date: 2025-02-13 15:44+0100\n"
 "PO-Revision-Date: 2021-01-27 13:07+0100\n"
 "Last-Translator: Marc Sommerhalder <marc.sommerhalder@seantis.ch>\n"
 "Language-Team: German\n"

--- a/src/onegov/agency/models/person.py
+++ b/src/onegov/agency/models/person.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from onegov.agency.utils import get_html_paragraph_with_line_breaks
+from onegov.core.orm.mixins import dict_property, meta_property
 from onegov.org.models import Organisation
 from onegov.org.models.extensions import AccessExtension
 from onegov.org.models.extensions import PublicationExtension
@@ -35,6 +36,8 @@ class ExtendedPerson(Person, AccessExtension, PublicationExtension):
         'phone_internal': {'type': 'text'},
         'phone_es': {'type': 'text'}
     }
+
+    external_user_id : dict_property[str | None] = meta_property()
 
     @property
     def es_suggestion(self) -> tuple[str, ...]:

--- a/src/onegov/agency/models/person.py
+++ b/src/onegov/agency/models/person.py
@@ -37,7 +37,7 @@ class ExtendedPerson(Person, AccessExtension, PublicationExtension):
         'phone_es': {'type': 'text'}
     }
 
-    external_user_id : dict_property[str | None] = meta_property()
+    external_user_id: dict_property[str | None] = meta_property()
 
     @property
     def es_suggestion(self) -> tuple[str, ...]:

--- a/src/onegov/agency/views/people.py
+++ b/src/onegov/agency/views/people.py
@@ -18,7 +18,7 @@ from onegov.core.security import Private
 from onegov.core.security import Public
 from onegov.form import Form
 from onegov.org.elements import Link
-from onegov.org.forms import PersonForm
+from onegov.agency.forms.person import AgencyPersonForm
 from onegov.org.mail import send_ticket_mail
 from onegov.org.models import AtoZ
 from onegov.org.models import TicketMessage
@@ -36,6 +36,7 @@ if TYPE_CHECKING:
     from onegov.core.types import RenderData
     from onegov.ticket import Ticket
     from webob import Response as BaseResponse
+    from onegov.agency.forms.person import AuthenticatedPersonMutationForm
 
 
 class FilterOption(NamedTuple):
@@ -47,11 +48,11 @@ class FilterOption(NamedTuple):
 def get_person_form_class(
     model: object,
     request: AgencyRequest
-) -> type[PersonForm]:
+) -> type[AgencyPersonForm]:
 
     if isinstance(model, ExtendedPerson):
-        return model.with_content_extensions(PersonForm, request)
-    return ExtendedPerson().with_content_extensions(PersonForm, request)
+        return model.with_content_extensions(AgencyPersonForm, request)
+    return ExtendedPerson().with_content_extensions(AgencyPersonForm, request)
 
 
 @AgencyApp.html(
@@ -264,7 +265,7 @@ def view_sort_person(
 def add_person(
     self: ExtendedPersonCollection,
     request: AgencyRequest,
-    form: PersonForm
+    form: AgencyPersonForm
 ) -> RenderData | BaseResponse:
 
     if form.submitted(request):
@@ -295,7 +296,7 @@ def add_person(
 def edit_person(
     self: ExtendedPerson,
     request: AgencyRequest,
-    form: PersonForm
+    form: AgencyPersonForm
 ) -> RenderData | BaseResponse:
 
     if form.submitted(request):
@@ -337,7 +338,7 @@ def handle_delete_person(
 def do_report_person_change(
     self: ExtendedPerson,
     request: AgencyRequest,
-    form: PersonMutationForm
+    form: PersonMutationForm | AuthenticatedPersonMutationForm
 ) -> Ticket:
 
     session = request.session

--- a/src/onegov/api/models.py
+++ b/src/onegov/api/models.py
@@ -363,8 +363,7 @@ class ApiEndpoint(Generic[_M]):
                     (HiddenField, HoneyPotField)
                 )
             }
-            breakpoint()
-            
+
             formdata = MultiDict()
             try:
                 json_data = request.json

--- a/src/onegov/api/models.py
+++ b/src/onegov/api/models.py
@@ -363,6 +363,8 @@ class ApiEndpoint(Generic[_M]):
                     (HiddenField, HoneyPotField)
                 )
             }
+            breakpoint()
+            
             formdata = MultiDict()
             try:
                 json_data = request.json

--- a/src/onegov/org/forms/person.py
+++ b/src/onegov/org/forms/person.py
@@ -30,18 +30,17 @@ class PersonForm(Form):
     political_party = StringField(_('Political Party'))
     parliamentary_group = StringField(_('Parliamentary Group'))
     website = StringField(_('Website'), filters=(ensure_scheme, ))
-    website_2 = StringField(_('Website 2'), filters=(ensure_scheme, ))
-    lu_external_id = StringField(_('External ID'))
+    website_3 = StringField(_('Website 2'), filters=(ensure_scheme, ))
 
     location_address = TextAreaField(
         label=_('Location address'),
-        render_kw={'rows': 2}
+        render_kw={'rows': 3}
     )
     location_code_city = StringField(label=_('Location Code and City'))
 
     postal_address = TextAreaField(
         label=_('Postal address'),
-        render_kw={'rows': 2}
+        render_kw={'rows': 3}
     )
     postal_code_city = StringField(label=_('Postal Code and City'))
 
@@ -54,5 +53,5 @@ class PersonForm(Form):
     notes = TextAreaField(
         label=_('Notes'),
         description=_('Public extra information about this person'),
-        render_kw={'rows': 5}
+        render_kw={'rows': 6}
     )

--- a/src/onegov/org/forms/person.py
+++ b/src/onegov/org/forms/person.py
@@ -30,7 +30,7 @@ class PersonForm(Form):
     political_party = StringField(_('Political Party'))
     parliamentary_group = StringField(_('Parliamentary Group'))
     website = StringField(_('Website'), filters=(ensure_scheme, ))
-    website_3 = StringField(_('Website 2'), filters=(ensure_scheme, ))
+    website_2 = StringField(_('Website 2'), filters=(ensure_scheme, ))
 
     location_address = TextAreaField(
         label=_('Location address'),

--- a/src/onegov/org/forms/settings.py
+++ b/src/onegov/org/forms/settings.py
@@ -722,7 +722,7 @@ class ModuleSettingsForm(Form):
             ('postal_address', _('Postal address')),
             ('postal_code_city', _('Postal Code and City')),
             ('notes', _('Notes')),
-            ('external_id', _('External ID'))
+            ('external_user_id', _('External ID'))
         ])
 
     mtan_session_duration_seconds = IntegerField(

--- a/src/onegov/org/models/organisation.py
+++ b/src/onegov/org/models/organisation.py
@@ -99,7 +99,7 @@ class Organisation(Base, TimestampMixin):
     redirect_homepage_to: dict_property[str | None] = meta_property()
     redirect_path: dict_property[str | None] = meta_property()
     hidden_people_fields: dict_property[list[str]] = meta_property(
-        default=list
+        default=lambda: ['external_user_id']
     )
     event_locations: dict_property[list[str]] = meta_property(default=list)
     geo_provider: dict_property[str] = meta_property(default='geo-mapbox')

--- a/src/onegov/people/models/person.py
+++ b/src/onegov/people/models/person.py
@@ -156,11 +156,6 @@ class Person(Base, ContentMixin, TimestampMixin, ORMSearchable,
     #: some remarks about the person
     notes: Column[str | None] = Column(Text, nullable=True)
 
-    #: It's an external system identifier for synchronization.
-    #: Used to match our records of persons with external source (lu staka api)
-    #: Is called 'Benutzer-ID' in csv import file, 'division' in api.
-    lu_external_id: Column[str | None] = Column(Text, nullable=True)
-
     memberships: relationship[AppenderQuery[AgencyMembership]]
     memberships = relationship(
         AgencyMembership,

--- a/src/onegov/people/upgrade.py
+++ b/src/onegov/people/upgrade.py
@@ -202,9 +202,7 @@ def fix_agency_address_column(context: UpgradeContext) -> None:
         ))
 
 
-@upgrade_task('Add lu_external_id for agency import')
-def add_external_id_for_agency_import(context: UpgradeContext) -> None:
-    if not context.has_column('people', 'lu_external_id'):
-        context.operations.add_column('people', Column(
-            'lu_external_id', Text, nullable=True
-        ))
+@upgrade_task('Remove_lu_external_id ')
+def remove_external_id_for_agency_import(context: UpgradeContext) -> None:
+    if context.has_column('people', 'lu_external_id'):
+        context.operations.drop_column('people', 'lu_external_id)')

--- a/tests/onegov/agency/test_forms.py
+++ b/tests/onegov/agency/test_forms.py
@@ -374,7 +374,7 @@ def test_person_mutation_form():
         'first_name': 'nick',
         'last_name': 'Rivera',
         'academic_title': 'Dr.',
-        'lu_external_id': '123456'
+        'external_user_id': '123456'
     }))
     form.model = ExtendedPerson(first_name="Nick", last_name="Riviera")
     form.request = DummyRequest(None)
@@ -385,14 +385,14 @@ def test_person_mutation_form():
         'email', 'notes', 'first_name', 'last_name', 'born', 'phone',
         'parliamentary_group', 'location_address',
         'location_code_city', 'postal_address', 'postal_code_city',
-        'profession', 'phone_direct', 'academic_title', 'lu_external_id'
+        'profession', 'phone_direct', 'academic_title', 'external_user_id'
     }
     assert form.first_name.description == 'Nick'
     assert form.last_name.description == 'Riviera'
     assert form.academic_title.description is None
     assert form.proposed_changes == {
         'academic_title': 'Dr.', 'first_name': 'nick', 'last_name': 'Rivera',
-        'lu_external_id': '123456'
+        'external_user_id': '123456'
     }
     assert form.get_useful_data() == {
         'submitter_email': 'info@hospital-springfield.org',
@@ -416,7 +416,7 @@ def test_person_mutation_form():
         'postal_address': None,
         'postal_code_city': None,
         'notes': None,
-        'lu_external_id': '123456'
+        'external_user_id': '123456'
     }
     assert form.validate()
 

--- a/tests/onegov/agency/test_forms.py
+++ b/tests/onegov/agency/test_forms.py
@@ -374,7 +374,6 @@ def test_person_mutation_form():
         'first_name': 'nick',
         'last_name': 'Rivera',
         'academic_title': 'Dr.',
-        'external_user_id': '123456'
     }))
     form.model = ExtendedPerson(first_name="Nick", last_name="Riviera")
     form.request = DummyRequest(None)
@@ -385,14 +384,13 @@ def test_person_mutation_form():
         'email', 'notes', 'first_name', 'last_name', 'born', 'phone',
         'parliamentary_group', 'location_address',
         'location_code_city', 'postal_address', 'postal_code_city',
-        'profession', 'phone_direct', 'academic_title', 'external_user_id'
+        'profession', 'phone_direct', 'academic_title'
     }
     assert form.first_name.description == 'Nick'
     assert form.last_name.description == 'Riviera'
     assert form.academic_title.description is None
     assert form.proposed_changes == {
-        'academic_title': 'Dr.', 'first_name': 'nick', 'last_name': 'Rivera',
-        'external_user_id': '123456'
+        'academic_title': 'Dr.', 'first_name': 'nick', 'last_name': 'Rivera'
     }
     assert form.get_useful_data() == {
         'submitter_email': 'info@hospital-springfield.org',
@@ -415,8 +413,7 @@ def test_person_mutation_form():
         'location_code_city': None,
         'postal_address': None,
         'postal_code_city': None,
-        'notes': None,
-        'external_user_id': '123456'
+        'notes': None
     }
     assert form.validate()
 

--- a/tests/onegov/api/test_views.py
+++ b/tests/onegov/api/test_views.py
@@ -237,7 +237,7 @@ def test_view_private_field_unauthorized(client):
 
     people = ExtendedPersonCollection(session)
     person = people.add(
-        first_name='vorname', last_name='nachname', lu_external_id='123456'
+        first_name='vorname', last_name='nachname', external_user_id='123456'
     )
     session.flush()
     person_id = person.id.hex
@@ -249,7 +249,7 @@ def test_view_private_field_unauthorized(client):
     person_item_data = json.loads(response_item.body.decode('utf-8'))
     person_data = person_item_data['collection']['items'][0]['data']
     assert not any(
-        d['name'] == 'lu_external_id'
+        d['name'] == 'external_user_id'
         for d in person_data
     )
 
@@ -271,7 +271,7 @@ def test_view_private_field(client):
     session = client.app.session()  # Get fresh session after commit
     people = ExtendedPersonCollection(session)
     person = people.add(
-        first_name='vorname', last_name='nachname', lu_external_id='123456'
+        first_name='vorname', last_name='nachname', external_user_id='123456'
     )
     session.flush()  # Ensure ID is generated
     person_id = person.id.hex  # Store ID before commit
@@ -309,6 +309,6 @@ def test_view_private_field(client):
     person_item_data = json.loads(response_item.body.decode('utf-8'))
     person_data = person_item_data['collection']['items'][0]['data']
     assert any(
-        d['name'] == 'lu_external_id' and d['value'] == '123456'
+        d['name'] == 'external_user_id' and d['value'] == '123456'
         for d in person_data
     )


### PR DESCRIPTION
- Uses a meta field for the external_user_id (So we don't have a specific column
  in `org` for a specific feature of agency)
- Make sure the api uses it's own mutation form such that it's seperated form
  public facing mutations.
- Make sure `hidden_people_fields` is honored everywhere


TYPE: Bugfix
LINK: OGC-2061