### PR TITLE
Server: Avoids caching partially configured application instances

### DIFF
--- a/src/onegov/server/collection.py
+++ b/src/onegov/server/collection.py
@@ -35,9 +35,15 @@ class CachedApplication:
 
     def get(self) -> Application:
         if self.instance is None:
-            self.instance = self.application_class()
-            self.instance.namespace = self.namespace
-            self.instance.configure_application(**self.configuration)
+            instance = self.application_class()
+            instance.namespace = self.namespace
+            instance.configure_application(**self.configuration)
+            # NOTE: Only set the attribute after we successfully configured
+            #       the application, since the server will continue operating
+            #       after exceptions, we may otherwise end up with partially
+            #       initialized application instances. It's better if we
+            #       fail the same way each request.
+            self.instance = instance
         return self.instance
 
 


### PR DESCRIPTION
## Commit message

Server: Avoids caching partially configured application instances

Since `CachedApplication` was setting `self.instance` before the application was configured and the server will continue serving subsequent requests after a failed one, it was possible for a partially initialized application to end up in the cache, which leads to cryptic error messages.

It's better if we fail the same way on every request, so we don't get distracted by red herrings.

TYPE: Bugfix

## Checklist

- [x] I have performed a self-review of my code
