### PR TITLE
Town6 display phone numbers in international format

### DIFF
--- a/src/onegov/agency/templates/macros.pt
+++ b/src/onegov/agency/templates/macros.pt
@@ -40,12 +40,12 @@
 
                 <tal:block tal:condition="agency.phone">
                     <dt i18n:translate>Phone</dt>
-                    <dd><a href="tel: ${agency.phone}">${agency.phone}</a></dd>
+                    <dd><a href="tel: ${layout.format_phone_number(agency.phone)}">${layout.format_phone_number(agency.phone)}</a></dd>
                 </tal:block>
 
                 <tal:block tal:condition="agency.phone_direct">
                     <dt i18n:translate>Alternate Phone Number or Fax</dt>
-                    <dd><a href="tel: ${agency.phone_direct}">${agency.phone_direct}</a></dd>
+                    <dd><a href="tel: ${layout.format_phone_number(agency.phone_direct)}">${layout.format_phone_number(agency.phone_direct)}</a></dd>
                 </tal:block>
 
                 <tal:block tal:condition="agency.email">
@@ -115,7 +115,7 @@
                     <a href="mailto:${person.email}">${person.email}</a>
                 </li>
                 <li tal:condition="person.phone and 'phone' not in exclude" class="person-card-phone">
-                    <a href="tel:${person.phone}">${person.phone}</a>
+                    <a href="tel:${layout.format_phone_number(person.phone)}">${layout.format_phone_number(person.phone)}</a>
                 </li>
             </ul>
             <div class="clearfix"></div>
@@ -191,12 +191,12 @@
 
                         <tal:block tal:condition="person.phone and 'phone' not in exclude">
                             <dt i18n:translate>Phone</dt>
-                            <dd><a href="tel:${person.phone}">${person.phone}</a></dd>
+                            <dd><a href="tel:${layout.format_phone_number(person.phone)}">${layout.format_phone_number(person.phone)}</a></dd>
                         </tal:block>
 
                         <tal:block tal:condition="person.phone_direct and 'phone_direct' not in exclude">
                             <dt i18n:translate>Direct Phone</dt>
-                            <dd><a href="tel:${person.phone_direct}">${person.phone_direct}</a></dd>
+                            <dd><a href="tel:${layout.format_phone_number(person.phone_direct)}">${layout.format_phone_number(person.phone_direct)}</a></dd>
                         </tal:block>
 
                         <tal:block tal:condition="person.website and 'website' not in exclude">
@@ -206,7 +206,7 @@
 
                         <tal:block tal:condition="person.website_2 and 'website_2' not in exclude">
                             <dt i18n:translate>Website 2</dt>
-                            <dd><a href="${person.website_2}">${person .website_2}</a></dd>
+                            <dd><a href="${person.website_2}">${person.website_2}</a></dd>
                         </tal:block>
 
                         <tal:block tal:condition="person.notes and 'notes' not in exclude">

--- a/src/onegov/feriennet/templates/bookings.pt
+++ b/src/onegov/feriennet/templates/bookings.pt
@@ -225,7 +225,7 @@
                                                                                 <i class="fa fa-envelope" aria-hidden="true"></i>
                                                                             </a>
 
-                                                                            <a href="tel:${row.phone}" tal:condition="row.phone" title="${row.phone}">
+                                                                            <a href="tel:${layout.format_phone_number(row.phone)}" tal:condition="row.phone" title="${layout.format_phone_number(row.phone)}">
                                                                                 <span class="show-for-sr" i18n:translate>
                                                                                     Call <tal:b i18n:name="name">${row.parent}</tal:b>
                                                                                 </span>

--- a/src/onegov/feriennet/templates/macros.pt
+++ b/src/onegov/feriennet/templates/macros.pt
@@ -281,7 +281,7 @@
     </div>
     <div tal:define="phone user.data.get('phone')" tal:condition="phone">
         <dt i18n:translate>Phone</dt>
-        <dd><a href="tel:${phone}">${phone}</a></dd>
+        <dd><a href="tel:${layout.format_phone_number(phone)}">${layout.format_phone_number(phone)}</a></dd>
     </div>
 </metal:b
 
@@ -415,7 +415,7 @@
             </tal:b>
             <tal:b condition="'phone' in public">
                 <li class="organiser-phone" tal:condition="organiser.data.phone|nothing">
-                    <a href="tel:${organiser.data.phone}">${organiser.data.phone}</a>
+                    <a href="tel:${layout.format_phone_number(organiser.data.phone)}">${layout.format_phone_number(organiser.data.phone)}</a>
                 </li>
             </tal:b>
             <tal:b condition="'website' in public">

--- a/src/onegov/feriennet/templates/occasion_attendees.pt
+++ b/src/onegov/feriennet/templates/occasion_attendees.pt
@@ -55,12 +55,11 @@
                                 </div>
                                 <div>
                                     <span i18n:translate>Phone:</span>
-                                    <span><a href="tel:${volunteer.phone}">${volunteer.phone}</a></span>
+                                    <span><a href="tel:${layout.format_phone_number(volunteer.phone)}">${layout.format_phone_number(volunteer.phone)}</a></span>
                                 </div>
                             </li>
                         </ul>
                     </tal:b>
-
 
                     <h4 i18n:translate>Attendees</h4>
                     <ul class="attendees">

--- a/src/onegov/feriennet/templates/volunteers.pt
+++ b/src/onegov/feriennet/templates/volunteers.pt
@@ -99,7 +99,7 @@
                                                         </a>
                                                     </li>
                                                     <li>
-                                                        <a href="tel:${record.phone}">
+                                                        <a href="tel:${layout.format_phone_number(record.phone)}">
                                                             <i class="fa fa-fw fa-phone-square" aria-hidden="true"></i>
                                                             <tal:b i18n:translate>
                                                                 Contact by phone
@@ -183,7 +183,7 @@
                                                     <div>
                                                         <dt i18n:translate>Phone</dt>
                                                         <dd>
-                                                            <a href="tel:${record.phone}">${record.phone}</a>
+                                                            <a href="tel:${layout.format_phone_number(record.phone)}">${layout.format_phone_number(record.phone)}</a>
                                                         </dd>
                                                     </div>
                                                 </dl>

--- a/src/onegov/org/layout.py
+++ b/src/onegov/org/layout.py
@@ -665,6 +665,9 @@ class Layout(ChameleonLayout, OpenGraphMixin):
 
         return ''
 
+    def format_phone_number(self, phone_number: str) -> str:
+        return utils.format_phone_number(phone_number)
+
     def password_reset_url(self, user: User | None) -> str | None:
         if not user:
             return None

--- a/src/onegov/org/templates/macros.pt
+++ b/src/onegov/org/templates/macros.pt
@@ -1068,7 +1068,7 @@
 
         <tal:b condition="event.organizer_phone">
             <dt i18n:translate>Organizer phone number</dt>
-            <dd><a href="tel:${event.organizer_phone}" tal:content="event.organizer_phone" /></dd>
+            <dd><a href="tel:${layout.format_phone_number(event.organizer_phone)}" tal:content="layout.format_phone_number(event.organizer_phone)" /></dd>
         </tal:b>
 
         <tal:b condition="event.tags and show_tags">

--- a/src/onegov/org/templates/macros.pt
+++ b/src/onegov/org/templates/macros.pt
@@ -764,7 +764,7 @@
                 <a href="mailto:${person.email}">${person.email}</a>
             </li>
             <li tal:condition="person.phone and 'phone' not in exclude" class="person-card-phone">
-                <a href="tel:${person.phone}">${person.phone}</a>
+                <a href="tel:${layout.format_phone_number(person.phone)}">${layout.format_phone_number(person.phone)}</a>
             </li>
         </ul>
         <div class="clearfix"></div>
@@ -814,10 +814,10 @@
                         <a href="mailto:${person.email}">${person.email}</a>
                     </li>
                     <li tal:condition="person.phone and 'phone' not in exclude" class="person-card-phone">
-                        <a href="tel:${person.phone}">${person.phone}</a>
+                        <a href="tel:${layout.format_phone_number(person.phone)}">${layout.format_phone_number(person.phone)}</a>
                     </li>
                     <li tal:condition="person.phone_direct and 'phone_direct' not in exclude" class="person-card-phone-direct">
-                        <a href="tel:${person.phone_direct}">${person.phone_direct}</a>
+                        <a href="tel:${layout.format_phone_number(person.phone_direct)}">${layout.format_phone_number(person.phone_direct)}</a>
                     </li>
                     <li tal:condition="person.website and 'website' not in exclude" class="person-card-website">
                         <a href="${person.website}">${person.website}</a>

--- a/src/onegov/org/templates/occurrence.pt
+++ b/src/onegov/org/templates/occurrence.pt
@@ -70,7 +70,7 @@
                         </div>
                         <div tal:condition="organizer_phone">
                             <dt i18n:translate>Organizer phone number</dt>
-                            <dd><a href="tel:${organizer_phone}" tal:content="organizer_phone" /></dd>
+                            <dd><a href="tel:${layout.format_phone_number(organizer_phone)}" tal:content="layout.format_phone_number(organizer_phone)" /></dd>
                         </div>
                     </dl>
                 </div>

--- a/src/onegov/org/utils.py
+++ b/src/onegov/org/utils.py
@@ -1258,8 +1258,11 @@ def format_phone_number(phone_number: str) -> str:
     if not phone_number:
         return ''
 
-    parsed = phonenumbers.parse(phone_number, 'CH')
-    return phonenumbers.format_number(
-        parsed,
-        phonenumbers.PhoneNumberFormat.INTERNATIONAL
-    )
+    try:
+        parsed = phonenumbers.parse(phone_number, 'CH')
+
+        return phonenumbers.format_number(
+            parsed, phonenumbers.PhoneNumberFormat.INTERNATIONAL
+        )
+    except phonenumbers.phonenumberutil.NumberParseException:
+        return phone_number

--- a/src/onegov/org/utils.py
+++ b/src/onegov/org/utils.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import colorsys
 import re
+
+import phonenumbers
 import sedate
 import pytz
 
@@ -1247,3 +1249,17 @@ def extract_categories_and_subcategories(
         return cats
 
     return cats, subcats
+
+
+def format_phone_number(phone_number: str) -> str:
+    """
+    Returns phone number in the international format +41 79 123 45 67
+    """
+    if not phone_number:
+        return ''
+
+    parsed = phonenumbers.parse(phone_number, 'CH')
+    return phonenumbers.format_number(
+        parsed,
+        phonenumbers.PhoneNumberFormat.INTERNATIONAL
+    )

--- a/src/onegov/pas/templates/parliamentarian.pt
+++ b/src/onegov/pas/templates/parliamentarian.pt
@@ -85,15 +85,15 @@
             </div>
             <div tal:condition="parliamentarian.phone_private">
                 <dt i18n:translate>Private phone number</dt>
-                <dd>${parliamentarian.phone_private}</dd>
+                <dd>${layout.format_phone_number(parliamentarian.phone_private)}</dd>
             </div>
             <div tal:condition="parliamentarian.phone_mobile">
                 <dt i18n:translate>Mobile phone number</dt>
-                <dd>${parliamentarian.phone_mobile}</dd>
+                <dd>${layout.format_phone_number(parliamentarian.phone_mobile)}</dd>
             </div>
             <div tal:condition="parliamentarian.phone_business">
                 <dt i18n:translate>Business phone number</dt>
-                <dd>${parliamentarian.phone_business}</dd>
+                <dd>${layout.format_phone_number(parliamentarian.phone_business)}</dd>
             </div>
             <div tal:condition="parliamentarian.email_primary">
                 <dt i18n:translate>Primary email address</dt>

--- a/src/onegov/town6/templates/macros.pt
+++ b/src/onegov/town6/templates/macros.pt
@@ -1055,10 +1055,10 @@
                 <a href="mailto:${person.email}">${person.email}</a>
             </li>
             <li tal:condition="person.phone and 'phone' not in exclude" class="person-card-phone">
-                <a href="tel:${person.phone}">${person.phone}</a>
+                <a href="tel:${layout.format_phone_number(person.phone)}">${layout.format_phone_number(person.phone)}</a>
             </li>
             <li tal:condition="person.phone_direct and 'phone_direct' not in exclude" class="person-card-phone_direct">
-                <a href="tel:${person.phone_direct}">${person.phone_direct}</a>
+                <a href="tel:${layout.format_phone_number(person.phone_direct)}">${layout.format_phone_number(person.phone_direct)}</a>
             </li>
         </ul>
         <a href="${link}"><i class="fa fa-chevron-right"></i></a>
@@ -1108,10 +1108,10 @@
                         <a href="mailto:${person.email}">${person.email}</a>
                     </li>
                     <li tal:condition="person.phone and 'phone' not in exclude" class="person-card-phone">
-                        <a href="tel:${person.phone}">${person.phone}</a>
+                        <a href="tel:${layout.format_phone_number(person.phone)}">${layout.format_phone_number(person.phone)}</a>
                     </li>
                     <li tal:condition="person.phone_direct and 'phone_direct' not in exclude" class="person-card-phone-direct">
-                        <a href="tel:${person.phone_direct}">${person.phone_direct}</a>
+                        <a href="tel:${layout.format_phone_number(person.phone_direct)}">${layout.format_phone_number(person.phone_direct)}</a>
                     </li>
                     <li tal:condition="person.website and 'website' not in exclude" class="person-card-website">
                         <a href="${person.website}">${person.website}</a>

--- a/src/onegov/town6/templates/macros.pt
+++ b/src/onegov/town6/templates/macros.pt
@@ -1373,7 +1373,7 @@
         </tal:b>
         <tal:b condition="event.organizer_phone">
             <dt i18n:translate>Organizer phone number</dt>
-            <dd><a href="tel:${event.organizer_phone}" tal:content="event.organizer_phone" /></dd>
+            <dd>tschupre <a href="tel:${layout.format_phone_number(event.organizer_phone)}" tal:content="layout.format_phone_number(event.organizer_phone)" /></dd>
         </tal:b>
 
         <tal:b condition="event.tags and show_tags">

--- a/src/onegov/town6/templates/occurrence.pt
+++ b/src/onegov/town6/templates/occurrence.pt
@@ -69,7 +69,7 @@
                         </div>
                         <div tal:condition="organizer_phone">
                             <dt i18n:translate>Organizer phone number</dt>
-                            <dd><a href="tel:${organizer_phone}" tal:content="organizer_phone" /></dd>
+                            <dd><a href="tel:${layout.format_phone_number(organizer_phone)}" tal:content="layout.format_phone_number(organizer_phone)" /></dd>
                         </div>
                     </dl>
                 </div>

--- a/tests/onegov/feriennet/test_views.py
+++ b/tests/onegov/feriennet/test_views.py
@@ -549,7 +549,7 @@ def test_organiser_info(client, scenario):
     contact.form['zip_code'] = '20001'
     contact.form['place'] = 'Washington'
     contact.form['email'] = 'editors-association@example.org'
-    contact.form['phone'] = '+41 23 456 789'
+    contact.form['phone'] = '+41234567890'
     contact.form['website'] = 'https://www.example.org'
     contact.form['emergency'] = '+01 234 56 78 (Peter)'
     contact.form.submit()
@@ -600,28 +600,28 @@ def test_organiser_info(client, scenario):
     assert "Admins Association" not in page
     assert "Washington" in page
     assert "editors-association@example.org" not in page
-    assert "+41 23 456 789" not in page
+    assert "+41 23 456 78 90" not in page
     assert "https://www.example.org" not in page
 
     page = with_public_organiser_data(['email'])
     assert "Admins Association" not in page
     assert "Washington" not in page
     assert "editors-association@example.org" in page
-    assert "+41 23 456 789" not in page
+    assert "+41 23 456 78 90" not in page
     assert "https://www.example.org" not in page
 
     page = with_public_organiser_data(['phone'])
     assert "Admins Association" not in page
     assert "Washington" not in page
     assert "editors-association@example.org" not in page
-    assert "+41 23 456 789" in page
+    assert "+41 23 456 78 90" in page
     assert "https://www.example.org" not in page
 
     page = with_public_organiser_data(['website'])
     assert "Admins Association" not in page
     assert "Washington" not in page
     assert "editors-association@example.org" not in page
-    assert "+41 23 456 789" not in page
+    assert "+41 23 456 78 90" not in page
     assert "https://www.example.org" in page
 
 

--- a/tests/onegov/org/test_utils.py
+++ b/tests/onegov/org/test_utils.py
@@ -322,3 +322,8 @@ def test_format_phone_number():
     assert utils.format_phone_number('41') == '+41 41'
     assert utils.format_phone_number('') == ''
     assert utils.format_phone_number(None) == ''
+
+    # force error (too long for phone number), will return the input
+    long_text = ('You can reach me during office hours at 041 111 22 33 '
+                 'otherwise at 041 111 22 44')
+    assert utils.format_phone_number(long_text) == long_text

--- a/tests/onegov/org/test_utils.py
+++ b/tests/onegov/org/test_utils.py
@@ -1,4 +1,6 @@
 from datetime import date, datetime
+
+
 from onegov.core.utils import Bunch
 from onegov.org import utils
 from pytz import timezone
@@ -297,3 +299,26 @@ def test_extract_categories_and_subcategories():
     result = utils.extract_categories_and_subcategories(categories,
                                                         flattened=True)
     assert result == ['a', 'b', 'c', 'd', 'a1', 'a2', 'b1']
+
+
+def test_format_phone_number():
+    assert utils.format_phone_number('+41411112233') == '+41 41 111 22 33'
+    assert utils.format_phone_number('0041411112233') == '+41 41 111 22 33'
+    assert utils.format_phone_number('0411112233') == '+41 41 111 22 33'
+    assert utils.format_phone_number('411112233') == '+41 41 111 22 33'
+    assert utils.format_phone_number('41 111 22 33') == '+41 41 111 22 33'
+    assert utils.format_phone_number('041 111 22 33') == '+41 41 111 22 33'
+    assert utils.format_phone_number('041-111-22-33') == '+41 41 111 22 33'
+    assert utils.format_phone_number('041/111/22/33') == '+41 41 111 22 33'
+    assert utils.format_phone_number('041/111-22 33') == '+41 41 111 22 33'
+
+    # invalid phone numbers are just prefixed with the country code
+    assert utils.format_phone_number('41111223') == '+41 41111223'
+    assert utils.format_phone_number('4111122') == '+41 4111122'
+    assert utils.format_phone_number('411112') == '+41 411112'
+    assert utils.format_phone_number('41111') == '+41 41111'
+    assert utils.format_phone_number('4111') == '+41 4111'
+    assert utils.format_phone_number('411') == '+41 411'
+    assert utils.format_phone_number('41') == '+41 41'
+    assert utils.format_phone_number('') == ''
+    assert utils.format_phone_number(None) == ''

--- a/tests/onegov/org/test_views_event.py
+++ b/tests/onegov/org/test_views_event.py
@@ -400,7 +400,7 @@ def test_submit_event(broadcast, authenticate, connect, client, skip):
     assert "Bibliothek" in preview_page
     assert "The Organizer" in preview_page
     assert "event@myevents.ch" in preview_page
-    assert "076 987 65 43" in preview_page
+    assert "+41 76 987 65 43" in preview_page
     assert "{} 18:00 - 22:00".format(
         babel.dates.format_date(
             start_date, format='d. MMMM yyyy', locale='de'
@@ -480,7 +480,7 @@ def test_submit_event(broadcast, authenticate, connect, client, skip):
     assert "A special place" in ticket_page
     assert "The Organizer" in ticket_page
     assert "event@myevents.ch" in preview_page
-    assert "076 987 65 43" in preview_page
+    assert "+41 76 987 65 43" in preview_page
     assert "Ausstellung" in ticket_page
     assert "Bibliothek" in ticket_page
     assert "Veranstaltung bearbeitet" in ticket_page
@@ -536,7 +536,7 @@ def test_submit_event(broadcast, authenticate, connect, client, skip):
     assert "Bibliothek" in message
     assert "A carful organizer" in message
     assert "info@myevents.ch" in preview_page
-    assert "076 111 22 33" in preview_page
+    assert "+41 76 111 22 33" in preview_page
     assert "{} 18:00 - 22:00".format(
         start_date.strftime('%d.%m.%Y')) in message
     for days in range(5):

--- a/tests/onegov/town6/test_views_event.py
+++ b/tests/onegov/town6/test_views_event.py
@@ -160,7 +160,7 @@ def test_event_steps(broadcast, authenticate, connect, client):
 
     # Make some more corrections
     form_page = confirmation_page.click("Bearbeiten Sie diese Veranstaltung.")
-    form_page.form['organizer'] = "A carful organizer"
+    form_page.form['organizer'] = "A careful organizer"
     form_page.form['organizer_phone'] = "079 123 45 56"
     preview_page = form_page.form.submit().follow()
     assert "My event is exceptional." in preview_page
@@ -191,8 +191,8 @@ def test_event_steps(broadcast, authenticate, connect, client):
     assert "A special place" in message
     assert "Ausstellung" in message
     assert "Bibliothek" in message
-    assert "A carful organizer" in message
-    assert "079 123 45 56" in ticket_page
+    assert "A careful organizer" in message
+    assert "+41 79 123 45 56" in ticket_page
     assert "a@b.ch" in ticket_page
     assert "{} 18:00 - 22:00".format(
         start_date.strftime('%d.%m.%Y')) in message


### PR DESCRIPTION
Org: Display phone numbers in international format

The international format prefixes the country code e.g. +41 for Switzerland

TYPE: Feature
LINK: ogc-2113