### PR TITLE
Improves the merge experience for po files. [skip ci]

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.po merge=po-merge


### PR DESCRIPTION
This fixes this typical pattern of merge conflict:

```po
#
msgid ""
msgstr ""
"Project-Id-Version: PACKAGE 1.0\n"
<<<<<<< HEAD
"POT-Creation-Date: 2025-05-28 01:50+0200\n"
=======
"POT-Creation-Date: 2025-06-11 13:31+0200\n"
>>>>>>> 1d69308051f8532384ee231ee01163e93f7005be
"PO-Revision-Date: 2022-03-15 10:21+0100\n"
```

Use with this:
```
git config merge.po-merge.driver 'python3 -c "
import re
with open(\"%A\", \"r\") as f: content = f.read()
with open(\"%B\", \"r\") as f: new_date = re.search(r\"\\\"POT-Creation-Date: [^\\\"]*\\\"\", f.read()).group()
content = re.sub(r\"\\\"POT-Creation-Date: [^\\\"]*\\\"\", new_date, content)
with open(\"%A\", \"w\") as f: f.write(content)
"'
```

## Commit message

Improves the merge experience for po files. [skip ci]

<Optional Description>

TYPE: Feature
LINK: None


## Checklist


- [x] I considered adding a reviewer

