### PR TITLE
Don't require swisspass id

### DIFF
--- a/src/onegov/feriennet/forms/attendee.py
+++ b/src/onegov/feriennet/forms/attendee.py
@@ -128,8 +128,7 @@ class AttendeeForm(AttendeeBase):
 
     swisspass = StringField(
         label=_('Swisspass ID'),
-        description='XXX-XXX-XXX-X',
-        validators=[InputRequired()],
+        description='XXX-XXX-XXX-X'
     )
 
     differing_address = BooleanField(
@@ -237,7 +236,6 @@ class AttendeeSignupForm(AttendeeBase):
     swisspass = StringField(
         label=_('Swisspass ID'),
         description='XXX-XXX-XXX-X',
-        validators=[InputRequired()],
         depends_on=('attendee', 'other')
     )
 


### PR DESCRIPTION
Please fill in the commit message below and work through the checklist. You can delete parts that are not needed, e.g. the optional description, the link to a ticket or irrelevant options of the checklist.

## Commit message

Feriennet: Swisspass ID is now optional

TYPE: Feature
LINK: OGC-1388