### PR TITLE
Wil event import: Provider url alternatively to event url

### DIFF
--- a/src/onegov/event/collections/events.py
+++ b/src/onegov/event/collections/events.py
@@ -602,7 +602,12 @@ class EventCollection(Pagination[Event]):
             event_image, event_image_name = get_event_image(event)
 
             ticket_price = find_element_text(event, 'ticketPrice')
-            event_url = find_element_text(event, 'originalEventUrl') or None
+            event_url = find_element_text(event, 'originalEventUrl') or ''
+
+            provider_url = ''
+            provider_ref = event.find('ns:providerReference', namespaces=ns)
+            if provider_ref:
+                provider_url = find_element_text(provider_ref, 'url')
 
             tags = []
             if event.find('ns:tags', namespaces=ns) is not None:
@@ -675,7 +680,7 @@ class EventCollection(Pagination[Event]):
                             location=location,
                             coordinates=coordinates,
                             price=ticket_price,
-                            external_event_url=event_url,
+                            external_event_url=event_url or provider_url,
                             tags=tags,
                             filter_keywords=None,
                             source=schedule_id,

--- a/tests/onegov/org/test_cronjobs.py
+++ b/tests/onegov/org/test_cronjobs.py
@@ -2198,6 +2198,9 @@ def test_wil_daily_event_import(wil_app, capturelog):
             <tag>Library</tag>
           </tags>
           <originalEventUrl></originalEventUrl>
+          <providerReference>
+            <url>https://www.lemington.ch/events/reading-johanna-beehrens</url>
+          </providerReference>
           <schedules>
             <schedule>
               <uuid7>S132451</uuid7>
@@ -2361,7 +2364,7 @@ def test_wil_daily_event_import(wil_app, capturelog):
     assert events[1].organizer == 'Culture Club'
     assert events[1].organizer_email == 'info@cultureclub.io'
     assert events[1].organizer_phone == '044 321 7744'
-    assert events[1].external_event_url == None
+    assert events[1].external_event_url == 'https://www.lemington.ch/events/reading-johanna-beehrens'
 
     # events 3 and 4 are actually the same event but different schedules
     for i, start in zip(


### PR DESCRIPTION
Org: Wil event import: Provider url alternatively to event url

TYPE: Feature
LINK: ogc-2184

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I considered adding a reviewer
- [ ] I have added an upgrade hint such as data migration commands to be run
- [ ] I have updated the PO files
- [ ] I have added new modules to the docs
- [ ] I made changes/features for both org and town6
- [ ] I have updated the election_day API docs
- [ ] I have tested my code thoroughly by hand
    - [ ] I have tested styling changes/features on different browsers
    - [ ] I have tested javascript changes/features on different browsers
    - [ ] I have tested database upgrades
    - [ ] I have tested sending mails
    - [ ] I have tested building the documentation
- [ ] I have added tests for my changes/features
    - [ ] I am using freezegun for tests depending on date and times
    - [ ] I considered using browser tests für javascript changes/features
    - [ ] I have added/updated jest tests for d3rendering (election_day, swissvotes)
