### PR TITLE
Org: Allows adjusting individual reservations within a ticket

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
         exclude: .pre-commit-config.yaml
       - id: pt_structure
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.8
+    rev: v0.11.9
     hooks:
       - id: ruff
         args: [ "--fix" ]
@@ -26,11 +26,13 @@ repos:
         files: '^src.*\.py'
         additional_dependencies:
         - flake8-type-checking>=3.0.0
-  - repo: https://github.com/pre-commit/mirrors-scss-lint
-    rev: 'v0.60.0'
-    hooks:
-    - id: scss-lint
-      files: '^src/.*\.scss'
+# FIXME: Let's try to get a maintained and correctly configured scss linter
+#        back into the workflow, right now this one is broken: OGC-2251
+#  - repo: https://github.com/pre-commit/mirrors-scss-lint
+#    rev: 'v0.60.0'
+#    hooks:
+#    - id: scss-lint
+#      files: '^src/.*\.scss'
   - repo: https://github.com/pre-commit/mirrors-eslint
     rev: v9.26.0
     hooks:

--- a/src/onegov/agency/pdf.py
+++ b/src/onegov/agency/pdf.py
@@ -271,7 +271,7 @@ class AgencyPdfZg(AgencyPdfDefault):
         canvas.drawRightString(
             doc.pagesize[0] - doc.rightMargin,
             doc.bottomMargin / 2,
-            f'{canvas.getPageNumber()}'  # type:ignore[no-untyped-call]
+            f'{canvas.getPageNumber()}'
         )
         canvas.restoreState()
 
@@ -316,7 +316,7 @@ class AgencyPdfAr(AgencyPdfDefault):
         canvas.drawRightString(
             doc.pagesize[0] - doc.rightMargin,
             doc.bottomMargin / 2,
-            f'{canvas.getPageNumber()}'  # type:ignore[no-untyped-call]
+            f'{canvas.getPageNumber()}'
         )
         canvas.restoreState()
 
@@ -439,7 +439,7 @@ class AgencyPdfBs(AgencyPdfDefault):
         canvas.drawRightString(
             doc.pagesize[0] - doc.rightMargin,
             doc.bottomMargin / 2,
-            f'{canvas.getPageNumber()}'  # type:ignore[no-untyped-call]
+            f'{canvas.getPageNumber()}'
         )
         canvas.restoreState()
 

--- a/src/onegov/org/app.py
+++ b/src/onegov/org/app.py
@@ -591,6 +591,7 @@ def get_public_ticket_messages() -> Collection[str]:
         'event',
         'payment',
         'reservation',
+        'reservation_adjusted',
         'submission',
         'ticket',
         'ticket_chat',

--- a/src/onegov/org/forms/__init__.py
+++ b/src/onegov/org/forms/__init__.py
@@ -22,6 +22,7 @@ from onegov.org.forms.newsletter import NewsletterTestForm
 from onegov.org.forms.page import LinkForm, PageForm, IframeForm
 from onegov.org.forms.person import PersonForm
 from onegov.org.forms.reservation import FindYourSpotForm
+from onegov.org.forms.reservation import ReservationAdjustmentForm
 from onegov.org.forms.reservation import ReservationForm
 from onegov.org.forms.resource import ResourceCleanupForm
 from onegov.org.forms.resource import ResourceExportForm
@@ -84,6 +85,7 @@ __all__ = (
     'PersonForm',
     'PublicMTANForm',
     'PublicRequestMTANForm',
+    'ReservationAdjustmentForm',
     'ReservationForm',
     'ResourceCleanupForm',
     'ResourceExportForm',

--- a/src/onegov/org/forms/reservation.py
+++ b/src/onegov/org/forms/reservation.py
@@ -91,6 +91,28 @@ class ReservationForm(Form):
                 'data_auto_fill'] = json.dumps(auto_fill_data)
 
 
+class ReservationAdjustmentForm(Form):
+
+    # NOTE: Currently we don't allow adjusting a reservation
+    #       to a different allocation, so it's impossible to
+    #       change the date, but once we do support that we
+    #       may want to add a date field here
+
+    start_time = TimeField(
+        label=_('Starting at'),
+        description=_('HH:MM'),
+        validators=[InputRequired()],
+        fieldset=_('Time'),
+    )
+
+    end_time = TimeField(
+        label=_('Ending at'),
+        description=_('HH:MM'),
+        validators=[InputRequired()],
+        fieldset=_('Time'),
+    )
+
+
 class FindYourSpotForm(Form):
 
     if TYPE_CHECKING:

--- a/src/onegov/org/kaba.py
+++ b/src/onegov/org/kaba.py
@@ -101,7 +101,7 @@ class KabaClient:
         start: datetime,
         end: datetime,
         components: list[str]
-    ) -> tuple[str, str]:
+    ) -> str:
         res = self.session.post(
             f'{self.base_url}/{self.site_id}/visit',
             json={
@@ -122,7 +122,7 @@ class KabaClient:
         )
         self.raise_for_status(res)
         data = res.json()
-        return data['id'], data['link']
+        return data['id']
 
     def revoke_visit(self, visit_id: str) -> None:
         res = self.session.post(

--- a/src/onegov/org/locale/de_CH/LC_MESSAGES/onegov.org.po
+++ b/src/onegov/org/locale/de_CH/LC_MESSAGES/onegov.org.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE 1.0\n"
-"POT-Creation-Date: 2025-04-30 07:35+0200\n"
+"POT-Creation-Date: 2025-05-14 12:47+0200\n"
 "PO-Revision-Date: 2022-03-15 10:21+0100\n"
 "Last-Translator: Marc Sommerhalder <marc.sommerhalder@seantis.ch>\n"
 "Language-Team: German\n"
@@ -1328,6 +1328,12 @@ msgstr "Öffentliche Extra Informationen zu dieser Person"
 
 msgid "Tag"
 msgstr "Schlagwort"
+
+msgid "Starting at"
+msgstr "Von"
+
+msgid "Ending at"
+msgstr "Bis"
 
 msgid "I am looking to make a reservation lasting"
 msgstr "Ich suche einen Termin für"
@@ -3319,6 +3325,22 @@ msgstr "Eingabe bearbeiten"
 msgid "Key Code"
 msgstr "Schlüsselcode"
 
+msgid "Reject"
+msgstr "Absagen"
+
+msgid "Do you really want to reject this reservation?"
+msgstr "Möchten Sie diese Reservation wirklich absagen?"
+
+#, python-format
+msgid "Rejecting ${title} can't be undone."
+msgstr "Die Absage von ${title} kann nicht rückgängig gemacht werden."
+
+msgid "Reject reservation"
+msgstr "Reservation absagen"
+
+msgid "Adjust"
+msgstr "Anpassen"
+
 msgid "Accept all reservations"
 msgstr "Alle Reservationen annehmen"
 
@@ -3346,22 +3368,8 @@ msgstr "Reservationen absagen"
 msgid "Reject all with message"
 msgstr "Alle absagen mit Kommentar"
 
-#, python-format
-msgid "Reject ${title}"
-msgstr "${title} absagen"
-
-msgid "Do you really want to reject this reservation?"
-msgstr "Möchten Sie diese Reservation wirklich absagen?"
-
-#, python-format
-msgid "Rejecting ${title} can't be undone."
-msgstr "Die Absage von ${title} kann nicht rückgängig gemacht werden."
-
-msgid "Reject reservation"
-msgstr "Reservation absagen"
-
-#. Used in sentence: "${event} published."
 #.
+#. Used in sentence: "${event} published."
 msgid "Event"
 msgstr "Veranstaltung"
 
@@ -3733,9 +3741,10 @@ msgid ""
 "than the number of levels in the breadcrumbs."
 msgstr ""
 "Um die Breadcrumbs anzuzeigen, können Sie ${bc_level} als Parameter zur URL "
-"hinzufügen. Die Zahl definiert, wo die Breadcrumbs beginnen. 1 in diesem Fall "
-"bedeutet, dass die erste Ebene verborgen ist. Sie können jede Zahl verwenden, "
-"solange sie kleiner ist als die Anzahl der Ebenen in den Breadcrumbs."
+"hinzufügen. Die Zahl definiert, wo die Breadcrumbs beginnen. 1 in diesem "
+"Fall bedeutet, dass die erste Ebene verborgen ist. Sie können jede Zahl "
+"verwenden, solange sie kleiner ist als die Anzahl der Ebenen in den "
+"Breadcrumbs."
 
 msgid ""
 "Please review your data and press \"Complete\" to finalize the process. If "
@@ -4688,6 +4697,9 @@ msgstr "1 Reservation abgelehnt."
 
 msgid "${count} reservations rejected."
 msgstr "${count} Reservationen abgelehnt."
+
+msgid "1 reservation adjusted:"
+msgstr "1 Reservation angepasst:"
 
 msgid "Registration confirmed."
 msgstr "Anmeldung bestätigt."
@@ -6420,6 +6432,18 @@ msgstr ""
 
 msgid "Reject all reservations with message"
 msgstr "Alle Reservationen absagen mit Kommentar"
+
+msgid "Adjust reservation"
+msgstr "Reservation Anpassen"
+
+msgid "One of your reservations was adjusted"
+msgstr "Eine von Ihren Reservationen wurde angepasst"
+
+msgid "The reservation was adjusted"
+msgstr "Die Reservation wurde angepasst"
+
+msgid "The reservation was left unchanged"
+msgstr "Die Reservation ist unverändert geblieben"
 
 msgid "Added a new daypass"
 msgstr "Eine neue Tageskarte wurde hinzugefügt"

--- a/src/onegov/org/locale/fr_CH/LC_MESSAGES/onegov.org.po
+++ b/src/onegov/org/locale/fr_CH/LC_MESSAGES/onegov.org.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE 1.0\n"
-"POT-Creation-Date: 2025-04-30 07:35+0200\n"
+"POT-Creation-Date: 2025-05-14 12:47+0200\n"
 "PO-Revision-Date: 2022-03-15 10:50+0100\n"
 "Last-Translator: Marc Sommerhalder <marc.sommerhalder@seantis.ch>\n"
 "Language-Team: French\n"
@@ -1327,6 +1327,12 @@ msgstr "Informations publiques supplémentaires à propos de cette semaine"
 
 msgid "Tag"
 msgstr "Étiquette"
+
+msgid "Starting at"
+msgstr "Commençant à"
+
+msgid "Ending at"
+msgstr "Finissant à"
 
 msgid "I am looking to make a reservation lasting"
 msgstr "Je cherche à faire une réservation d'une durée de"
@@ -3326,6 +3332,22 @@ msgstr "Modifier votre envoi"
 msgid "Key Code"
 msgstr "Code clé"
 
+msgid "Reject"
+msgstr "Refuser"
+
+msgid "Do you really want to reject this reservation?"
+msgstr "Voulez-vous vraiment refuser cette réservation?"
+
+#, python-format
+msgid "Rejecting ${title} can't be undone."
+msgstr "Refuser ${title} est irréversible."
+
+msgid "Reject reservation"
+msgstr "Refuser la réservation"
+
+msgid "Adjust"
+msgstr "Ajuster"
+
 msgid "Accept all reservations"
 msgstr "Accepter toutes les réservations"
 
@@ -3353,22 +3375,8 @@ msgstr "Refuser les réservations"
 msgid "Reject all with message"
 msgstr "Tout refuser avec message"
 
-#, python-format
-msgid "Reject ${title}"
-msgstr "Refuser ${title}"
-
-msgid "Do you really want to reject this reservation?"
-msgstr "Voulez-vous vraiment refuser cette réservation ?"
-
-#, python-format
-msgid "Rejecting ${title} can't be undone."
-msgstr "Refuser ${title} est irréversible."
-
-msgid "Reject reservation"
-msgstr "Refuser la réservation"
-
-#. Used in sentence: "${event} published."
 #.
+#. Used in sentence: "${event} published."
 msgid "Event"
 msgstr "Événement"
 
@@ -3744,8 +3752,8 @@ msgid ""
 "than the number of levels in the breadcrumbs."
 msgstr ""
 "Pour afficher le fil d'Ariane, vous pouvez ajouter ${bc_level} comme "
-"paramètre à l'URL. Le nombre définit où le fil d'Ariane commence. 1 dans ce "
-" cas signifie que le premier niveau est masqué. Vous pouvez utiliser "
+"paramètre à l'URL. Le nombre définit où le fil d'Ariane commence. 1 dans ce  "
+"cas signifie que le premier niveau est masqué. Vous pouvez utiliser "
 "n'importe quel nombre tant qu'il est inférieur au nombre de niveaux dans le "
 "fil d'Ariane."
 
@@ -3755,8 +3763,8 @@ msgid ""
 "filled-out form."
 msgstr ""
 "Veuillez vérifier vos données et appuyez sur « Compléter » pour finaliser le "
-"processus. S'il y a quelque chose que vous souhaitez modifier, cliquez sur « "
-"Modifier » pour retourner sur le formulaire complété."
+"processus. S'il y a quelque chose que vous souhaitez modifier, cliquez sur "
+"« Modifier » pour retourner sur le formulaire complété."
 
 msgid ""
 "The image shown in the list view is a square. To have your image shown fully "
@@ -4701,6 +4709,9 @@ msgstr "1 réservation rejetée."
 
 msgid "${count} reservations rejected."
 msgstr "${count} réservations rejetées."
+
+msgid "1 reservation adjusted:"
+msgstr "1 réservation ajustée:"
 
 msgid "Registration confirmed."
 msgstr "Inscription confirmée."
@@ -6438,6 +6449,18 @@ msgstr ""
 
 msgid "Reject all reservations with message"
 msgstr "Refuser toutes les réservations avec le message"
+
+msgid "Adjust reservation"
+msgstr "Ajuster la réservation"
+
+msgid "One of your reservations was adjusted"
+msgstr "Une de vos réservations a été ajustée"
+
+msgid "The reservation was adjusted"
+msgstr "La réservation a été ajustée"
+
+msgid "The reservation was left unchanged"
+msgstr "La réservation est restée inchangée"
 
 msgid "Added a new daypass"
 msgstr "Nouvel abonnement à la journée ajouté"

--- a/src/onegov/org/locale/it_CH/LC_MESSAGES/onegov.org.po
+++ b/src/onegov/org/locale/it_CH/LC_MESSAGES/onegov.org.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"POT-Creation-Date: 2025-04-30 07:35+0200\n"
+"POT-Creation-Date: 2025-05-14 12:47+0200\n"
 "PO-Revision-Date: 2022-03-15 10:52+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -1331,6 +1331,12 @@ msgstr "Informazioni pubbliche aggiuntive su questa persona"
 
 msgid "Tag"
 msgstr "Tag"
+
+msgid "Starting at"
+msgstr "A partire da"
+
+msgid "Ending at"
+msgstr "Fine a"
 
 msgid "I am looking to make a reservation lasting"
 msgstr "Voglio fare una prenotazione di"
@@ -3329,6 +3335,22 @@ msgstr "Modifica iscrizione"
 msgid "Key Code"
 msgstr "Codice chiave"
 
+msgid "Reject"
+msgstr "Rifiutare"
+
+msgid "Do you really want to reject this reservation?"
+msgstr "Vuoi davvero rifiutare questa prenotazione?"
+
+#, python-format
+msgid "Rejecting ${title} can't be undone."
+msgstr "Il rifiuto di ${title} non può essere annullato."
+
+msgid "Reject reservation"
+msgstr "Rifiuta prenotazione"
+
+msgid "Adjust"
+msgstr "Regolare"
+
 msgid "Accept all reservations"
 msgstr "Accetta tutte le prenotazioni"
 
@@ -3356,22 +3378,8 @@ msgstr "Rifiuta le prenotazioni"
 msgid "Reject all with message"
 msgstr "Rifiuta tutto con messaggio"
 
-#, python-format
-msgid "Reject ${title}"
-msgstr "Rifiuta ${title}"
-
-msgid "Do you really want to reject this reservation?"
-msgstr "Vuoi davvero rifiutare questa prenotazione?"
-
-#, python-format
-msgid "Rejecting ${title} can't be undone."
-msgstr "Il rifiuto di ${title} non può essere annullato."
-
-msgid "Reject reservation"
-msgstr "Rifiuta prenotazione"
-
-#. Used in sentence: "${event} published."
 #.
+#. Used in sentence: "${event} published."
 msgid "Event"
 msgstr "Evento"
 
@@ -3741,8 +3749,8 @@ msgstr ""
 "Per visualizzare le briciole di pane si può aggiungere ${bc_level} come "
 "parametro all'URL. Il numero definisce l'inizio delle briciole di pane. 1 in "
 "questo caso significa che il primo livello è nascosto. È possibile "
-"utilizzare qualsiasi numero, purché sia inferiore al numero di livelli "
-"delle briciole di pane."
+"utilizzare qualsiasi numero, purché sia inferiore al numero di livelli delle "
+"briciole di pane."
 
 msgid ""
 "Please review your data and press \"Complete\" to finalize the process. If "
@@ -4685,6 +4693,9 @@ msgstr "1 prenotazione rifiutata."
 
 msgid "${count} reservations rejected."
 msgstr "${count} prenotazioni rifiutate."
+
+msgid "1 reservation adjusted:"
+msgstr "1 prenotazione regolata:"
 
 msgid "Registration confirmed."
 msgstr "Iscrizione confermata."
@@ -6420,6 +6431,18 @@ msgstr ""
 
 msgid "Reject all reservations with message"
 msgstr "Rifiuta tutte le prenotazioni con messaggio"
+
+msgid "Adjust reservation"
+msgstr "Regolare la prenotazione"
+
+msgid "One of your reservations was adjusted"
+msgstr "Una delle vostre prenotazioni è stata regolata"
+
+msgid "The reservation was adjusted"
+msgstr "La prenotazione è stata regolata"
+
+msgid "The reservation was left unchanged"
+msgstr "La prenotazione è rimasta invariata"
 
 msgid "Added a new daypass"
 msgstr "Aggiunto un nuovo biglietto giornaliero"

--- a/src/onegov/org/models/__init__.py
+++ b/src/onegov/org/models/__init__.py
@@ -33,6 +33,7 @@ from onegov.org.models.message import DirectoryMessage
 from onegov.org.models.message import EventMessage
 from onegov.org.models.message import PaymentMessage
 from onegov.org.models.message import ReservationMessage
+from onegov.org.models.message import ReservationAdjustedMessage
 from onegov.org.models.message import SubmissionMessage
 from onegov.org.models.message import TicketChatMessage
 from onegov.org.models.message import TicketMessage
@@ -102,6 +103,7 @@ __all__ = (
     'PersonMove',
     'PublicationCollection',
     'ReservationMessage',
+    'ReservationAdjustedMessage',
     'ResourcePersonMove',
     'ResourceRecipient',
     'ResourceRecipientCollection',

--- a/src/onegov/org/models/message.py
+++ b/src/onegov/org/models/message.py
@@ -216,6 +216,30 @@ class ReservationMessage(Message, TicketMessageMixin):
         ])
 
 
+class ReservationAdjustedMessage(Message, TicketMessageMixin):
+
+    __mapper_args__ = {
+        'polymorphic_identity': 'reservation_adjusted'
+    }
+
+    @classmethod
+    def create(  # type:ignore[override]
+        cls,
+        old_reservation: Reservation,
+        new_reservation: Reservation,
+        ticket: Ticket,
+        request: OrgRequest,
+    ) -> Self:
+        return super().create(
+            ticket,
+            request,
+            old_start=old_reservation.display_start(),
+            old_end=old_reservation.display_end(),
+            new_start=new_reservation.display_start(),
+            new_end=new_reservation.display_end()
+        )
+
+
 class SubmissionMessage(Message, TicketMessageMixin):
 
     __mapper_args__ = {

--- a/src/onegov/org/pdf/ticket.py
+++ b/src/onegov/org/pdf/ticket.py
@@ -108,7 +108,7 @@ class TicketPdf(Pdf):
         canvas.drawRightString(
             doc.pagesize[0] - doc.rightMargin,
             doc.bottomMargin / 2,
-            f'{canvas.getPageNumber()}'  # type:ignore[no-untyped-call]
+            f'{canvas.getPageNumber()}'
         )
         canvas.restoreState()
 

--- a/src/onegov/org/templates/macros.pt
+++ b/src/onegov/org/templates/macros.pt
@@ -980,22 +980,27 @@
 </metal:reservations>
 
 <metal:reservations define-macro="reservations" i18n:domain="onegov.org">
-    <ul tal:condition="reservations" class="reservations">
-        <li tal:repeat="reservation reservations">
-            <tal:b define="start reservation.display_start(); end reservation.display_end()">
-                <strong>
-                    ${layout.format_date(start, 'weekday_long')},
-                    ${layout.format_date(start, 'date_long')}
-                </strong>
-                <!--! simple whole day check: -->
-                <span tal:condition="start.time() != end.time()">
-                    <br>
-                    ${layout.format_time_range(start, end)}
-                </span>
-                <br><span i18n:translate>Quota</span>
-                <span>
-                    ${reservation.quota}
-                </span>
+    <ul tal:condition="reservations" tal:define="get_links get_links|None" class="reservations">
+        <li tal:repeat="reservation reservations" tal:attributes="class 'reservation' if get_links else None">
+            <tal:b define="start reservation.display_start(); end reservation.display_end(); links get_links(reservation, request) if get_links else []">
+                <div class="reservation-details" tal:omit-tag="not:links">
+                    <strong>
+                        ${layout.format_date(start, 'weekday_long')},
+                        ${layout.format_date(start, 'date_long')}
+                    </strong>
+                    <!--! simple whole day check: -->
+                    <span tal:condition="start.time() != end.time()">
+                        <br>
+                        ${layout.format_time_range(start, end)}
+                    </span>
+                    <br><span i18n:translate>Quota</span>
+                    <span>
+                        ${reservation.quota}
+                    </span>
+                </div>
+                <div class="reservation-actions text-links" tal:condition="links">
+                    <tal:b repeat="link links" content="link(layout)" />
+                </div>
             </tal:b>
         </li>
     </ul>

--- a/src/onegov/org/templates/message_reservation_adjusted.pt
+++ b/src/onegov/org/templates/message_reservation_adjusted.pt
@@ -1,0 +1,35 @@
+<tal:b i18n:domain="onegov.org">
+    <metal:b use-macro="layout.macros['generic_message']">
+        <metal:b fill-slot="title">
+            <a href="${link}">${model.channel_id}</a> - ${model.meta.group}
+        </metal:b>
+        <metal:b fill-slot="text">
+            <tal:b i18n:translate>1 reservation adjusted:</tal:b>
+            <div class="reservation-adjustment">
+                <div tal:define="start model.meta.old_start; end model.meta.old_end" class="reservation-details old">
+                    <strong>
+                        ${layout.format_date(start, 'weekday_long')},
+                        ${layout.format_date(start, 'date_long')}
+                    </strong>
+                    <!--! simple whole day check: -->
+                    <span tal:condition="start.time() != end.time()">
+                        <br>
+                        ${layout.format_time_range(start, end)}
+                    </span>
+                </div>
+                <div class="fa fa-arrow-right"></div>
+                <div tal:define="start model.meta.new_start; end model.meta.new_end" class="reservation-details new">
+                    <strong>
+                        ${layout.format_date(start, 'weekday_long')},
+                        ${layout.format_date(start, 'date_long')}
+                    </strong>
+                    <!--! simple whole day check: -->
+                    <span tal:condition="start.time() != end.time()">
+                        <br>
+                        ${layout.format_time_range(start, end)}
+                    </span>
+                </div>
+            </div>
+        </metal:b>
+    </metal:b>
+</tal:b>

--- a/src/onegov/org/theme/styles/org.scss
+++ b/src/onegov/org/theme/styles/org.scss
@@ -4283,6 +4283,26 @@ ul.search-results {
         li {
             margin-bottom: .5rem;
         }
+
+        .reservation {
+            background: $white-smoke;
+            border-radius: 2px;
+            margin-bottom: 1rem;
+            margin-left: -0.5rem;
+            position: relative;
+        }
+
+        .reservation-details {
+            font-size: .8rem;
+            padding: .5rem 8rem .5rem .5rem;
+        }
+
+        .reservation-actions {
+            font-size: .8rem;
+            position: absolute;
+            right: .5rem;
+            top: .275rem;
+        }
     }
 
     .occurrence.occurrence {
@@ -4836,6 +4856,29 @@ h2 + div.timeline {
     .file {
         margin-left: 4rem;
     }
+
+    .reservation-adjustment {
+        display: flex;
+        align-items: center;
+        gap: 1rem;
+        margin: 0;
+
+        .fa {
+            font-size: 1.5rem;
+            color: rgba(0, 0, 0, .5);
+        }
+
+        .reservation-details {
+            font-size: .8rem;
+            padding: .5rem;
+            background: rgba(255, 255, 255, .7);
+            border-radius: 2px;
+            box-shadow: 3px 3px 3px rgba(220, 220, 220, .2);
+            flex: 0 0 32.66%;
+            margin: .5rem 0;
+        }
+
+    }
 }
 
 /*
@@ -4847,6 +4890,10 @@ h2 + div.timeline {
 .message-directory,
 .message-submission {
     background: lighten($green-pastel, 2.5%);
+}
+
+.message-reservation_adjusted {
+    background: lighten($yellow-pastel, 2.5%);
 }
 
 .message-ticket_note {

--- a/src/onegov/org/views/reservation.py
+++ b/src/onegov/org/views/reservation.py
@@ -16,14 +16,15 @@ from onegov.org import _, log, OrgApp
 from onegov.org import utils
 from onegov.org.cli import close_ticket
 from onegov.org.elements import Link
-from onegov.org.forms import ReservationForm, InternalTicketChatMessageForm
+from onegov.org.forms import (
+    ReservationAdjustmentForm, ReservationForm, InternalTicketChatMessageForm)
 from onegov.org.kaba import KabaApiError, KabaClient
 from onegov.org.layout import ReservationLayout, TicketChatMessageLayout
-from onegov.org.layout import DefaultMailLayout
+from onegov.org.layout import DefaultMailLayout, TicketLayout
 from onegov.org.mail import send_ticket_mail
 from onegov.org.models import (
-    TicketMessage, TicketChatMessage, ReservationMessage,
-    ResourceRecipient, ResourceRecipientCollection)
+    TicketMessage, TicketChatMessage, ReservationAdjustedMessage,
+    ReservationMessage, ResourceRecipient, ResourceRecipientCollection)
 from onegov.org.models.resource import FindYourSpotCollection
 from onegov.org.models.ticket import ReservationTicket
 from onegov.org.utils import emails_for_new_ticket
@@ -813,7 +814,7 @@ def accept_reservation(
                 try:
                     start = reservation.display_start() - lead_delta
                     end = reservation.display_end() + lag_delta
-                    visit_id, link = client.create_visit(
+                    visit_id = client.create_visit(
                         code=code,
                         name=ticket.number,
                         message='Managed through OneGov Cloud',
@@ -839,7 +840,6 @@ def accept_reservation(
                     data['kaba'] = {
                         'code': code,
                         'visit_id': visit_id,
-                        'link': link,
                     }
 
             # libres does not automatically detect changes yet
@@ -865,7 +865,6 @@ def accept_reservation(
                 origin='internal',
             )
 
-        # TODO: Add link to open doors online?
         send_ticket_mail(
             request=request,
             template='mail_reservation_accepted.pt',
@@ -1299,4 +1298,184 @@ def reject_reservation_with_message_from_ticket(
         request,
         form,
         layout or TicketChatMessageLayout(self, request, internal=True)
+    )
+
+
+@OrgApp.form(
+    model=Reservation,
+    name='adjust',
+    permission=Private,
+    form=ReservationAdjustmentForm,
+    template='form.pt'
+)
+def adjust_reservation(
+    self: Reservation,
+    request: OrgRequest,
+    form: ReservationAdjustmentForm,
+    view_ticket: ReservationTicket | None = None,
+    layout: ReservationLayout | TicketLayout | None = None
+) -> RenderData | Response:
+
+    token = self.token
+    resource = request.app.libres_resources.by_reservation(self)
+    assert resource is not None
+    reservation_id_str = request.params.get('reservation-id')
+    if isinstance(reservation_id_str, str) and reservation_id_str.isdigit():
+        reservation_id = int(reservation_id_str)
+    else:
+        raise exc.HTTPNotFound()
+
+    reservation: Reservation | None = (
+        resource.scheduler.reservations_by_token(token)  # type:ignore
+        .filter(Reservation.id == reservation_id)
+        .one_or_none()
+    )
+    if reservation is None or not (
+        # is this reservation adjustable?
+        reservation.target_type == 'allocation'
+        and request.session.query(
+            reservation
+            ._target_allocations()
+            .filter(Allocation.partly_available.is_(True))
+            .exists()
+        ).scalar()
+    ):
+        raise exc.HTTPNotFound()
+
+    tickets = TicketCollection(request.session)
+    ticket = tickets.by_handler_id(token.hex)
+    assert ticket is not None
+
+    # if we're accessing this view through the ticket it
+    # had better match the ticket we retrieved
+    if view_ticket is not None and view_ticket != ticket:
+        raise exc.HTTPNotFound()
+
+    def show_form() -> RenderData:
+        if not request.POST:
+            form.start_time.data = reservation.display_start().time()
+            form.end_time.data = reservation.display_end().time()
+        return {
+            'title': _('Adjust reservation'),
+            'layout': layout or ReservationLayout(resource, request),
+            'form': form,
+        }
+
+    if not form.submitted(request):
+        return show_form()
+
+    try:
+        start_time = form.start_time.data
+        end_time = form.end_time.data
+        assert start_time is not None and end_time is not None
+        # TODO: Should we raise for invalid DST transition times?
+        #       we could also make that a validator on the form instead
+        new_start, new_end = sedate.get_date_range(
+            reservation.display_start(),
+            start_time,
+            end_time
+        )
+        new_reservation = resource.scheduler.change_reservation(
+            token,
+            reservation.id,
+            new_start,
+            new_end,
+        )
+    except LibresError as e:
+        # rollback previous changes
+        transaction.abort()
+        transaction.begin()
+        request.alert(utils.get_libres_error(e, request))
+        return show_form()
+
+    if new_reservation is not None:
+        client = KabaClient.from_resource(resource, request.app)
+        data = reservation.data = reservation.data or {}
+        if client and (kaba := data.get('kaba')):
+            # adjust visit
+            components = resource.kaba_components  # type: ignore[attr-defined]
+            try:
+                code = kaba['code']
+                lead_delta = timedelta(
+                    minutes=ticket.handler.data['key_code_lead_time']
+                )
+                lag_delta = timedelta(
+                    minutes=ticket.handler.data['key_code_lag_time']
+                )
+                start = new_reservation.display_start() - lead_delta
+                end = new_reservation.display_end() + lag_delta
+                client.revoke_visit(kaba['visit_id'])
+                visit_id = client.create_visit(
+                    code=code,
+                    name=ticket.number,
+                    message='Managed through OneGov Cloud',
+                    start=start,
+                    end=end,
+                    components=components,
+                )
+            except KabaApiError:
+                log.info('Kaba API error', exc_info=True)
+
+                # roll back previous changes
+                transaction.abort()
+                transaction.begin()
+                request.alert(_(
+                    'Failed to create visits using the dormakaba API '
+                    'please make sure your credentials are still valid.'
+                ))
+                return show_form()
+            else:
+                data['kaba'] = {
+                    'code': code,
+                    'visit_id': visit_id,
+                }
+
+                # libres does not automatically detect changes yet
+                flag_modified(reservation, 'data')
+
+        ReservationAdjustedMessage.create(
+            reservation,
+            new_reservation,
+            ticket,
+            request,
+        )
+        request.success(_('The reservation was adjusted'))
+    else:
+        request.warning(_('The reservation was left unchanged'))
+
+    if view_ticket is not None:
+        return request.redirect(request.link(view_ticket))
+
+    return request.redirect(request.link(self))
+
+
+@OrgApp.form(
+    model=ReservationTicket,
+    name='adjust-reservation',
+    permission=Private,
+    form=ReservationAdjustmentForm,
+    template='form.pt'
+)
+def adjust_reservation_from_ticket(
+    self: ReservationTicket,
+    request: OrgRequest,
+    form: ReservationAdjustmentForm,
+    layout: TicketLayout | None = None
+) -> RenderData | Response | None:
+
+    if self.handler.deleted:
+        raise exc.HTTPNotFound()
+
+    layout = layout or TicketLayout(self, request)
+    layout.breadcrumbs[-1].attrs['href'] = request.link(self)
+    layout.breadcrumbs.append(
+        Link(_('Adjust reservation'), '#')
+    )
+
+    return adjust_reservation(
+        self.handler.reservations[0],
+        request,
+        form,
+        self,
+        layout
     )

--- a/src/onegov/org/views/reservation.py
+++ b/src/onegov/org/views/reservation.py
@@ -1365,25 +1365,25 @@ def adjust_reservation(
     if not form.submitted(request):
         return show_form()
 
+    start_time = form.start_time.data
+    end_time = form.end_time.data
+    assert start_time is not None and end_time is not None
+    try:
+        new_start, new_end = sedate.get_date_range(
+            reservation.display_start(),
+            start_time,
+            end_time,
+            raise_non_existent=True
+        )
+    except pytz.NonExistentTimeError:
+        request.alert(_(
+            'The selected time does not exist on this date due to '
+            'the switch from standard time to daylight saving time.'
+        ))
+        return show_form()
+
     savepoint = transaction.savepoint()
     try:
-        start_time = form.start_time.data
-        end_time = form.end_time.data
-        assert start_time is not None and end_time is not None
-        try:
-            new_start, new_end = sedate.get_date_range(
-                reservation.display_start(),
-                start_time,
-                end_time,
-                raise_non_existent=True
-            )
-        except pytz.NonExistentTimeError:
-            request.alert(_(
-                'The selected time does not exist on this date due to '
-                'the switch from standard time to daylight saving time.'
-            ))
-            return show_form()
-
         new_reservation = resource.scheduler.change_reservation(
             token,
             reservation.id,

--- a/src/onegov/pdf/page_functions.py
+++ b/src/onegov/pdf/page_functions.py
@@ -37,7 +37,7 @@ def page_fn_footer(canvas: Canvas, doc: Template) -> None:
     canvas.drawRightString(
         doc.pagesize[0] - doc.rightMargin,
         doc.bottomMargin / 2,
-        f'{canvas.getPageNumber()}'  # type:ignore[no-untyped-call]
+        f'{canvas.getPageNumber()}'
     )
     canvas.restoreState()
 

--- a/src/onegov/town6/locale/de_CH/LC_MESSAGES/onegov.town6.po
+++ b/src/onegov/town6/locale/de_CH/LC_MESSAGES/onegov.town6.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: OneGov Cloud 1.0\n"
-"POT-Creation-Date: 2025-04-24 09:21+0200\n"
+"POT-Creation-Date: 2025-05-14 12:57+0200\n"
 "PO-Revision-Date: 2021-03-03 16:24+0100\n"
 "Last-Translator: Lukas Burkhard <lukas.burkhard@seantis.ch>\n"
 "Language-Team: German\n"
@@ -236,6 +236,9 @@ msgstr "Abbrechen"
 #. Used in sentence: "${event} published."
 msgid "Event"
 msgstr "Veranstaltung"
+
+msgid "Copy"
+msgstr "Kopieren"
 
 msgid "Export"
 msgstr "Export"
@@ -473,6 +476,18 @@ msgid "You can copy the following code to embed this page as an iFrame:"
 msgstr ""
 "Sie können den folgenden Code kopieren, um diese Seite als iFrame "
 "einzubetten:"
+
+msgid ""
+"To display the breadcrumbs you can add ${bc_level} as a parameter to the "
+"URL. The number defines where the breadcrumbs start. 1 in this case means "
+"that the first level is hidden. You can use any number as long as it is less "
+"than the number of levels in the breadcrumbs."
+msgstr ""
+"Um die Breadcrumbs anzuzeigen, können Sie ${bc_level} als Parameter zur URL "
+"hinzufügen. Die Zahl definiert, wo die Breadcrumbs beginnen. 1 in diesem "
+"Fall bedeutet, dass die erste Ebene verborgen ist. Sie können jede Zahl "
+"verwenden, solange sie kleiner ist als die Anzahl der Ebenen in den "
+"Breadcrumbs."
 
 msgid ""
 "Please review your data and press \"Complete\" to finalize the process. If "
@@ -1502,6 +1517,9 @@ msgstr "1 Reservation abgelehnt."
 msgid "${count} reservations rejected."
 msgstr "${count} Reservationen abgelehnt."
 
+msgid "1 reservation adjusted:"
+msgstr "1 Reservation angepasst:"
+
 msgid "Registration confirmed."
 msgstr "Anmeldung bestätigt."
 
@@ -2109,14 +2127,26 @@ msgstr "Inaktiv"
 msgid "Role"
 msgstr "Rolle"
 
-msgid "local"
-msgstr "lokal"
-
 msgid "User group"
 msgstr "Benutzergruppe"
 
 msgid "None"
 msgstr "Keine"
+
+msgid "local"
+msgstr "lokal"
+
+msgid "Last login"
+msgstr "Zuletzt eingeloggt"
+
+msgid "Never"
+msgstr "Nie"
+
+msgid "Session information"
+msgstr "Session Information"
+
+msgid "Display information"
+msgstr "Information anzeigen"
 
 msgid "No links found."
 msgstr "Keine Verknüpfungen gefunden."

--- a/src/onegov/town6/locale/fr_CH/LC_MESSAGES/onegov.town6.po
+++ b/src/onegov/town6/locale/fr_CH/LC_MESSAGES/onegov.town6.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: OneGov Cloud 1.0\n"
-"POT-Creation-Date: 2025-04-24 09:21+0200\n"
+"POT-Creation-Date: 2025-05-14 12:57+0200\n"
 "PO-Revision-Date: 2021-03-03 14:04+0100\n"
 "Last-Translator: Lukas Burkhard <lukas.burkhard@seantis.ch>\n"
 "Language-Team: French\n"
@@ -236,6 +236,9 @@ msgstr "Annuler"
 #. Used in sentence: "${event} published."
 msgid "Event"
 msgstr "Événement"
+
+msgid "Copy"
+msgstr "Copie"
 
 msgid "Export"
 msgstr "Exporter"
@@ -474,6 +477,18 @@ msgstr "Intégrer une iFrame"
 msgid "You can copy the following code to embed this page as an iFrame:"
 msgstr ""
 "Vous pouvez copier le code suivant pour intégrer cette page dans une iFrame:"
+
+msgid ""
+"To display the breadcrumbs you can add ${bc_level} as a parameter to the "
+"URL. The number defines where the breadcrumbs start. 1 in this case means "
+"that the first level is hidden. You can use any number as long as it is less "
+"than the number of levels in the breadcrumbs."
+msgstr ""
+"Pour afficher le fil d'Ariane, vous pouvez ajouter ${bc_level} comme "
+"paramètre à l'URL. Le nombre définit où le fil d'Ariane commence. 1 dans ce  "
+"cas signifie que le premier niveau est masqué. Vous pouvez utiliser "
+"n'importe quel nombre tant qu'il est inférieur au nombre de niveaux dans le "
+"fil d'Ariane."
 
 msgid ""
 "Please review your data and press \"Complete\" to finalize the process. If "
@@ -1501,6 +1516,9 @@ msgstr "1 réservation rejetée."
 msgid "${count} reservations rejected."
 msgstr "${count} réservations rejetées."
 
+msgid "1 reservation adjusted:"
+msgstr "1 réservation ajustée:"
+
 msgid "Registration confirmed."
 msgstr "Inscription confirmée."
 
@@ -2114,14 +2132,26 @@ msgstr "Inactif"
 msgid "Role"
 msgstr "Rôle"
 
-msgid "local"
-msgstr "local"
-
 msgid "User group"
 msgstr "Groupe d'utilisateurs"
 
 msgid "None"
 msgstr "Aucune"
+
+msgid "local"
+msgstr "local"
+
+msgid "Last login"
+msgstr "Dernière connexion"
+
+msgid "Never"
+msgstr "Jamais"
+
+msgid "Session information"
+msgstr "Session Information"
+
+msgid "Display information"
+msgstr "Afficher les informations"
 
 msgid "No links found."
 msgstr "Aucun lien trouvé."

--- a/src/onegov/town6/locale/it_CH/LC_MESSAGES/onegov.town6.po
+++ b/src/onegov/town6/locale/it_CH/LC_MESSAGES/onegov.town6.po
@@ -1,7 +1,7 @@
 # This file was generated from translations.town6.xlsx
 msgid ""
 msgstr ""
-"POT-Creation-Date: 2025-04-24 09:21+0200\n"
+"POT-Creation-Date: 2025-05-14 12:57+0200\n"
 "PO-Revision-Date: 2021-09-27 16:02+0200\n"
 "Language: it_CH\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -232,6 +232,9 @@ msgstr "Annulla"
 #. Used in sentence: "${event} published."
 msgid "Event"
 msgstr "Evento"
+
+msgid "Copy"
+msgstr "Copia"
 
 msgid "Export"
 msgstr "Esporta"
@@ -471,6 +474,18 @@ msgid "You can copy the following code to embed this page as an iFrame:"
 msgstr ""
 "È possibile copiare il seguente codice per incorporare questa pagina come "
 "iFrame:"
+
+msgid ""
+"To display the breadcrumbs you can add ${bc_level} as a parameter to the "
+"URL. The number defines where the breadcrumbs start. 1 in this case means "
+"that the first level is hidden. You can use any number as long as it is less "
+"than the number of levels in the breadcrumbs."
+msgstr ""
+"Per visualizzare le briciole di pane si può aggiungere ${bc_level} come "
+"parametro all'URL. Il numero definisce l'inizio delle briciole di pane. 1 in "
+"questo caso significa che il primo livello è nascosto. È possibile "
+"utilizzare qualsiasi numero, purché sia inferiore al numero di livelli delle "
+"briciole di pane."
 
 msgid ""
 "Please review your data and press \"Complete\" to finalize the process. If "
@@ -1494,6 +1509,9 @@ msgstr "1 prenotazione rifiutata."
 msgid "${count} reservations rejected."
 msgstr "${count} prenotazioni rifiutate."
 
+msgid "1 reservation adjusted:"
+msgstr "1 prenotazione regolata:"
+
 msgid "Registration confirmed."
 msgstr "Iscrizione confermata."
 
@@ -2110,14 +2128,26 @@ msgstr "Inattivo"
 msgid "Role"
 msgstr "Ruolo"
 
-msgid "local"
-msgstr "locale"
-
 msgid "User group"
 msgstr "Gruppo di utenti"
 
 msgid "None"
 msgstr "Nessuno"
+
+msgid "local"
+msgstr "locale"
+
+msgid "Last login"
+msgstr "Ultimo accesso"
+
+msgid "Never"
+msgstr "Mai"
+
+msgid "Session information"
+msgstr "Session Information"
+
+msgid "Display information"
+msgstr "Mostra informazioni"
 
 msgid "No links found."
 msgstr "Nessun collegamento trovato."

--- a/src/onegov/town6/templates/macros.pt
+++ b/src/onegov/town6/templates/macros.pt
@@ -1291,22 +1291,26 @@
 </metal:reservations>
 
 <metal:reservations define-macro="reservations" i18n:domain="onegov.town6">
-    <ul tal:condition="reservations" class="reservations">
-        <li tal:repeat="reservation reservations">
-            <tal:b define="start reservation.display_start(); end reservation.display_end()">
-                <strong>
-                    ${layout.format_date(start, 'weekday_long')},
-                    ${layout.format_date(start, 'date_long')}
-                </strong>
-                <!--! simple whole day check: -->
-                <span tal:condition="start.time() != end.time()">
-                    <br>
-                    ${layout.format_time_range(start, end)}
-                </span>
-                <br><span i18n:translate>Quota</span>
-                <span>
-                    ${reservation.quota}
-                </span>
+    <ul tal:condition="reservations" tal:define="get_links get_links|None" class="reservations">
+        <li tal:repeat="reservation reservations" tal:attributes="class 'reservation' if get_links else None">
+            <tal:b define="start reservation.display_start(); end reservation.display_end(); links get_links(reservation, request) if get_links else []">
+                <div class="reservation-details" tal:omit-tag="not:links">
+                    <strong>
+                        ${layout.format_date(start, 'weekday_long')},
+                        ${layout.format_date(start, 'date_long')}
+                    </strong>
+                    <!--! simple whole day check: -->
+                    <span tal:condition="start.time() != end.time()">
+                        <br>
+                        ${layout.format_time_range(start, end)}
+                    </span>
+                    <br><span i18n:translate>Quota</span>
+                    <span>
+                        ${reservation.quota}
+                    </span>
+                <div class="reservation-actions text-links" tal:condition="links">
+                    <tal:b repeat="link links" content="link(layout)" />
+                </div>
             </tal:b>
         </li>
     </ul>

--- a/src/onegov/town6/templates/message_reservation_adjusted.pt
+++ b/src/onegov/town6/templates/message_reservation_adjusted.pt
@@ -1,0 +1,35 @@
+<tal:b i18n:domain="onegov.town6">
+    <metal:b use-macro="layout.macros['generic_message']">
+        <metal:b fill-slot="title">
+            <a href="${link}">${model.channel_id}</a> - ${model.meta.group}
+        </metal:b>
+        <metal:b fill-slot="text">
+            <tal:b i18n:translate>1 reservation adjusted:</tal:b>
+            <div class="reservation-adjustment">
+                <div tal:define="start model.meta.old_start; end model.meta.old_end" class="reservation-details old">
+                    <strong>
+                        ${layout.format_date(start, 'weekday_long')},
+                        ${layout.format_date(start, 'date_long')}
+                    </strong>
+                    <!--! simple whole day check: -->
+                    <span tal:condition="start.time() != end.time()">
+                        <br>
+                        ${layout.format_time_range(start, end)}
+                    </span>
+                </div>
+                <div class="fa fa-arrow-right"></div>
+                <div tal:define="start model.meta.new_start; end model.meta.new_end" class="reservation-details new">
+                    <strong>
+                        ${layout.format_date(start, 'weekday_long')},
+                        ${layout.format_date(start, 'date_long')}
+                    </strong>
+                    <!--! simple whole day check: -->
+                    <span tal:condition="start.time() != end.time()">
+                        <br>
+                        ${layout.format_time_range(start, end)}
+                    </span>
+                </div>
+            </div>
+        </metal:b>
+    </metal:b>
+</tal:b>

--- a/src/onegov/town6/theme/styles/tickets.scss
+++ b/src/onegov/town6/theme/styles/tickets.scss
@@ -564,6 +564,26 @@ button {
         li {
             margin-bottom: .5rem;
         }
+
+        .reservation {
+            background: $white-smoke;
+            border-radius: 2px;
+            margin-bottom: 1rem;
+            margin-left: -0.5rem;
+            position: relative;
+        }
+
+        .reservation-details {
+            font-size: .8rem;
+            padding: .5rem 8rem .5rem .5rem;
+        }
+
+        .reservation-actions {
+            font-size: .8rem;
+            position: absolute;
+            right: .5rem;
+            top: .275rem;
+        }
     }
 
     .occurrence.occurrence {

--- a/src/onegov/town6/theme/styles/timeline.scss
+++ b/src/onegov/town6/theme/styles/timeline.scss
@@ -125,6 +125,29 @@ h2 + div.timeline {
     .file {
         margin-left: 4rem;
     }
+
+    .reservation-adjustment {
+        display: flex;
+        align-items: center;
+        gap: 1rem;
+        margin: 0;
+
+        .fa {
+            font-size: 1.5rem;
+            color: rgba(0, 0, 0, .5);
+        }
+
+        .reservation-details {
+            font-size: .8rem;
+            padding: .5rem;
+            background: rgba(255, 255, 255, .7);
+            border-radius: 2px;
+            box-shadow: 3px 3px 3px rgba(220, 220, 220, .2);
+            flex: 0 0 32.66%;
+            margin: .5rem 0;
+        }
+
+    }
 }
 
 /*
@@ -136,6 +159,10 @@ h2 + div.timeline {
 .message-directory,
 .message-submission {
     background: lighten($green-pastel, 2.5%);
+}
+
+.message-reservation_adjusted {
+    background: lighten($yellow-pastel, 2.5%);
 }
 
 .message-ticket_note {

--- a/src/onegov/town6/views/reservation.py
+++ b/src/onegov/town6/views/reservation.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 from onegov.core.security import Public, Private
-from onegov.org.forms import InternalTicketChatMessageForm
+from onegov.org.forms import (
+    InternalTicketChatMessageForm,
+    ReservationAdjustmentForm,
+)
 from onegov.org.models.ticket import ReservationTicket
 from onegov.org.views.reservation import (
     handle_reservation_form,
@@ -10,13 +13,19 @@ from onegov.org.views.reservation import (
     finalize_reservation,
     accept_reservation_with_message,
     accept_reservation_with_message_from_ticket,
+    adjust_reservation,
+    adjust_reservation_from_ticket,
     reject_reservation_with_message,
     reject_reservation_with_message_from_ticket,
 )
 from onegov.town6 import TownApp
 
 from onegov.reservation import Reservation, Resource
-from onegov.town6.layout import ReservationLayout, TicketChatMessageLayout
+from onegov.town6.layout import (
+    ReservationLayout,
+    TicketChatMessageLayout,
+    TicketLayout,
+)
 
 
 from typing import TYPE_CHECKING
@@ -137,4 +146,38 @@ def town_reject_reservation_with_message_from_ticket(
 ) -> RenderData | Response | None:
     layout = TicketChatMessageLayout(self, request, internal=True)
     return reject_reservation_with_message_from_ticket(
+        self, request, form, layout)
+
+
+@TownApp.form(
+    model=Reservation,
+    name='adjust',
+    permission=Private,
+    form=ReservationAdjustmentForm,
+    template='form.pt'
+)
+def town_adjust_reservation(
+    self: Reservation,
+    request: TownRequest,
+    form: ReservationAdjustmentForm
+) -> RenderData | Response | None:
+    layout = ReservationLayout(self, request)  # type:ignore
+    return adjust_reservation(self, request, form, None, layout)
+
+
+@TownApp.form(
+    model=ReservationTicket,
+    name='adjust-reservation',
+    permission=Private,
+    form=ReservationAdjustmentForm,
+    template='form.pt'
+)
+def town_adjust_reservation_from_ticket(
+    self: ReservationTicket,
+    request: TownRequest,
+    form: ReservationAdjustmentForm,
+    layout: TicketLayout | None = None
+) -> RenderData | Response | None:
+    layout = TicketLayout(self, request)
+    return adjust_reservation_from_ticket(
         self, request, form, layout)

--- a/src/onegov/user/auth/clients/oidc.py
+++ b/src/onegov/user/auth/clients/oidc.py
@@ -130,11 +130,11 @@ class OIDCClient:
             #       to create these dummy endpoints
             endpoints = [AuthorizationEndpoint(
                 'code',
-                None,
+                None,  # type: ignore[arg-type]
                 {'code': AuthorizationCodeGrant(None)}
             ), TokenEndpoint(
                 'authorization_code',
-                None,
+                None,  # type: ignore[arg-type]
                 {'authorization_code': AuthorizationCodeGrant(None)}
             )]
             metadata = MetadataEndpoint(endpoints, claims).claims

--- a/tests/onegov/org/test_views_resources.py
+++ b/tests/onegov/org/test_views_resources.py
@@ -1257,8 +1257,14 @@ def test_reserve_allocation_adjustment_pre_acceptance(client):
     assert "12:00" in ticket
     assert "Anpassen" in ticket
 
-    # adjust it
+    # try an invalid adjustment
     adjust = ticket.click('Anpassen', index=0)
+    adjust.form['start_time'] = '09:00'
+    adjust = adjust.form.submit()
+    assert 'Zeitraum liegt ausserhalb' in adjust
+
+    # adjust it (valid this time)
+    adjust.form['start_time'] = '10:00'
     adjust.form['end_time'] = '11:00'
     ticket = adjust.form.submit().follow()
     assert "10:00" in ticket

--- a/tests/onegov/org/test_views_resources.py
+++ b/tests/onegov/org/test_views_resources.py
@@ -1220,6 +1220,129 @@ def test_reserve_allocation_partially(client):
 
 
 @freeze_time("2015-08-28", tick=True)
+def test_reserve_allocation_adjustment_pre_acceptance(client):
+    # prepate the required data
+    resources = ResourceCollection(client.app.libres_context)
+    resource = resources.by_name('tageskarte')
+    scheduler = resource.get_scheduler(client.app.libres_context)
+
+    allocations = scheduler.allocate(
+        dates=(datetime(2015, 8, 28, 10), datetime(2015, 8, 28, 14)),
+        whole_day=False,
+        partly_available=True
+    )
+
+    reserve = client.bound_reserve(allocations[0])
+    transaction.commit()
+
+    # create a reservation
+    assert reserve('10:00', '12:00').json == {'success': True}
+
+    # fill out the form
+    formular = client.get('/resource/tageskarte/form')
+    formular.form['email'] = 'info@example.org'
+
+    ticket = formular.form.submit().follow().form.submit().follow()
+
+    assert 'RSV-' in ticket.text
+    assert len(os.listdir(client.app.maildir)) == 1
+
+    # open the created ticket
+    client.login_admin()
+
+    ticket = client.get('/tickets/ALL/open').click('Annehmen').follow()
+
+    assert "info@example.org" in ticket
+    assert "10:00" in ticket
+    assert "12:00" in ticket
+    assert "Anpassen" in ticket
+
+    # adjust it
+    adjust = ticket.click('Anpassen', index=0)
+    adjust.form['end_time'] = '11:00'
+    ticket = adjust.form.submit().follow()
+    assert "10:00" in ticket
+    assert "11:00" in ticket
+
+    # accept it
+    ticket = ticket.click('Alle Reservationen annehmen').follow()
+
+    message = client.get_email(1)['TextBody']
+    assert "Tageskarte" in message
+    assert "28. August 2015" in message
+    assert "10:00" in message
+    assert "11:00" in message
+
+    # see if the slots are partitioned correctly
+    url = '/resource/tageskarte/slots?start=2015-08-01&end=2015-08-30'
+    slots = client.get(url).json
+    assert slots[0]['partitions'] == [[25.0, True], [75.0, False]]
+
+
+@freeze_time("2015-08-28", tick=True)
+def test_reserve_allocation_adjustment_post_acceptance(client):
+    # prepate the required data
+    resources = ResourceCollection(client.app.libres_context)
+    resource = resources.by_name('tageskarte')
+    scheduler = resource.get_scheduler(client.app.libres_context)
+
+    allocations = scheduler.allocate(
+        dates=(datetime(2015, 8, 28, 10), datetime(2015, 8, 28, 14)),
+        whole_day=False,
+        partly_available=True
+    )
+
+    reserve = client.bound_reserve(allocations[0])
+    transaction.commit()
+
+    # create a reservation
+    assert reserve('10:00', '12:00').json == {'success': True}
+
+    # fill out the form
+    formular = client.get('/resource/tageskarte/form')
+    formular.form['email'] = 'info@example.org'
+
+    ticket = formular.form.submit().follow().form.submit().follow()
+
+    assert 'RSV-' in ticket.text
+    assert len(os.listdir(client.app.maildir)) == 1
+
+    # open the created ticket
+    client.login_admin()
+
+    ticket = client.get('/tickets/ALL/open').click('Annehmen').follow()
+
+    assert "info@example.org" in ticket
+    assert "10:00" in ticket
+    assert "12:00" in ticket
+    assert "Anpassen" in ticket
+
+    # accept it
+    ticket = ticket.click('Alle Reservationen annehmen').follow()
+
+    # adjust it
+    adjust = ticket.click('Anpassen', index=0)
+    adjust.form['end_time'] = '11:00'
+    ticket = adjust.form.submit().follow()
+    assert "10:00" in ticket
+    assert "11:00" in ticket
+
+    # the mail went out before so it still shows the old time
+    # TODO: Do we send a notification in this case or do we rely
+    #       on supporters to do that?
+    message = client.get_email(1)['TextBody']
+    assert "Tageskarte" in message
+    assert "28. August 2015" in message
+    assert "10:00" in message
+    assert "12:00" in message
+
+    # see if the slots are partitioned correctly
+    url = '/resource/tageskarte/slots?start=2015-08-01&end=2015-08-30'
+    slots = client.get(url).json
+    assert slots[0]['partitions'] == [[25.0, True], [75.0, False]]
+
+
+@freeze_time("2015-08-28", tick=True)
 def test_reserve_no_definition_pick_up_hint(client):
     # prepate the required data
     resources = ResourceCollection(client.app.libres_context)


### PR DESCRIPTION
## Commit message

Org: Allows adjusting individual reservations within a ticket

For now these adjustments are limited to the same allocation on the same day. Eventually we may allow moving reservations to arbitrary free allocations as long as the settings on the target allocation allow it.

TYPE: Feature
LINK: OGC-2155

## Checklist

- [x] I have performed a self-review of my code
- [x] I have updated the PO files
- [x] I made changes/features for both org and town6
- [x] I have tested my code thoroughly by hand
- [x] I have added tests for my changes/features
