### PR TITLE
Dashboard: Show only topics in 'Edited Pages` boardlet

### DIFF
--- a/src/onegov/feriennet/boardlets.py
+++ b/src/onegov/feriennet/boardlets.py
@@ -8,7 +8,7 @@ from onegov.feriennet import FeriennetApp
 from onegov.feriennet.collections import BillingCollection, MatchCollection
 from onegov.feriennet.exports.unlucky import UnluckyExport
 from onegov.feriennet.layout import DefaultLayout
-from onegov.org.boardlets import TicketBoardlet, EditedPagesBoardlet, \
+from onegov.org.boardlets import TicketBoardlet, EditedTopicsBoardlet, \
     EditedNewsBoardlet, PlausibleStats, PlausibleTopPages
 from onegov.org.models import Boardlet, BoardletFact
 from sqlalchemy import func
@@ -60,7 +60,7 @@ class DisabledTicketBoardlet(TicketBoardlet):
 
 
 @FeriennetApp.boardlet(name='pages', order=(1, 2), icon='fa-edit')
-class DisabledEditedPagesBoardlet(EditedPagesBoardlet):
+class DisabledEditedPagesBoardlet(EditedTopicsBoardlet):
 
     @property
     def is_available(self) -> bool:

--- a/src/onegov/org/boardlets.py
+++ b/src/onegov/org/boardlets.py
@@ -153,7 +153,7 @@ def get_icon_title(request: OrgRequest, access: str) -> str:
 
 
 @OrgApp.boardlet(name='pages', order=(1, 2), icon='fa-edit')
-class EditedPagesBoardlet(OrgBoardlet):
+class EditedTopicsBoardlet(OrgBoardlet):
 
     @property
     def title(self) -> str:

--- a/src/onegov/org/boardlets.py
+++ b/src/onegov/org/boardlets.py
@@ -9,8 +9,7 @@ from typing import TYPE_CHECKING
 
 from onegov.org import OrgApp
 from onegov.org.layout import DefaultLayout
-from onegov.org.models import Boardlet, BoardletFact, News
-from onegov.page import Page
+from onegov.org.models import Boardlet, BoardletFact, News, Topic
 from onegov.plausible.plausible_api import PlausibleAPI
 from onegov.ticket import Ticket
 from onegov.town6 import _
@@ -163,16 +162,16 @@ class EditedPagesBoardlet(OrgBoardlet):
     @property
     def facts(self) -> Iterator[BoardletFact]:
 
-        last_edited_pages = self.session.query(Page).order_by(
-            Page.last_change.desc()).limit(8)
+        last_edited_pages = self.session.query(Topic).order_by(
+            Topic.last_change.desc()).limit(8)
 
         for p in last_edited_pages:
             yield BoardletFact(
                 text='',
                 link=(self.layout.request.link(p), p.title),
                 icon='fas fa-file',
-                visibility_icon=get_icon_for_access_level(p.access),  # type:ignore[attr-defined]
-                icon_title=get_icon_title(self.request, p.access)  # type:ignore[attr-defined]
+                visibility_icon=get_icon_for_access_level(p.access),
+                icon_title=get_icon_title(self.request, p.access)
             )
 
 
@@ -186,7 +185,7 @@ class EditedNewsBoardlet(OrgBoardlet):
     @property
     def facts(self) -> Iterator[BoardletFact]:
         last_edited_news = self.session.query(News).order_by(
-            Page.last_change.desc()).limit(8)
+            News.last_change.desc()).limit(8)
 
         for n in last_edited_news:
             yield BoardletFact(

--- a/src/onegov/org/boardlets.py
+++ b/src/onegov/org/boardlets.py
@@ -157,7 +157,7 @@ class EditedTopicsBoardlet(OrgBoardlet):
 
     @property
     def title(self) -> str:
-        return _('Last Edited Pages')
+        return _('Last Edited Topics')
 
     @property
     def facts(self) -> Iterator[BoardletFact]:

--- a/src/onegov/org/locale/de_CH/LC_MESSAGES/onegov.org.po
+++ b/src/onegov/org/locale/de_CH/LC_MESSAGES/onegov.org.po
@@ -53,8 +53,8 @@ msgstr "Zeit von Bearbeitung bis Schliessung in Tagen im letzten Monat"
 msgid "Access"
 msgstr "Zugriff"
 
-msgid "Last Edited Pages"
-msgstr "Zuletzt bearbeitete Seiten"
+msgid "Last Edited Topics"
+msgstr "Zuletzt bearbeitete Themen"
 
 msgid "Last Edited News"
 msgstr "Zuletzt bearbeitete News"

--- a/src/onegov/org/locale/fr_CH/LC_MESSAGES/onegov.org.po
+++ b/src/onegov/org/locale/fr_CH/LC_MESSAGES/onegov.org.po
@@ -54,8 +54,8 @@ msgstr "Délai de traitement de l'attente à la clôture en jours le mois dernie
 msgid "Access"
 msgstr "Accès"
 
-msgid "Last Edited Pages"
-msgstr "Dernières pages modifiées"
+msgid "Last Edited Topics"
+msgstr "Derniers sujets modifiés"
 
 msgid "Last Edited News"
 msgstr "Dernières nouvelles modifiées"

--- a/src/onegov/org/locale/it_CH/LC_MESSAGES/onegov.org.po
+++ b/src/onegov/org/locale/it_CH/LC_MESSAGES/onegov.org.po
@@ -54,11 +54,11 @@ msgstr ""
 msgid "Access"
 msgstr "Accesso"
 
-msgid "Last Edited Pages"
-msgstr "Ultime pagine modificate"
+msgid "Last Edited Topics"
+msgstr "Argomenti modificati di recente"
 
 msgid "Last Edited News"
-msgstr "Ultime notizie modificate"
+msgstr "Notizie modificate di recente"
 
 msgid "Web Statistics"
 msgstr "Statistiche Web"

--- a/tests/onegov/org/test_views_dashboard.py
+++ b/tests/onegov/org/test_views_dashboard.py
@@ -131,14 +131,12 @@ def test_view_dashboard_topics_news(handlers, client):
         link_texts.append(link.text)
 
     # Topics
-    assert link_texts[0] == 'Wir haben eine neue Webseite!'
-    assert link_texts[1] == 'Aktuelles'
-    assert link_texts[2] == 'Kontakt'
-    assert link_texts[3] == 'Themen'
-    assert link_texts[4] == 'Organisation'
+    assert link_texts[0] == 'Kontakt'
+    assert link_texts[1] == 'Themen'
+    assert link_texts[2] == 'Organisation'
     # News
-    assert link_texts[5] == 'Wir haben eine neue Webseite!'
-    assert link_texts[6] == 'Aktuelles'
+    assert link_texts[3] == 'Wir haben eine neue Webseite!'
+    assert link_texts[4] == 'Aktuelles'
 
 
 def test_view_dashboard_web_stats(client, monkeypatch):

--- a/tests/onegov/org/test_views_dashboard.py
+++ b/tests/onegov/org/test_views_dashboard.py
@@ -35,7 +35,7 @@ def test_view_dashboard_no_ticket(client):
     assert fact_numbers[5] == '-'  # lead time pending to closing
 
     # pages and news
-    assert 'Zuletzt bearbeitete Seiten' in page
+    assert 'Zuletzt bearbeitete Themen' in page
     assert 'Zuletzt bearbeitete News' in page
 
 
@@ -104,7 +104,7 @@ def test_view_dashboard_tickets(handlers, client, org_app):
     page = client.get('/dashboard')
     assert page.pyquery('.boardlet').length == 3
     assert 'Tickets' in page
-    assert 'Zuletzt bearbeitete Seiten' in page
+    assert 'Zuletzt bearbeitete Themen' in page
     assert 'Zuletzt bearbeitete News' in page
     fact_numbers = page.pyquery('.fact-number').text()
     fact_numbers = fact_numbers.split()
@@ -122,7 +122,7 @@ def test_view_dashboard_topics_news(handlers, client):
 
     assert page.pyquery('.boardlet').length == 3
     assert 'Tickets' in page
-    assert 'Zuletzt bearbeitete Seiten' in page
+    assert 'Zuletzt bearbeitete Themen' in page
     assert 'Zuletzt bearbeitete News' in page
 
     links = page.pyquery('.boardlet a')


### PR DESCRIPTION
Org: Show only topics in 'Edited Topics` boardlet on dashboard

TYPE: Bugfix
LINK: ogc-2121