### PR TITLE
Reservation: Fixes decimal fractions being silently dropped in `price`.

### DIFF
--- a/src/onegov/reservation/models/custom_reservation.py
+++ b/src/onegov/reservation/models/custom_reservation.py
@@ -46,7 +46,7 @@ class CustomReservation(Reservation, ModelBase, Payable):
         if resource.pricing_method == 'per_hour':
             assert self.start is not None and self.end is not None
             duration = self.end + timedelta(microseconds=1) - self.start
-            hours = duration.total_seconds() // 3600
+            hours = duration.total_seconds() / 3600
 
             assert resource.price_per_hour is not None
             return Price(hours * resource.price_per_hour, resource.currency)

--- a/tests/onegov/org/test_views_resources.py
+++ b/tests/onegov/org/test_views_resources.py
@@ -2639,3 +2639,51 @@ def test_resource_recipient_overview(client):
     assert "Gymnasium" in page
     assert "Dailypass" in page
     assert "Meeting" not in page
+
+
+@freeze_time("2024-04-08", tick=True)
+def test_reserve_fractions_of_hours_total_correct_in_price(client):
+    resources = ResourceCollection(client.app.libres_context)
+    resource = resources.by_name('tageskarte')
+    assert resource
+    resource.pricing_method = 'per_hour'
+    resource.price_per_hour = 10.00
+    resource.payment_method = 'manual'
+
+    scheduler = resource.get_scheduler(client.app.libres_context)
+    allocations = scheduler.allocate(
+        dates=(
+            datetime(2024, 4, 9, 10, 0),
+            datetime(2024, 4, 9, 14, 0)  # 4-hour slot
+        ),
+        partly_available=True,
+        whole_day=False
+    )
+
+    reserve = client.bound_reserve(allocations[0])
+    transaction.commit()
+
+    # Reserve 1.5 hours (10:00 to 11:30)
+    result = reserve(start='10:00', end='11:30')
+    assert result.json == {'success': True}
+
+    # Check price on confirmation page
+    form_page = client.get('/resource/tageskarte/form')
+    form_page.form['email'] = 'tester@example.org'
+    form_page.showbrowser()
+
+    confirmation_page = form_page.form.submit().follow()
+
+    # Expected price: 1.5 hours * 10.00 CHF/hour = 15.00 CHF
+    total_amount_dt = confirmation_page.pyquery('dt:contains("Totalbetrag")')
+    assert total_amount_dt, 'Total amount dt not found'
+    total_amount_dd = total_amount_dt.next('dd')
+    assert total_amount_dd, 'Total amount dd not found'
+    assert total_amount_dd.text().strip() == '15.00'
+    assert '10:00 - 11:30' in confirmation_page
+
+    # Check price in reservations JSON
+    reservations_url = '/resource/tageskarte/reservations'
+    reservations_data = client.get(reservations_url).json['reservations']
+    assert len(reservations_data) == 1
+    assert reservations_data[0]['price']['amount'] == 15.00


### PR DESCRIPTION
## Commit message

Reservation: Fixes decimal fractions being silently dropped in `price`.

This only occurred when the reservation duration wasn’t a whole hour 
e.g., 1.5 hours was truncated to 1.0 hour.

<Optional Description>

TYPE: Bugfix
LINK: OGC-2152


## Checklist

- [x] I have performed a self-review of my code

