### PR TITLE
No need to escape a string that doesn't contain html

### DIFF
--- a/src/onegov/feriennet/views/notification_template.py
+++ b/src/onegov/feriennet/views/notification_template.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 from collections import OrderedDict
 
-from markupsafe import escape
+from markupsafe import Markup
+
 
 from onegov.activity import PeriodCollection
 from onegov.core.elements import BackLink
@@ -183,7 +184,7 @@ def handle_send_notification(
     variables = TemplateVariables(request, period)
     layout = NotificationTemplateLayout(self, request)
 
-    subject = variables.render(escape(self.subject))
+    subject = variables.render(Markup(self.subject))  # nosec: B704
     message = variables.render(sanitize_html(self.text))
 
     if form.submitted(request):


### PR DESCRIPTION
Please fill in the commit message below and work through the checklist. You can delete parts that are not needed, e.g. the optional description, the link to a ticket or irrelevant options of the checklist.

## Commit message

Feriennet: Display quotes in mail subjects correctly

TYPE: Bugfix
LINK: PRO-1297