### PR TITLE
Move translations to boardlet

### DIFF
--- a/src/onegov/org/boardlets.py
+++ b/src/onegov/org/boardlets.py
@@ -213,6 +213,14 @@ class PlausibleStats(OrgBoardlet):
         if not self.plausible_api:
             return None
 
+        texts = [
+            _('Unique Visitors in the Last Month'),
+            _('Total Visits in the Last Month'),
+            _('Total Page Views in the Last Month'),
+            _('Number of Page Views per Visit'),
+            _('Average Visit Duration in Minutes')
+        ]
+
         results = self.plausible_api.get_stats()
         if not results:
             yield BoardletFact(
@@ -220,10 +228,10 @@ class PlausibleStats(OrgBoardlet):
                 number=None
             )
 
-        for text, number in results.items():
+        for text, value in zip(texts, results):
             yield BoardletFact(
-                text=self.request.translate(_(text)),
-                number=number
+                text=text,
+                number=value
             )
 
 

--- a/src/onegov/plausible/plausible_api.py
+++ b/src/onegov/plausible/plausible_api.py
@@ -54,7 +54,7 @@ class PlausibleAPI:
 
         return response.json()
 
-    def get_stats(self) -> dict[str, int] | dict[str, str]:
+    def get_stats(self) -> list[str]:
         """
         Get basic stats from Plausible API
 
@@ -76,7 +76,7 @@ class PlausibleAPI:
 
         results = r.get('results', [])
         if not results:
-            return {}
+            return figures
 
         figures = results[0].get('metrics', figures)
 
@@ -84,15 +84,7 @@ class PlausibleAPI:
         figures[-1] = (
             str(round(int(figures[-1]) / 60, 1))) if figures[-1] else '0'
 
-        texts = [
-            'Unique Visitors in the Last Month',
-            'Total Visits in the Last Month',
-            'Total Page Views in the Last Month',
-            'Number of Page Views per Visit',
-            'Average Visit Duration in Minutes'
-        ]
-
-        return {text: figures[i] for i, text in enumerate(texts)}
+        return figures
 
     def get_top_pages(self, limit: int = 10) -> dict[str, int]:
         """


### PR DESCRIPTION
Org: Fix dashboard translations get lost

Executing `do/translate onegov.town6` made dashboard translations disappear

TYPE: Bugfix
LINK: None