### PR TITLE
Org: Refreshes results summary in occupancy view when changing filters

### DIFF
--- a/src/onegov/org/assets/js/date-range-selector.js
+++ b/src/onegov/org/assets/js/date-range-selector.js
@@ -22,18 +22,20 @@ var set_date_range_selector_filter = function(name, value) {
     delete location.query.page;
 
     // keep range in query if range is equal 'past' and if date (value) is in the past, otherwise delete
-    if (date.isSame(moment(), 'day') || date.isAfter(moment(), 'day') || location.query.range != 'past') {
+    if (date.isSame(moment(), 'day') || date.isAfter(moment(), 'day') || location.query.range !== 'past') {
         delete location.query.range;
     }
 
     var url = location.toString();
     var target = $('.date-range-selector-target');
+    var results = $('.date-range-selector-results');
 
     if (target.length === 0) {
         window.location.href = url;
     } else {
         $.get(url, function(data) {
             target.replaceWith($(data).find('.date-range-selector-target'));
+            results.replaceWith($(data).find('.date-range-selector-results'));
             history.replaceState({}, "", url);
         });
     }


### PR DESCRIPTION
Previously we would only refresh the results list, but the summary is just as important.

TYPE: Bugfix
LINK: OGC-2284

Please fill in the commit message below and work through the checklist. You can delete parts that are not needed, e.g. the optional description, the link to a ticket or irrelevant options of the checklist.

## Commit message

Org: Refreshes results summary in occupancy view when changing filters

Previously we would only refresh the results list, but the summary is just as important.

TYPE: Bugfix
LINK: OGC-2284

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have tested my code thoroughly by hand
