### PR TITLE
Show all occurrences in newsletter form

### DIFF
--- a/src/onegov/org/views/newsletter.py
+++ b/src/onegov/org/views/newsletter.py
@@ -69,16 +69,10 @@ def get_newsletter_form(
     form = form.with_publications(request, publications)
 
     occurrences = OccurrenceCollection(request.session).query()
-    s = occurrences.with_entities(Occurrence.id)
-    # FIXME: Why are we ordering the subquery? As far as I can tell
-    #        that doesn't actually do anything
-    s = s.order_by(None)
-    s = s.order_by(
-        Occurrence.event_id,
-        Occurrence.start
+    occurrences = OccurrenceCollection(request.session).query()
+    occurrences = occurrences.order_by(
+        Occurrence.start, Occurrence.title
     )
-    s = s.distinct(Occurrence.event_id).subquery()
-    occurrences = occurrences.filter(Occurrence.id.in_(s))
     form = form.with_occurrences(request, occurrences)
 
     move_fields(

--- a/tests/onegov/town6/test_views_newsletter.py
+++ b/tests/onegov/town6/test_views_newsletter.py
@@ -571,7 +571,7 @@ def test_newsletter_send(client):
 
     new.select_checkbox("news", "Testnews")
     new.select_checkbox("occurrences", "150 Jahre Govikon")
-    new.select_checkbox("occurrences", "Gemeinsames Turnen")
+    new.select_checkbox("occurrences", "Gemeinsames Turnen", limit=3)
 
     new.form['closing_remark'] = '<p>Closing Remarks</p>'
 
@@ -647,7 +647,7 @@ def test_newsletter_send(client):
     # check content of mail
     assert 'Like many of you,' in message
     assert '150 Jahre Govikon' in message
-    assert 'Gemeinsames Turnen' in message
+    assert message.count('Gemeinsames Turnen') == 3
     assert 'Testnews' in message
     assert 'My Lead Text' in message
     assert 'My Html editor text' in message

--- a/tests/shared/client.py
+++ b/tests/shared/client.py
@@ -118,12 +118,21 @@ class Client(TestApp):
 
 class GenericResponseExtension:
 
-    def select_checkbox(self, groupname, label, form=None, checked=True):
+    def select_checkbox(
+        self,
+        groupname,
+        label,
+        form=None,
+        checked=True,
+        limit=None
+    ):
         """ Selects one of many checkboxes by fuzzy searching the label next to
         it. Webtest is not good enough in this regard.
 
         Selects the checkbox from the form returned by page.form, or the given
         form if passed. In any case, the form needs to be part of the page.
+
+        A limit can be set to restrict the number of checkboxes to select.
 
         """
 
@@ -133,10 +142,14 @@ class GenericResponseExtension:
             raise KeyError(f"No input named {groupname} found")
 
         form = form or self.form
+        count = 0
 
         for ix, el in enumerate(elements):
             if label in el.label.text_content():
                 form.get(groupname, index=ix).value = checked
+                count += 1
+                if limit is not None and count >= limit:
+                    break
 
     def select_radio(self, groupname, label, form=None):
         """ Like `select_checkbox`, but with the ability to select a radio


### PR DESCRIPTION
Newsletter: List all occurrences in newsletter creation form

Previously only Events without their reoccurrences were listed when creating a newsletter

TYPE: Feature
LINK: ogc-2280

## Checklist

- [x] I have performed a self-review of my code
- [x] I considered adding a reviewer
- [x] I made changes/features for both org and town6
- [x] I have tested my code thoroughly by hand
- [x] I have added tests for my changes/features
