### PR TITLE
Core: Make AdjacencyList use midpoint for insertion of new items.

### DIFF
--- a/src/onegov/agency/data_import.py
+++ b/src/onegov/agency/data_import.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from decimal import Decimal
 import re
 from collections import defaultdict
 from datetime import datetime
@@ -656,8 +657,8 @@ def import_lu_agencies(
     top_level.sort(key=lambda a: a.title)
     for ix, agency in enumerate(top_level, start=1):
         if agency.title == 'Staatskanzlei':
-            agency.order = 0
-        agency.order = ix
+            agency.order = Decimal(0)
+        agency.order = Decimal(ix)
 
     session.flush()
 

--- a/src/onegov/core/orm/abstract/adjacency_list.py
+++ b/src/onegov/core/orm/abstract/adjacency_list.py
@@ -5,7 +5,7 @@ from itertools import chain
 from lazy_object_proxy import Proxy  # type:ignore[import-untyped]
 from onegov.core.orm import Base, observes
 from onegov.core.utils import normalize_for_url, increment_name, is_sorted
-from sqlalchemy import Column, ForeignKey, Integer, Text
+from sqlalchemy import Column, ForeignKey, Integer, Text, Numeric
 from sqlalchemy.ext.declarative import declared_attr
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import (
@@ -119,7 +119,7 @@ class AdjacencyList(Base):
 
     #: the order of the items - items are added at the end by default
     # FIXME: This should probably have been nullable=False
-    order: Column[int] = Column(Integer, default=2 ** 16)
+    order = Column(Numeric(precision=30, scale=15), default=2**16)
 
     # default sort order is order, id
     @declared_attr

--- a/src/onegov/core/orm/abstract/adjacency_list.py
+++ b/src/onegov/core/orm/abstract/adjacency_list.py
@@ -531,7 +531,8 @@ class AdjacencyListCollection(Generic[_L]):
             else:
                 # --- Strategy 2: Append numerically at the end ---
                 child.order = max(
-                    (s.order for s in existing_siblings if s.order is not None),
+                    (s.order for s in existing_siblings if s.order
+                        is not None),
                     default=Decimal('65535'),
                 ) + Decimal('1')
 

--- a/src/onegov/core/upgrades.py
+++ b/src/onegov/core/upgrades.py
@@ -230,15 +230,15 @@ def change_adjacency_list_order_to_numeric(context: UpgradeContext) -> None:
             and not isabstract(cls)
         )
 
-    adjacency_subclasses = set(
-        chain(
+    table_names: set[str] = {
+        cls.__tablename__  # type: ignore[attr-defined]
+        for cls in chain(
             find_models(Base, is_concrete_subclass),
             find_models(ORMBase, is_concrete_subclass),
         )
-    )
+    }
 
-    for cls in adjacency_subclasses:
-        table_name = cls.__tablename__  # type: ignore[attr-defined]
+    for table_name in table_names:
         if context.has_table(table_name):
             context.operations.alter_column(
                 table_name,

--- a/src/onegov/org/cronjobs.py
+++ b/src/onegov/org/cronjobs.py
@@ -1070,7 +1070,7 @@ def normalize_adjacency_list_order(request: OrgRequest) -> None:
                         "{pk_column}",
                         ROW_NUMBER() OVER (
                             PARTITION BY "{parent_column}" -- Partition by actual parent_id
-                            ORDER BY "{order_column}" ASC
+                            ORDER BY "{order_column}" ASC NULLS LAST
                         ) as new_order
                     FROM
                         "{table_name}"
@@ -1083,6 +1083,7 @@ def normalize_adjacency_list_order(request: OrgRequest) -> None:
                 WHERE "{table_name}"."{pk_column}" = numbered_siblings."{pk_column}";
                 COMMIT;
             """)
+
             # Note: The CTE 'numbered_siblings' already filters for non-null parent_id,
             # so we only need to join by primary key here.
 

--- a/src/onegov/org/cronjobs.py
+++ b/src/onegov/org/cronjobs.py
@@ -1093,7 +1093,7 @@ def normalize_adjacency_list_order(request: OrgRequest) -> None:
             where "{table_name}"."{pk_column_name}" =
                 numbered_siblings."{pk_column_name}";
             COMMIT;
-        """)
+        """)  # nosec: B608
 
         try:
             session.execute(update_sql)

--- a/src/onegov/org/cronjobs.py
+++ b/src/onegov/org/cronjobs.py
@@ -1103,4 +1103,4 @@ def normalize_adjacency_list_order(request: OrgRequest) -> None:
             try:
                 session.rollback()
             except Exception:
-                log.exception(f"Error during rollback for table '{table_name}'")
+                log.exception(f"Error during rollback for '{table_name}'")

--- a/src/onegov/org/request.py
+++ b/src/onegov/org/request.py
@@ -231,17 +231,6 @@ class OrgRequest(CoreRequest):
         return tuple(p for p in self.pages_tree if include(p))
 
     @orm_cached(policy='on-table-change:pages', by_role=True)
-    def news_root_pages(self) -> tuple[PageMeta, ...]:
-
-        def include(page: PageMeta) -> bool:
-            if page.type == 'news':
-                return True
-
-            return True if page.children else False
-
-        return tuple(p for p in self.pages_tree if include(p))
-
-    @orm_cached(policy='on-table-change:pages', by_role=True)
     def homepage_pages(self) -> dict[int, list[PageMeta]]:
 
         def visit_topics(

--- a/src/onegov/org/request.py
+++ b/src/onegov/org/request.py
@@ -231,6 +231,17 @@ class OrgRequest(CoreRequest):
         return tuple(p for p in self.pages_tree if include(p))
 
     @orm_cached(policy='on-table-change:pages', by_role=True)
+    def news_root_pages(self) -> tuple[PageMeta, ...]:
+
+        def include(page: PageMeta) -> bool:
+            if page.type == 'news':
+                return True
+
+            return True if page.children else False
+
+        return tuple(p for p in self.pages_tree if include(p))
+
+    @orm_cached(policy='on-table-change:pages', by_role=True)
     def homepage_pages(self) -> dict[int, list[PageMeta]]:
 
         def visit_topics(

--- a/src/onegov/org/request.py
+++ b/src/onegov/org/request.py
@@ -241,24 +241,6 @@ class OrgRequest(CoreRequest):
 
         return tuple(p for p in self.pages_tree if include(p))
 
-    def visualize_page_tree(
-        self,
-        pages: Iterable[PageMeta],
-        indent: int = 0
-    ) -> str:
-        """ Returns a string visualizing the page tree structure. """
-        result = ''
-        indent_str = '  ' * indent
-        for page in pages:
-            child_count = len(page.children)
-            result += (
-                f'{indent_str}- {page.title} '
-                f'({page.type}, {child_count} children)\n'
-            )
-            if page.children:
-                result += self.visualize_page_tree(page.children, indent + 1)
-        return result
-
     @orm_cached(policy='on-table-change:pages', by_role=True)
     def homepage_pages(self) -> dict[int, list[PageMeta]]:
 

--- a/src/onegov/org/request.py
+++ b/src/onegov/org/request.py
@@ -241,6 +241,24 @@ class OrgRequest(CoreRequest):
 
         return tuple(p for p in self.pages_tree if include(p))
 
+    def visualize_page_tree(
+        self,
+        pages: Iterable[PageMeta],
+        indent: int = 0
+    ) -> str:
+        """ Returns a string visualizing the page tree structure. """
+        result = ''
+        indent_str = '  ' * indent
+        for page in pages:
+            child_count = len(page.children)
+            result += (
+                f'{indent_str}- {page.title} '
+                f'({page.type}, {child_count} children)\n'
+            )
+            if page.children:
+                result += self.visualize_page_tree(page.children, indent + 1)
+        return result
+
     @orm_cached(policy='on-table-change:pages', by_role=True)
     def homepage_pages(self) -> dict[int, list[PageMeta]]:
 

--- a/src/onegov/people/models/agency.py
+++ b/src/onegov/people/models/agency.py
@@ -15,6 +15,7 @@ from onegov.file.utils import extension_for_content_type
 from onegov.gis import CoordinatesMixin
 from onegov.people.models.membership import AgencyMembership
 from onegov.search import ORMSearchable
+from decimal import Decimal
 from sqlalchemy import Column
 from sqlalchemy import Text
 from sqlalchemy.orm import object_session
@@ -211,7 +212,7 @@ class Agency(AdjacencyList, ContentMixin, TimestampMixin, ORMSearchable,
 
         children = sorted(self.children, key=sortkey)
         for order, child in enumerate(children):
-            child.order = order
+            child.order = Decimal(order)
 
     def sort_relationships(
         self,

--- a/src/onegov/server/cli.py
+++ b/src/onegov/server/cli.py
@@ -561,6 +561,9 @@ class WsgiServer(FileSystemEventHandler):
         if src_path.endswith('.rdb'):
             return
 
+        if src_path.endswith('.md'):
+            return
+
         if '/.testmondata' in src_path:
             return
 

--- a/tests/onegov/core/test_adjacency_list.py
+++ b/tests/onegov/core/test_adjacency_list.py
@@ -278,7 +278,6 @@ def test_change_title(session):
 
     b.title = 'd'
 
-    # is still ['a', 'b', 'c']
     assert a.siblings.all() == [a, c, b]
 
 
@@ -309,7 +308,9 @@ def test_numeric_priority():
         'ABA',
         'Z',
     )
-    assert sorted(input, key=numeric_priority) == ['A', 'AA', 'ABA', 'BA', 'Z']
+    assert sorted(input, key=numeric_priority) == [
+        'A', 'AA', 'ABA', 'BA', 'Z'
+    ]
 
 
 def test_move_uses_binary_gap(session):

--- a/tests/onegov/core/test_adjacency_list_performance.py
+++ b/tests/onegov/core/test_adjacency_list_performance.py
@@ -70,7 +70,7 @@ def test_add_performance_large_collection(session, item_count):
     assert new_item is not None
     assert new_item.title == title_to_add
     # Fetch from DB to be sure
-    fetched_item = session.get(News, new_item.id)
+    fetched_item = session.query(News).get(new_item.id)
     assert fetched_item is not None
 
     # The crucial assertion: Adding one item should be very fast.

--- a/tests/onegov/core/test_adjacency_list_performance.py
+++ b/tests/onegov/core/test_adjacency_list_performance.py
@@ -1,0 +1,91 @@
+import pytest
+import time
+
+from onegov.core.utils import Bunch
+from onegov.org.models import News, NewsCollection
+from onegov.core.utils import normalize_for_url
+
+
+@pytest.mark.parametrize("item_count", [1000])  # Parameterize if needed later
+def test_add_performance_large_collection(session, item_count):
+    """
+    Previously we had the following issue:
+    AdjacencyList items were sorted alphabetically by sort key. When we
+    had 1200 news items (not unusual in real world scenarios) and
+    created a news item with title 'AAAAAAA', depending on the tree
+    structure, the order was adjusted for a lot of news items.
+    Everything went into the ORM update queue from the Indexer, creating
+    a delay of several seconds.
+
+    To tackle this problem, we have now a smarter insertion method, starting
+    at the midpoint.
+
+    So this test verifies that adding one item is fast and doesn't scale
+    linearly with the number of existing items (i.e., avoids O(N) updates
+    to all ordering).
+    """
+
+    request = Bunch(session=session)
+    news_collection = NewsCollection(request)
+
+    start_setup = time.perf_counter()
+    for i in range(item_count):
+        # Use unique titles to ensure they spread out in initial order
+        title = f'News Item {i:04d}'
+        title = normalize_for_url(title)
+        # Add as root items for simplicity, adjust if parent is required
+        item = News(title=title, name=title, type='news')
+        session.add(item)
+        # Flush periodically to manage transaction size
+        if i % 100 == 99:
+            print(f'  Flushing at item {i + 1}...')
+            session.flush()
+
+    # Final flush and commit to persist the initial items
+    session.flush()
+    end_setup = time.perf_counter()
+    print(f'Setup took {end_setup - start_setup:.4f} seconds.')
+
+    # --- Timed Addition Phase ---
+    title_to_add = (
+        'AAAAAA Very First News'  # Title designed to go near the start
+    )
+    print(f"Timing the addition of one news item ('{title_to_add}')...")
+
+    start_add = time.perf_counter()
+
+    # Add one item using the collection method
+    new_item = news_collection.add(
+        parent=None, title=title_to_add
+    )  # Add as root
+    session.flush()  # Ensure the add operation (incl. order calc and DB write) completes
+
+    end_add = time.perf_counter()
+    duration_add = end_add - start_add
+
+    print(f'Adding one item took {duration_add:.6f} seconds.')
+
+    # --- Verification ---
+    # Check the item was added
+    assert new_item is not None
+    assert new_item.title == title_to_add
+    # Fetch from DB to be sure
+    fetched_item = session.get(News, new_item.id)
+    assert fetched_item is not None
+
+    # The crucial assertion: Adding one item should be very fast.
+    # Set a generous threshold (e.g., 0.5 seconds). If it takes longer,
+    # it suggests the O(N) update problem might still exist.
+    # Adjust threshold based on your system/DB performance, but it should
+    # be significantly less than the setup time or multiple seconds.
+    threshold = 0.5
+    assert duration_add < threshold, (
+        f'Adding one item took too long ({duration_add:.6f}s), '
+        f'expected less than {threshold}s. Possible O(N) update issue?'
+    )
+
+    # Optional: Clean up if session fixture doesn't handle it fully
+    # (e.g., if using a persistent test DB)
+    # print("Cleaning up...")
+    # session.query(News).delete()
+    # session.commit()

--- a/tests/onegov/org/test_cronjobs.py
+++ b/tests/onegov/org/test_cronjobs.py
@@ -1845,7 +1845,7 @@ def test_normalize_adjacency_list_order(org_app):
     assert [n.order for n in news_items] == [
         Decimal('1.0'), Decimal('5.0'), Decimal('10.0')
     ]
-    assert [n.title for n in news_items] == ["News 1", "News 2", "News 3"]
+    assert [n.title for n in news_items] == ['News 1', 'News 2', 'News 3']
 
     # Execute the cron job
     client.get(get_cronjob_url(job))
@@ -1862,7 +1862,8 @@ def test_normalize_adjacency_list_order(org_app):
     ]
 
     # Relative order must be preserved
-    assert [n.title for n in news_items_after] == ["News 1", "News 2", "News 3"]
+    assert [n.title for n in news_items_after] == ['News 1',
+                                                   'News 2', 'News 3']
     # Verify the root page order was not affected
     root = pages.by_id(news_root_id)
     assert root.order == default_root_order
@@ -1878,9 +1879,9 @@ def test_normalize_adjacency_list_order_with_null_becomes_default(org_app):
     # Corresponds to default value set in AdjacencyList.order
     default_order_value = Decimal('65536')
     items_data = [
-        ("Item C", Decimal('1.0')),
-        ("Item A", Decimal('5.0')),
-        ("Item B", None),  # Pass None, expecting it to take the default value
+        ('Item C', Decimal('1.0')),
+        ('Item A', Decimal('5.0')),
+        ('Item B', None),  # Pass None, expecting it to take the default value
     ]
 
     pages = PageCollection(session)
@@ -1895,17 +1896,16 @@ def test_normalize_adjacency_list_order_with_null_becomes_default(org_app):
     _create_news_hierarchy(session, root_item, items_data)
     transaction.commit()
 
-    # Verify initial state - Check that None resulted in the default value
+    # Verify initial state
     news_items_initial = pages.query().filter(
-        News.parent_id == news_root_id).order_by(News.title).all()  # Order by title for check
+        News.parent_id == news_root_id).order_by(News.title).all()
     orders_initial = {n.title: n.order for n in news_items_initial}
     assert orders_initial == {
-        "Item A": Decimal('5.0'),
-        "Item B": default_order_value,  # Check it received the default
-        "Item C": Decimal('1.0'),
+        'Item A': Decimal('5.0'),
+        'Item B': default_order_value,  # Check it received the default
+        'Item C': Decimal('1.0'),
     }
 
-    # Execute the cron job
     client.get(get_cronjob_url(job))
     session.expire_all()  # Force reload from DB
 
@@ -1918,10 +1918,8 @@ def test_normalize_adjacency_list_order_with_null_becomes_default(org_app):
     news_items_after = NewsCollection(request).query().filter(
         News.parent_id == news_root_id).order_by(News.order).all()
 
-    # Expected normalized orders based on initial values (1.0, 5.0, 65536.0)
     expected_orders = [Decimal('1.0'), Decimal('2.0'), Decimal('3.0')]
-    # Expected titles in the new order
-    expected_titles = ["Item C", "Item A", "Item B"]
+    expected_titles = ['Item C', 'Item A', 'Item B']
 
     assert [n.order for n in news_items_after] == expected_orders
     assert [n.title for n in news_items_after] == expected_titles


### PR DESCRIPTION
## Commit message

Core: Make AdjacencyList use midpoint for insertion of new items.

It's essentially implementing a sparse ordering system where new 
items can be inserted between existing ones. This means we can
now insert news items without having to reorder everything.

TYPE: Performance
LINK: OGC-2134


## Before / After: Submitting a News
| Before | After |
|--------|-------|
| ![image](https://github.com/user-attachments/assets/e05b1c4e-d6fd-4724-b13c-242113c9a26b) | ![image](https://github.com/user-attachments/assets/7a83b8f6-c920-40c6-bbd2-eb5a2d041994) |

## TODO

- [ ] clean up: there's technically no need for `sort_siblings` function anymore. Shall we remove it

## Checklist

- [x] I considered adding a reviewer
- [x] I have tested my code thoroughly by hand
- [x] I have added tests for my changes/features

