### PR TITLE
Add retry for postmark bounce api call

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
         exclude: .pre-commit-config.yaml
       - id: pt_structure
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.7
+    rev: v0.11.8
     hooks:
       - id: ruff
         args: [ "--fix" ]
@@ -32,7 +32,7 @@ repos:
     - id: scss-lint
       files: '^src/.*\.scss'
   - repo: https://github.com/pre-commit/mirrors-eslint
-    rev: v9.25.1
+    rev: v9.26.0
     hooks:
     - id: eslint
       files: '^src/.*\.jsx?$'

--- a/src/onegov/org/cronjobs.py
+++ b/src/onegov/org/cronjobs.py
@@ -844,7 +844,7 @@ def update_newsletter_email_bounce_statistics(
     # Postmark uses EST in `fromdate` and `todate`, see
     # https://postmarkapp.com/developer/api/bounce-api.
 
-    def create_retry_session():
+    def create_retry_session() -> requests.Session:
         adapter = HTTPAdapter(max_retries=Retry(
             total=3,
             backoff_factor=3,
@@ -875,11 +875,11 @@ def update_newsletter_email_bounce_statistics(
             r = session.get(
                 'https://api.postmarkapp.com/bounces',
                 params={
-                    'count': 500,
-                    'offset': 0,
-                    'fromDate': yesterday.date(),
-                    'toDate': yesterday.date(),
-                    'inactive': True,
+                    'count': '500',
+                    'offset': '0',
+                    'fromDate': str(yesterday.date()),
+                    'toDate': str(yesterday.date()),
+                    'inactive': 'true',
                 },
                 headers={
                     'Accept': 'application/json',

--- a/tests/onegov/org/test_cronjobs.py
+++ b/tests/onegov/org/test_cronjobs.py
@@ -1608,7 +1608,7 @@ def test_update_newsletter_email_bounce_statistics(org_app, handlers):
     transaction.commit()
     close_all_sessions()
 
-    with patch('requests.get') as mock_get:
+    with patch('requests.Session.get') as mock_get:
         mock_get.return_value = Bunch(
             status_code=200,
             json=lambda: {
@@ -1644,7 +1644,7 @@ def test_update_newsletter_email_bounce_statistics(org_app, handlers):
             'michu@user.ch').is_inactive is False
 
     # test raising runtime warning exception for status code 401
-    with patch('requests.get') as mock_get:
+    with patch('requests.Session.get') as mock_get:
         mock_get.return_value = Bunch(
             status_code=401,
             json=lambda: {},
@@ -1658,7 +1658,7 @@ def test_update_newsletter_email_bounce_statistics(org_app, handlers):
 
     # for other 30x and 40x status codes, the cronjob shall raise an exception
     for status_code in [301, 302, 303, 400, 402, 403, 404, 405]:
-        with patch('requests.get') as mock_get:
+        with patch('requests.Session.get') as mock_get:
             mock_get.return_value = Bunch(
                 status_code=status_code,
                 json=lambda: {},


### PR DESCRIPTION
Org: Add retry mechanism for postmark api calls on email bounce statistics cron job

TYPE: Feature
LINK: None

https://seantis-gmbh.sentry.io/issues/6583043507/