### PR TITLE
Org: Adds a citizen login with access to tickets and reservations

### DIFF
--- a/src/onegov/agency/app.py
+++ b/src/onegov/agency/app.py
@@ -167,6 +167,14 @@ def get_disabled_extensions() -> tuple[str, ...]:
     return ('PersonLinkExtension', )
 
 
+# NOTE: A citizen login doesn't make a ton of sense here, given the
+#       simplicity of the tickets processed in this system, but we
+#       can think about enabling it in the future.
+@AgencyApp.setting(section='org', name='citizen_login_enabled')
+def get_citizen_login_enabled() -> bool:
+    return False
+
+
 @AgencyApp.webasset_output()
 def get_webasset_output() -> str:
     return 'assets/bundles'

--- a/src/onegov/feriennet/app.py
+++ b/src/onegov/feriennet/app.py
@@ -316,6 +316,12 @@ def get_is_complete_userprofile_handler(
     return is_complete_userprofile
 
 
+# NOTE: Feriennet doesn't need a citizen login
+@FeriennetApp.setting(section='org', name='citizen_login_enabled')
+def get_citizen_login_enabled() -> bool:
+    return False
+
+
 @FeriennetApp.setting(section='i18n', name='localedirs')
 def get_i18n_localedirs() -> list[str]:
     return [

--- a/src/onegov/form/assets/js/chosen-init.js
+++ b/src/onegov/form/assets/js/chosen-init.js
@@ -11,9 +11,11 @@ $(document).ready(function() {
         if (data !== undefined) {
             $.each(data, function(id, value) {
                 $('#' + id).val(value).trigger('change');
-                $('#' + id).find(
-                    'input[value="' + value.replace(/"/g, '\\"') + '"]'
-                ).not(':checked').trigger('click');
+                if (value !== null) {
+                    $('#' + id).find(
+                        'input[value="' + String(value).replace(/"/g, '\\"') + '"]'
+                    ).not(':checked').trigger('click');
+                }
             });
         }
     });

--- a/src/onegov/fsi/app.py
+++ b/src/onegov/fsi/app.py
@@ -74,6 +74,12 @@ def get_create_new_organisation_factory(
     return create_new_organisation
 
 
+# NOTE: Fsi doesn't need a citizen login
+@FsiApp.setting(section='org', name='citizen_login_enabled')
+def get_citizen_login_enabled() -> bool:
+    return False
+
+
 @FsiApp.setting(section='i18n', name='localedirs')
 def get_i18n_localedirs() -> list[str]:
     mine = utils.module_path('onegov.fsi', 'locale')

--- a/src/onegov/intranet/app.py
+++ b/src/onegov/intranet/app.py
@@ -36,3 +36,9 @@ def get_template_variables(request: TownRequest) -> RenderData:
         'global_tools': tuple(get_global_tools(request)),
         'hide_search_header': not request.is_logged_in
     }
+
+
+# NOTE: Intranet doesn't need a citizen login
+@IntranetApp.setting(section='org', name='citizen_login_enabled')
+def get_citizen_login_enabled() -> bool:
+    return False

--- a/src/onegov/landsgemeinde/app.py
+++ b/src/onegov/landsgemeinde/app.py
@@ -72,6 +72,12 @@ def get_theme() -> LandsgemeindeTheme:
     return LandsgemeindeTheme()
 
 
+# NOTE: Landsgemeinde doesn't need a citizen login
+@LandsgemeindeApp.setting(section='org', name='citizen_login_enabled')
+def get_citizen_login_enabled() -> bool:
+    return False
+
+
 @LandsgemeindeApp.webasset('ticker')
 def get_backend_ticker() -> Iterator[str]:
     yield 'ticker.js'

--- a/src/onegov/org/app.py
+++ b/src/onegov/org/app.py
@@ -613,6 +613,11 @@ def get_disabled_extensions() -> Collection[str]:
     return ()
 
 
+@OrgApp.setting(section='org', name='citizen_login_enabled')
+def get_citizen_login_enabled() -> bool:
+    return True
+
+
 @OrgApp.setting(section='org', name='render_mtan_access_limit_exceeded')
 def get_render_mtan_access_limit_exceeded(
 ) -> Callable[[MTANAccessLimitExceeded, OrgRequest], Response]:

--- a/src/onegov/org/assets/js/occupancycalendar.jsx
+++ b/src/onegov/org/assets/js/occupancycalendar.jsx
@@ -263,7 +263,7 @@ oc.setupDatePicker = function(calendar, element) {
         }
     });
     var icon = $(
-        '<span class="fa fa-calendar"></span>'
+        '<span class="fa fa-calendar fa-calendar-alt"></span>'
     ).css('margin-left', '.5rem');
     input.unbind();
     title.append(icon);

--- a/src/onegov/org/assets/js/reservationcalendar.jsx
+++ b/src/onegov/org/assets/js/reservationcalendar.jsx
@@ -325,7 +325,7 @@ rc.setupDatePicker = function(calendar, element) {
         }
     });
     var icon = $(
-        '<span class="fa fa-calendar"></span>'
+        '<span class="fa fa-calendar fa-calendar-alt"></span>'
     ).css('margin-left', '.5rem');
     input.unbind();
     title.append(icon);

--- a/src/onegov/org/forms/__init__.py
+++ b/src/onegov/org/forms/__init__.py
@@ -5,6 +5,8 @@ from onegov.org.forms.allocation import DaypassAllocationEditForm
 from onegov.org.forms.allocation import DaypassAllocationForm
 from onegov.org.forms.allocation import RoomAllocationEditForm
 from onegov.org.forms.allocation import RoomAllocationForm
+from onegov.org.forms.citizen_login import CitizenLoginForm
+from onegov.org.forms.citizen_login import ConfirmCitizenLoginForm
 from onegov.org.forms.commission import CommissionForm
 from onegov.org.forms.directory import DirectoryForm
 from onegov.org.forms.directory import DirectoryImportForm
@@ -60,6 +62,8 @@ from onegov.org.forms.userprofile import UserProfileForm
 __all__ = (
     'AllocationRuleForm',
     'AnalyticsSettingsForm',
+    'CitizenLoginForm',
+    'ConfirmCitizenLoginForm',
     'CommissionForm',
     'DateRangeForm',
     'DaypassAllocationEditForm',

--- a/src/onegov/org/forms/citizen_login.py
+++ b/src/onegov/org/forms/citizen_login.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from onegov.form import Form
+from onegov.form.fields import HoneyPotField
+from onegov.org import _
+from wtforms.fields import EmailField, StringField
+from wtforms.validators import InputRequired
+
+
+class CitizenLoginForm(Form):
+
+    email = EmailField(
+        label=_('E-Mail'),
+        validators=[InputRequired()]
+    )
+
+    duplicate_of = HoneyPotField(
+        render_kw={
+            'autocomplete': 'lazy-wolves'
+        }
+    )
+
+
+class ConfirmCitizenLoginForm(Form):
+
+    token = StringField(
+        label=_('Token'),
+        validators=[InputRequired()]
+    )
+
+    duplicate_of = HoneyPotField(
+        render_kw={
+            'autocomplete': 'lazy-wolves'
+        }
+    )

--- a/src/onegov/org/forms/settings.py
+++ b/src/onegov/org/forms/settings.py
@@ -2084,3 +2084,11 @@ class VATSettingsForm(Form):
                       'apply to all prices in the forms.'),
         validators=[InputRequired(), NumberRange(0, 100)],
     )
+
+
+class CitizenLoginSettingsForm(Form):
+
+    citizen_login_enabled = BooleanField(
+        label=_('Enable Citizen Login'),
+        default=False,
+    )

--- a/src/onegov/org/layout.py
+++ b/src/onegov/org/layout.py
@@ -384,6 +384,10 @@ class Layout(ChameleonLayout, OpenGraphMixin):
         auth = Auth.from_request_path(self.request)
         return self.request.link(auth, name='login')
 
+    def citizen_login_from_path(self) -> str:
+        auth = Auth.from_request_path(self.request)
+        return self.request.link(auth, name='citizen-login')
+
     def export_formatter(self, format: str) -> Callable[[object], Any]:
         """ Returns a formatter function which takes a value and returns
         the value ready for export.

--- a/src/onegov/org/locale/de_CH/LC_MESSAGES/onegov.org.po
+++ b/src/onegov/org/locale/de_CH/LC_MESSAGES/onegov.org.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE 1.0\n"
-"POT-Creation-Date: 2025-07-03 09:03+0200\n"
+"POT-Creation-Date: 2025-07-03 09:16+0200\n"
 "PO-Revision-Date: 2022-03-15 10:21+0100\n"
 "Last-Translator: Marc Sommerhalder <marc.sommerhalder@seantis.ch>\n"
 "Language-Team: German\n"
@@ -157,7 +157,7 @@ msgid "Login"
 msgstr "Anmelden"
 
 msgid "Citizen Login"
-msgstr "Bürger-Login"
+msgstr "Kunden-Login"
 
 msgid "No registration necessary"
 msgstr "Keine Registrierung erforderlich"
@@ -2547,7 +2547,7 @@ msgstr ""
 "in den Formularen angewendet."
 
 msgid "Enable Citizen Login"
-msgstr "Bürger-Login aktivieren"
+msgstr "Kunden-Login aktivieren"
 
 msgid ""
 "Select newsletter categories your are interested in. You will receive the "
@@ -5783,7 +5783,7 @@ msgid "Invalid or expired login token provided."
 msgstr "Ungültiger oder abgelaufener Login-Code eingegeben."
 
 msgid "Confirm Citizen Login"
-msgstr "Bürger-Login bestätigen"
+msgstr "Kunden-Login bestätigen"
 
 msgid "A link was added to the clipboard"
 msgstr "Ein Verweis wurde in die Zwischenablage kopiert"

--- a/src/onegov/org/locale/de_CH/LC_MESSAGES/onegov.org.po
+++ b/src/onegov/org/locale/de_CH/LC_MESSAGES/onegov.org.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE 1.0\n"
-"POT-Creation-Date: 2025-07-01 09:10+0200\n"
+"POT-Creation-Date: 2025-07-02 14:11+0200\n"
 "PO-Revision-Date: 2022-03-15 10:21+0100\n"
 "Last-Translator: Marc Sommerhalder <marc.sommerhalder@seantis.ch>\n"
 "Language-Team: German\n"
@@ -156,6 +156,12 @@ msgstr "Abmelden"
 msgid "Login"
 msgstr "Anmelden"
 
+msgid "Citizen Login"
+msgstr "Bürger-Login"
+
+msgid "No registration necessary"
+msgstr "Keine Registrierung erforderlich"
+
 msgid "Register"
 msgstr "Registrierung"
 
@@ -215,6 +221,12 @@ msgstr "Abgeschlossene Tickets"
 
 msgid "Ticket"
 msgstr "Ticket"
+
+msgid "My Requests"
+msgstr "Meine Anfragen"
+
+msgid "My Reservations"
+msgstr "Meine Reservationen"
 
 msgid "This site is private"
 msgstr "Diese Seite ist privat"
@@ -393,6 +405,12 @@ msgstr "Kontingent per Reservation"
 
 msgid "Start time before end time"
 msgstr "Start-Zeit vor End-Zeit"
+
+msgid "E-Mail"
+msgstr "E-Mail"
+
+msgid "Token"
+msgstr "Login Code"
 
 msgid "Name"
 msgstr "Name"
@@ -674,9 +692,6 @@ msgstr "Ungültiger Name. Ein gültiger Vorschlag ist: ${name}"
 
 msgid "An entry with the same name exists"
 msgstr "Ein Eintrag mit diesem Namen existiert bereits"
-
-msgid "E-Mail"
-msgstr "E-Mail"
 
 msgid "Describes briefly what this form is about"
 msgstr "Beschreibt kurz um was es bei diesem Formular geht"
@@ -4442,6 +4457,19 @@ msgstr ""
 "Falls Sie sich nicht bei dieser Seite angemeldet haben, können Sie diese "
 "Nachricht ignorieren. Sie erhalten dann keine weiteren E-Mails von uns."
 
+msgid "Your e-mail address was just used to send a login link to ${homepage}."
+msgstr ""
+"Ihre E-Mail Adresse wurde soeben zum Senden eines Anmeldelinks auf "
+"${homepage} verwendet."
+
+msgid "Use the token below or click on the link to complete your login."
+msgstr ""
+"Verwenden Sie den untenstehenden Login-Code oder klicken Sie auf den Link, "
+"um Ihre Anmeldung abzuschliessen."
+
+msgid "Complete Login"
+msgstr "Anmeldung abschliessen"
+
 msgid "Hello"
 msgstr "Grüezi"
 
@@ -5743,6 +5771,16 @@ msgstr ""
 
 msgid "Successfully authenticated via mTAN."
 msgstr "Erfolgreich per mTAN authentifiziert."
+
+#, python-format
+msgid "Login Token for ${organisation}"
+msgstr "Login-Code für ${organisation}"
+
+msgid "Invalid or expired login token provided."
+msgstr "Ungültiger oder abgelaufener Login-Code eingegeben."
+
+msgid "Confirm Citizen Login"
+msgstr "Bürger-Login bestätigen"
 
 msgid "A link was added to the clipboard"
 msgstr "Ein Verweis wurde in die Zwischenablage kopiert"
@@ -7064,6 +7102,9 @@ msgstr "Ein Konto wurde für Sie erstellt"
 
 msgid "The user was created successfully"
 msgstr "Der Benutzer wurde erfolgreich erstellt"
+
+msgid "Please enter your e-mail address in order to continue"
+msgstr "Bitte geben Sie ihre E-Mail Adresse ein um fortzufahren"
 
 #~ msgid "Please note that this page has subpages which will also be deleted!"
 #~ msgstr ""

--- a/src/onegov/org/locale/de_CH/LC_MESSAGES/onegov.org.po
+++ b/src/onegov/org/locale/de_CH/LC_MESSAGES/onegov.org.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE 1.0\n"
-"POT-Creation-Date: 2025-07-02 14:11+0200\n"
+"POT-Creation-Date: 2025-07-03 09:03+0200\n"
 "PO-Revision-Date: 2022-03-15 10:21+0100\n"
 "Last-Translator: Marc Sommerhalder <marc.sommerhalder@seantis.ch>\n"
 "Language-Team: German\n"
@@ -2545,6 +2545,9 @@ msgid ""
 msgstr ""
 "Mehrwertsteuersatz in Prozent. Der Mehrwertsteuersatz wird auf alle Preise "
 "in den Formularen angewendet."
+
+msgid "Enable Citizen Login"
+msgstr "Bürger-Login aktivieren"
 
 msgid ""
 "Select newsletter categories your are interested in. You will receive the "

--- a/src/onegov/org/locale/fr_CH/LC_MESSAGES/onegov.org.po
+++ b/src/onegov/org/locale/fr_CH/LC_MESSAGES/onegov.org.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE 1.0\n"
-"POT-Creation-Date: 2025-07-03 09:03+0200\n"
+"POT-Creation-Date: 2025-07-03 09:16+0200\n"
 "PO-Revision-Date: 2022-03-15 10:50+0100\n"
 "Last-Translator: Marc Sommerhalder <marc.sommerhalder@seantis.ch>\n"
 "Language-Team: French\n"
@@ -157,7 +157,7 @@ msgid "Login"
 msgstr "Connexion"
 
 msgid "Citizen Login"
-msgstr "Connexion citoyen"
+msgstr "Connexion client"
 
 msgid "No registration necessary"
 msgstr "Aucune inscription n'est nécessaire"
@@ -2557,7 +2557,7 @@ msgstr ""
 "les prix dans les formulaires."
 
 msgid "Enable Citizen Login"
-msgstr "Activer la connexion des citoyens"
+msgstr "Activer la connexion des clients"
 
 msgid ""
 "Select newsletter categories your are interested in. You will receive the "
@@ -5799,7 +5799,7 @@ msgid "Invalid or expired login token provided."
 msgstr "Le code de connexion fourni n'est pas valide ou a expiré."
 
 msgid "Confirm Citizen Login"
-msgstr "Confirmer la connexion du citoyen"
+msgstr "Confirmer la connexion du client"
 
 msgid "A link was added to the clipboard"
 msgstr "Un lien a été ajouté au presse-papiers"

--- a/src/onegov/org/locale/fr_CH/LC_MESSAGES/onegov.org.po
+++ b/src/onegov/org/locale/fr_CH/LC_MESSAGES/onegov.org.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE 1.0\n"
-"POT-Creation-Date: 2025-07-01 09:10+0200\n"
+"POT-Creation-Date: 2025-07-02 14:11+0200\n"
 "PO-Revision-Date: 2022-03-15 10:50+0100\n"
 "Last-Translator: Marc Sommerhalder <marc.sommerhalder@seantis.ch>\n"
 "Language-Team: French\n"
@@ -156,6 +156,12 @@ msgstr "Se déconnecter"
 msgid "Login"
 msgstr "Connexion"
 
+msgid "Citizen Login"
+msgstr "Connexion citoyen"
+
+msgid "No registration necessary"
+msgstr "Aucune inscription n'est nécessaire"
+
 msgid "Register"
 msgstr "S'inscrire"
 
@@ -215,6 +221,12 @@ msgstr "Tickets clôturés"
 
 msgid "Ticket"
 msgstr "Ticket"
+
+msgid "My Requests"
+msgstr "Mes demandes"
+
+msgid "My Reservations"
+msgstr "Mes réservations"
 
 msgid "This site is private"
 msgstr "Ce site est privé"
@@ -393,6 +405,12 @@ msgstr "Limit des reservations"
 
 msgid "Start time before end time"
 msgstr "Heure de début avant l'heure de fin"
+
+msgid "E-Mail"
+msgstr "E-mail"
+
+msgid "Token"
+msgstr "Code"
 
 msgid "Name"
 msgstr "Nom"
@@ -675,9 +693,6 @@ msgstr "Nom invalide. Une suggestion valid est: ${name}"
 
 msgid "An entry with the same name exists"
 msgstr "Une entrée avec le même nom existe"
-
-msgid "E-Mail"
-msgstr "E-mail"
 
 msgid "Describes briefly what this form is about"
 msgstr "Décrit brièvement ce formulaire"
@@ -4450,6 +4465,18 @@ msgstr ""
 "Si vous pensez que c'est une erreur, ignorez ce message et nous ne vous "
 "importunerons plus jamais."
 
+msgid "Your e-mail address was just used to send a login link to ${homepage}."
+msgstr ""
+"Votre adresse e-mail vient d'être utilisée pour envoyer un lien de connexion "
+"à ${homepage}."
+
+msgid "Use the token below or click on the link to complete your login."
+msgstr ""
+"Utilisez le code ci-dessous ou cliquez sur le lien pour vous connecter."
+
+msgid "Complete Login"
+msgstr "Connexion complète"
+
 msgid "Hello"
 msgstr "Bonjour"
 
@@ -5760,6 +5787,16 @@ msgstr ""
 
 msgid "Successfully authenticated via mTAN."
 msgstr "Authentification via mTAN réussie."
+
+#, python-format
+msgid "Login Token for ${organisation}"
+msgstr "Code de connexion pour ${organisation}"
+
+msgid "Invalid or expired login token provided."
+msgstr "Le code de connexion fourni n'est pas valide ou a expiré."
+
+msgid "Confirm Citizen Login"
+msgstr "Confirmer la connexion du citoyen"
 
 msgid "A link was added to the clipboard"
 msgstr "Un lien a été ajouté au presse-papiers"
@@ -7078,6 +7115,9 @@ msgstr "Un compte a été créé pour vous"
 
 msgid "The user was created successfully"
 msgstr "L'utilisateur a bien été créé"
+
+msgid "Please enter your e-mail address in order to continue"
+msgstr "Veuillez saisir votre adresse e-mail pour continuer"
 
 #~ msgid "Please note that this page has subpages which will also be deleted!"
 #~ msgstr ""

--- a/src/onegov/org/locale/fr_CH/LC_MESSAGES/onegov.org.po
+++ b/src/onegov/org/locale/fr_CH/LC_MESSAGES/onegov.org.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE 1.0\n"
-"POT-Creation-Date: 2025-07-02 14:11+0200\n"
+"POT-Creation-Date: 2025-07-03 09:03+0200\n"
 "PO-Revision-Date: 2022-03-15 10:50+0100\n"
 "Last-Translator: Marc Sommerhalder <marc.sommerhalder@seantis.ch>\n"
 "Language-Team: French\n"
@@ -2555,6 +2555,9 @@ msgid ""
 msgstr ""
 "Il s'agit du taux de TVA en pourcentage. Le taux de TVA s'appliquera à tous "
 "les prix dans les formulaires."
+
+msgid "Enable Citizen Login"
+msgstr "Activer la connexion des citoyens"
 
 msgid ""
 "Select newsletter categories your are interested in. You will receive the "

--- a/src/onegov/org/locale/it_CH/LC_MESSAGES/onegov.org.po
+++ b/src/onegov/org/locale/it_CH/LC_MESSAGES/onegov.org.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"POT-Creation-Date: 2025-07-01 09:10+0200\n"
+"POT-Creation-Date: 2025-07-02 14:11+0200\n"
 "PO-Revision-Date: 2022-03-15 10:52+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -157,6 +157,12 @@ msgstr "Esci"
 msgid "Login"
 msgstr "Accedi"
 
+msgid "Citizen Login"
+msgstr "Accesso cittadino"
+
+msgid "No registration necessary"
+msgstr "Non è necessaria la registrazione"
+
 msgid "Register"
 msgstr "Registrati"
 
@@ -216,6 +222,12 @@ msgstr "Biglietti chiusi"
 
 msgid "Ticket"
 msgstr "Biglietto"
+
+msgid "My Requests"
+msgstr "Le mie richieste"
+
+msgid "My Reservations"
+msgstr "Le mie prenotazioni"
 
 msgid "This site is private"
 msgstr "Questo sito è privato"
@@ -394,6 +406,12 @@ msgstr "Slot per prenotazione"
 
 msgid "Start time before end time"
 msgstr "Ora di inizio precedente l'ora di fine"
+
+msgid "E-Mail"
+msgstr "E-mail"
+
+msgid "Token"
+msgstr "Token"
 
 msgid "Name"
 msgstr "Nome"
@@ -677,9 +695,6 @@ msgstr "Nome non valido. Un suggerimento valido è: ${name}"
 
 msgid "An entry with the same name exists"
 msgstr "Esiste già un elemento con lo stesso nome"
-
-msgid "E-Mail"
-msgstr "E-mail"
 
 msgid "Describes briefly what this form is about"
 msgstr "Descrive brevemente il contenuto di questo modulo"
@@ -4436,6 +4451,18 @@ msgstr ""
 "Se ritieni che si tratti di un errore, ignora questo messaggio e non ti "
 "disturberemo mai più."
 
+msgid "Your e-mail address was just used to send a login link to ${homepage}."
+msgstr ""
+"Il vostro indirizzo e-mail è stato appena utilizzato per inviare un link di "
+"accesso a ${homepage}."
+
+msgid "Use the token below or click on the link to complete your login."
+msgstr ""
+"Utilizzare il token sottostante o fare clic sul link per completare il login."
+
+msgid "Complete Login"
+msgstr "Accesso completo"
+
 msgid "Hello"
 msgstr "Ciao"
 
@@ -5736,6 +5763,16 @@ msgstr ""
 
 msgid "Successfully authenticated via mTAN."
 msgstr "Autenticazione tramite mTAN riuscita."
+
+#, python-format
+msgid "Login Token for ${organisation}"
+msgstr "Token di accesso per ${organizzazione}"
+
+msgid "Invalid or expired login token provided."
+msgstr "È stato fornito un token di accesso non valido o scaduto."
+
+msgid "Confirm Citizen Login"
+msgstr "Confermare l'accesso del cittadino"
 
 msgid "A link was added to the clipboard"
 msgstr "È stato aggiunto un collegamento agli appunti"
@@ -7056,6 +7093,9 @@ msgstr "È stato creato un account per te"
 
 msgid "The user was created successfully"
 msgstr "Utente creato correttamente"
+
+msgid "Please enter your e-mail address in order to continue"
+msgstr "Inserisci il tuo indirizzo e-mail per continuare"
 
 #~ msgid "Please note that this page has subpages which will also be deleted!"
 #~ msgstr ""

--- a/src/onegov/org/locale/it_CH/LC_MESSAGES/onegov.org.po
+++ b/src/onegov/org/locale/it_CH/LC_MESSAGES/onegov.org.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"POT-Creation-Date: 2025-07-02 14:11+0200\n"
+"POT-Creation-Date: 2025-07-03 09:03+0200\n"
 "PO-Revision-Date: 2022-03-15 10:52+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -2554,6 +2554,9 @@ msgid ""
 msgstr ""
 "Si tratta del tasso di IVA in percentuale. Il tasso di IVA si applicherà a "
 "tutti i prezzi nei moduli."
+
+msgid "Enable Citizen Login"
+msgstr "Abilitare l'accesso del cittadino"
 
 msgid ""
 "Select newsletter categories your are interested in. You will receive the "

--- a/src/onegov/org/locale/it_CH/LC_MESSAGES/onegov.org.po
+++ b/src/onegov/org/locale/it_CH/LC_MESSAGES/onegov.org.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"POT-Creation-Date: 2025-07-03 09:03+0200\n"
+"POT-Creation-Date: 2025-07-03 09:16+0200\n"
 "PO-Revision-Date: 2022-03-15 10:52+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -158,7 +158,7 @@ msgid "Login"
 msgstr "Accedi"
 
 msgid "Citizen Login"
-msgstr "Accesso cittadino"
+msgstr "Accesso cliente"
 
 msgid "No registration necessary"
 msgstr "Non è necessaria la registrazione"
@@ -2556,7 +2556,7 @@ msgstr ""
 "tutti i prezzi nei moduli."
 
 msgid "Enable Citizen Login"
-msgstr "Abilitare l'accesso del cittadino"
+msgstr "Abilitare l'accesso del cliente"
 
 msgid ""
 "Select newsletter categories your are interested in. You will receive the "
@@ -5775,7 +5775,7 @@ msgid "Invalid or expired login token provided."
 msgstr "È stato fornito un token di accesso non valido o scaduto."
 
 msgid "Confirm Citizen Login"
-msgstr "Confermare l'accesso del cittadino"
+msgstr "Confermare l'accesso del cliente"
 
 msgid "A link was added to the clipboard"
 msgstr "È stato aggiunto un collegamento agli appunti"

--- a/src/onegov/org/models/organisation.py
+++ b/src/onegov/org/models/organisation.py
@@ -262,6 +262,9 @@ class Organisation(Base, TimestampMixin):
     mtan_access_window_requests: dict_property[int | None] = meta_property()
     mtan_session_duration_seconds: dict_property[int | None] = meta_property()
 
+    # Citizen Login
+    citizen_login_enabled: dict_property[bool] = meta_property(default=False)
+
     # Open Data
     ogd_publisher_mail: dict_property[str | None] = meta_property()
     ogd_publisher_id: dict_property[str | None] = meta_property()

--- a/src/onegov/org/request.py
+++ b/src/onegov/org/request.py
@@ -91,7 +91,7 @@ class OrgRequest(CoreRequest):
 
     @property
     def current_username(self) -> str | None:
-        return self.identity .userid if self.identity else None
+        return self.identity.userid if self.identity else None
 
     @cached_property
     def current_user(self) -> User | None:
@@ -103,6 +103,14 @@ class OrgRequest(CoreRequest):
             .filter_by(username=self.identity.userid)
             .first()
         )
+
+    @cached_property
+    def authenticated_email(self) -> str | None:
+        """
+        Used for granting access to private information that isn't
+        necessarily tied to a registered user.
+        """
+        return self.browser_session.get('authenticated_email')
 
     @cached_property
     def first_admin_available(self) -> User | None:

--- a/src/onegov/org/templates/mail_citizen_login.pt
+++ b/src/onegov/org/templates/mail_citizen_login.pt
@@ -1,0 +1,28 @@
+<div metal:use-macro="layout.base" i18n:domain="onegov.org">
+    <tal:b metal:fill-slot="title">
+        ${title}
+    </tal:b>
+    <tal:b metal:fill-slot="body">
+        <p i18n:translate>Hello!</p>
+
+        <p tal:define="homepage request.link(request.app.org)">
+            <span i18n:translate>Your e-mail address was just used to send a login link to <a href="${homepage}" tal:content='homepage' i18n:name='homepage' />.</span>
+        </p>
+
+        <p i18n:translate>
+            Use the token below or click on the link to complete your login.
+        </p>
+
+        <p class="token">
+            ${token}
+        </p>
+
+        <p>
+            <a href="${confirm_link}" i18n:translate>Complete Login</a>
+        </p>
+
+        <p i18n:translate>
+            If you believe this is an error, ignore this message and we'll never bother you again.
+        </p>
+    </tal:b>
+</div>

--- a/src/onegov/org/templates/mail_layout.pt
+++ b/src/onegov/org/templates/mail_layout.pt
@@ -221,6 +221,13 @@
         padding: 0;
     }
 
+    .token {
+        background-color: #f5f5f5;
+        Margin-bottom: 10px;
+        padding: 0;
+        font-size: 22px;
+    }
+
     .header {
         background-color: #eee;
         padding: 5px 10px;

--- a/src/onegov/org/theme/styles/org.scss
+++ b/src/onegov/org/theme/styles/org.scss
@@ -348,6 +348,8 @@ $globals-height: 2.5rem;
     .ticket-archive::before { @include icon('\f1c6'); }
     .forms::before { @include icon('\f15c'); }
     .surveys::before { @include icon('\f080'); }
+    .citizen-tickets::before { @include icon('\f145'); }
+    .citizen-reservations::before { @include icon('\f133'); }
 
     .with-count::before {
         border: 1px solid $primary-fg-color;
@@ -3110,6 +3112,7 @@ button {
         z-index: 2;
         padding: 2px 4px;
         border-top-right-radius: 1.2rem;
+        white-space: nowrap;
 
         &::first-line {
             font-weight: bold;

--- a/src/onegov/org/theme/styles/org.scss
+++ b/src/onegov/org/theme/styles/org.scss
@@ -348,6 +348,7 @@ $globals-height: 2.5rem;
     .ticket-archive::before { @include icon('\f1c6'); }
     .forms::before { @include icon('\f15c'); }
     .surveys::before { @include icon('\f080'); }
+    .citizen-login::before { @include icon('\f090'); }
     .citizen-tickets::before { @include icon('\f145'); }
     .citizen-reservations::before { @include icon('\f133'); }
 

--- a/src/onegov/org/views/auth.py
+++ b/src/onegov/org/views/auth.py
@@ -738,6 +738,9 @@ def handle_citizen_login(
     layout: Layout | None = None
 ) -> RenderData | Response:
 
+    if not request.app.org.citizen_login_enabled:
+        raise exc.HTTPNotFound()
+
     if form.submitted(request):
         assert form.email.data is not None
         collection = TANCollection(request.session, scope='citizen-login')
@@ -795,6 +798,9 @@ def handle_confirm_citizen_login(
     layout: Layout | None = None
 ) -> RenderData | Response:
 
+    if not request.app.org.citizen_login_enabled:
+        raise exc.HTTPNotFound()
+
     if request.authenticated_email:
         return self.redirect(request, self.to)
 
@@ -840,6 +846,9 @@ def handle_citizen_logout(
     self: Auth,
     request: OrgRequest
 ) -> Response:
+
+    if not request.app.org.citizen_login_enabled:
+        raise exc.HTTPNotFound()
 
     if request.authenticated_email:
         del request.browser_session['authenticated_email']

--- a/src/onegov/org/views/auth.py
+++ b/src/onegov/org/views/auth.py
@@ -741,6 +741,9 @@ def handle_citizen_login(
     if not request.app.org.citizen_login_enabled:
         raise exc.HTTPNotFound()
 
+    if request.authenticated_email:
+        return self.redirect(request, self.to)
+
     if form.submitted(request):
         assert form.email.data is not None
         collection = TANCollection(request.session, scope='citizen-login')
@@ -815,6 +818,7 @@ def handle_confirm_citizen_login(
         else:
             request.browser_session['authenticated_email'] = (
                 tan_obj.meta['email'])
+            tan_obj.expire()
             return self.redirect(
                 request,
                 tan_obj.meta.get('redirect_to', self.to)

--- a/src/onegov/org/views/auth.py
+++ b/src/onegov/org/views/auth.py
@@ -5,17 +5,20 @@ import morepath
 
 from onegov.core.markdown import render_untrusted_markdown
 from onegov.core.security import Public, Personal
+from onegov.core.utils import append_query_param
 from onegov.org import _, OrgApp
 from onegov.org import log
 from onegov.org.auth import MTANAuth
 from onegov.org.elements import Link
 from onegov.org.forms import PublicMTANForm, PublicRequestMTANForm
+from onegov.org.forms import CitizenLoginForm, ConfirmCitizenLoginForm
 from onegov.org.layout import DefaultLayout
 from onegov.org.mail import send_transactional_html_mail
 from onegov.user import Auth, UserCollection
 from onegov.user.auth.provider import OauthProvider
 from onegov.user.auth.second_factor import MTANFactor
 from onegov.user.auth.second_factor import TOTPFactor
+from onegov.user.collections import TANCollection
 from onegov.user.errors import AlreadyActivatedError
 from onegov.user.errors import ExistingUserError
 from onegov.user.errors import ExpiredSignupLinkError
@@ -719,3 +722,126 @@ def handle_authenticate_mtan(
         'form': form,
         'form_width': 'small'
     }
+
+
+@OrgApp.form(
+    model=Auth,
+    name='citizen-login',
+    template='form.pt',
+    permission=Public,
+    form=CitizenLoginForm
+)
+def handle_citizen_login(
+    self: Auth,
+    request: OrgRequest,
+    form: CitizenLoginForm,
+    layout: Layout | None = None
+) -> RenderData | Response:
+
+    if form.submitted(request):
+        assert form.email.data is not None
+        collection = TANCollection(request.session, scope='citizen-login')
+        tan_obj = collection.add(
+            client=request.client_addr or 'unknown',
+            email=form.email.data,
+            redirect_to=self.to
+        )
+        title = request.translate(_(
+            'Login Token for ${organisation}',
+            mapping={'organisation': request.app.org.title}
+        ))
+        confirm_link = request.link(self, name='confirm-citizen-login')
+        send_transactional_html_mail(
+            request,
+            'mail_citizen_login.pt',
+            content={
+                'model': self,
+                'title': title,
+                'token': tan_obj.tan,
+                'confirm_link': append_query_param(
+                    confirm_link, 'token', tan_obj.tan
+                )
+            },
+            receivers=form.email.data,
+            subject=title,
+        )
+        return morepath.redirect(confirm_link)
+
+    layout = layout or DefaultLayout(self, request)
+    layout.breadcrumbs = [
+        Link(_('Homepage'), layout.homepage_url),
+        Link(_('Citizen Login'), '#')
+    ]
+
+    return {
+        'layout': layout,
+        'title': _('Citizen Login'),
+        'form': form,
+        'form_width': 'small'
+    }
+
+
+@OrgApp.form(
+    model=Auth,
+    name='confirm-citizen-login',
+    template='form.pt',
+    permission=Public,
+    form=ConfirmCitizenLoginForm
+)
+def handle_confirm_citizen_login(
+    self: Auth,
+    request: OrgRequest,
+    form: ConfirmCitizenLoginForm,
+    layout: Layout | None = None
+) -> RenderData | Response:
+
+    if request.authenticated_email:
+        return self.redirect(request, self.to)
+
+    if form.submitted(request):
+        assert form.token.data is not None
+        collection = TANCollection(request.session, scope='citizen-login')
+        tan_obj = collection.by_tan(form.token.data)
+        if tan_obj is None or 'email' not in tan_obj.meta:
+            client = request.client_addr or 'unknown'
+            log.info(f'Failed login by {client} (Citizen Login)')
+            request.alert(_('Invalid or expired login token provided.'))
+        else:
+            request.browser_session['authenticated_email'] = (
+                tan_obj.meta['email'])
+            return self.redirect(
+                request,
+                tan_obj.meta.get('redirect_to', self.to)
+            )
+    elif not request.POST and (token := request.GET.get('token')):
+        form.token.data = token
+
+    layout = layout or DefaultLayout(self, request)
+    layout.breadcrumbs = [
+        Link(_('Homepage'), layout.homepage_url),
+        Link(_('Citizen Login'), request.link(self, name='citizen-login')),
+        Link(_('Confirm'), '#')
+    ]
+
+    return {
+        'layout': layout,
+        'title': _('Confirm Citizen Login'),
+        'form': form,
+        'form_width': 'small'
+    }
+
+
+@OrgApp.view(
+    model=Auth,
+    name='citizen-logout',
+    permission=Public,
+)
+def handle_citizen_logout(
+    self: Auth,
+    request: OrgRequest
+) -> Response:
+
+    if request.authenticated_email:
+        del request.browser_session['authenticated_email']
+
+    return self.redirect(request, self.to)

--- a/src/onegov/org/views/resource.py
+++ b/src/onegov/org/views/resource.py
@@ -1196,6 +1196,9 @@ def view_my_reservations_json(
     more information.
 
     """
+    if not request.app.org.citizen_login_enabled:
+        raise exc.HTTPNotFound()
+
     if not request.authenticated_email:
         raise exc.HTTPForbidden()
 

--- a/src/onegov/org/views/ticket.py
+++ b/src/onegov/org/views/ticket.py
@@ -27,6 +27,7 @@ from onegov.org.forms import TicketChatMessageForm
 from onegov.org.forms import TicketNoteForm
 from onegov.org.layout import (
     FindYourSpotLayout, DefaultMailLayout, ArchivedTicketsLayout)
+from onegov.org.layout import DefaultLayout
 from onegov.org.layout import TicketChatMessageLayout
 from onegov.org.layout import TicketNoteLayout
 from onegov.org.layout import TicketsLayout
@@ -40,6 +41,7 @@ from onegov.org.models.ticket import ticket_submitter, ReservationHandler
 from onegov.org.pdf.ticket import TicketPdf
 from onegov.org.utils import get_current_tickets_url
 from onegov.org.views.message import view_messages_feed
+from onegov.org.views.utils import assert_citizen_logged_in
 from onegov.org.views.utils import show_tags, show_filters
 from onegov.ticket import handlers as ticket_handlers
 from onegov.ticket import Ticket, TicketCollection
@@ -1426,5 +1428,39 @@ def view_pending_tickets(
     return {
         'title': _('Submitted Requests'),
         'layout': layout or FindYourSpotLayout(self, request),
+        'tickets': tickets,
+    }
+
+
+@OrgApp.html(
+    model=TicketCollection,
+    name='my-tickets',
+    template='pending_tickets.pt',
+    permission=Public
+)
+def view_my_tickets(
+    self: TicketCollection,
+    request: OrgRequest,
+    layout: DefaultLayout | None = None
+) -> RenderData:
+
+    assert_citizen_logged_in(request)
+    assert request.authenticated_email
+
+    tickets = (
+        self.by_ticket_email(request.authenticated_email)
+        .order_by(Ticket.created.desc())
+        .all()
+    )
+
+    layout = layout or DefaultLayout(self, request)
+    layout.breadcrumbs = [
+        Link(_('Homepage'), layout.homepage_url),
+        Link(_('Submitted Requests'), '#')
+    ]
+
+    return {
+        'title': _('Submitted Requests'),
+        'layout': layout,
         'tickets': tickets,
     }

--- a/src/onegov/org/views/utils.py
+++ b/src/onegov/org/views/utils.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from functools import lru_cache
 from onegov.org.i18n import _
 from onegov.user import Auth
-from webob.exc import HTTPFound
+from webob.exc import HTTPFound, HTTPNotFound
 
 
 from typing import TYPE_CHECKING
@@ -23,6 +23,9 @@ def show_filters(request: OrgRequest) -> bool:
 
 
 def assert_citizen_logged_in(request: OrgRequest) -> None:
+    if not request.app.org.citizen_login_enabled:
+        raise HTTPNotFound()
+
     if not request.authenticated_email:
         request.info(
             _('Please enter your e-mail address in order to continue')

--- a/src/onegov/org/views/utils.py
+++ b/src/onegov/org/views/utils.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 from functools import lru_cache
+from onegov.org.i18n import _
+from onegov.user import Auth
+from webob.exc import HTTPFound
 
 
 from typing import TYPE_CHECKING
@@ -17,3 +20,14 @@ def show_tags(request: OrgRequest) -> bool:
 @lru_cache(maxsize=1)
 def show_filters(request: OrgRequest) -> bool:
     return request.app.org.event_filter_type in ('filters', 'tags_and_filters')
+
+
+def assert_citizen_logged_in(request: OrgRequest) -> None:
+    if not request.authenticated_email:
+        request.info(
+            _('Please enter your e-mail address in order to continue')
+        )
+        raise HTTPFound(location=request.link(
+            Auth.from_request_path(request),
+            name='citizen-login'
+        ))

--- a/src/onegov/pas/app.py
+++ b/src/onegov/pas/app.py
@@ -26,6 +26,12 @@ def get_create_new_organisation_factory(
     return create_new_organisation
 
 
+# NOTE: Feriennet doesn't need a citizen login
+@PasApp.setting(section='org', name='citizen_login_enabled')
+def get_citizen_login_enabled() -> bool:
+    return False
+
+
 @PasApp.template_variables()
 def get_template_variables(request: TownRequest) -> RenderData:
     return {

--- a/src/onegov/ticket/collection.py
+++ b/src/onegov/ticket/collection.py
@@ -267,6 +267,10 @@ class TicketCollection(TicketCollectionPagination):
         return self.query().filter(
             Ticket.handler_data['handler_data']['id'] == str(handler_data_id))
 
+    def by_ticket_email(self, ticket_email: str) -> Query[Ticket]:
+        return self.query().filter(
+            Ticket.ticket_email == ticket_email)
+
 
 # FIXME: Why is this its own subclass? shouldn't this at least override
 #        __init__ to pin state to 'archived'?!

--- a/src/onegov/town6/custom.py
+++ b/src/onegov/town6/custom.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
+from onegov.chat.collections import ChatCollection
 from onegov.core.elements import Link, LinkGroup
 from onegov.org.custom import get_global_tools as get_global_tools_base
 from onegov.town6 import _
-from onegov.chat.collections import ChatCollection
 
 
 from typing import TYPE_CHECKING

--- a/src/onegov/town6/custom.py
+++ b/src/onegov/town6/custom.py
@@ -15,7 +15,8 @@ if TYPE_CHECKING:
 def get_global_tools(request: TownRequest) -> Iterator[Link | LinkGroup]:
     for item in get_global_tools_base(request):
 
-        if getattr(item, 'attrs', {}).get('class') == {'login'}:
+        classes = getattr(item, 'attrs', {}).get('class')
+        if classes == {'login'} or classes == {'citizen-login'}:
             continue
 
         yield item

--- a/src/onegov/town6/locale/de_CH/LC_MESSAGES/onegov.town6.po
+++ b/src/onegov/town6/locale/de_CH/LC_MESSAGES/onegov.town6.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: OneGov Cloud 1.0\n"
-"POT-Creation-Date: 2025-07-02 14:13+0200\n"
+"POT-Creation-Date: 2025-07-03 09:15+0200\n"
 "PO-Revision-Date: 2021-03-03 16:24+0100\n"
 "Last-Translator: Lukas Burkhard <lukas.burkhard@seantis.ch>\n"
 "Language-Team: German\n"
@@ -699,7 +699,7 @@ msgid "Login"
 msgstr "Anmelden"
 
 msgid "Citizen Login"
-msgstr "Bürger-Login"
+msgstr "Kunden-Login"
 
 msgid "About"
 msgstr "Impressum"

--- a/src/onegov/town6/locale/de_CH/LC_MESSAGES/onegov.town6.po
+++ b/src/onegov/town6/locale/de_CH/LC_MESSAGES/onegov.town6.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: OneGov Cloud 1.0\n"
-"POT-Creation-Date: 2025-07-01 09:08+0200\n"
+"POT-Creation-Date: 2025-07-02 14:13+0200\n"
 "PO-Revision-Date: 2021-03-03 16:24+0100\n"
 "Last-Translator: Lukas Burkhard <lukas.burkhard@seantis.ch>\n"
 "Language-Team: German\n"
@@ -698,6 +698,9 @@ msgstr "Datenschutz"
 msgid "Login"
 msgstr "Anmelden"
 
+msgid "Citizen Login"
+msgstr "Bürger-Login"
+
 msgid "About"
 msgstr "Impressum"
 
@@ -1226,6 +1229,19 @@ msgstr "Nachfolgend sehen Sie Ihre Chat-Konversation:"
 
 msgid "Have a great day!"
 msgstr "Wir wünschen Ihnen einen schönen Tag!"
+
+msgid "Your e-mail address was just used to send a login link to ${homepage}."
+msgstr ""
+"Ihre E-Mail Adresse wurde soeben zum Senden eines Anmeldelinks auf "
+"${homepage} verwendet."
+
+msgid "Use the token below or click on the link to complete your login."
+msgstr ""
+"Verwenden Sie den untenstehenden Login-Code oder klicken Sie auf den Link, "
+"um Ihre Anmeldung abzuschliessen."
+
+msgid "Complete Login"
+msgstr "Anmeldung abschliessen"
 
 msgid "Hello"
 msgstr "Grüezi"
@@ -1951,14 +1967,14 @@ msgstr "Elektronische Visitenkarte (vCard)"
 msgid "Number"
 msgstr "Nummer"
 
-msgid "Type"
-msgstr "Typ"
+msgid "Business Type"
+msgstr "Geschäftsart"
 
 msgid "Status"
 msgstr "Status"
 
 msgid "Participants"
-msgstr "Teilnehmer"
+msgstr "Verfasser/Beteiligte"
 
 msgid "Parliamentary Group"
 msgstr "Fraktion"
@@ -2561,68 +2577,8 @@ msgstr "Ratsinformationssystem"
 msgid "Ratsinformationssystem (RIS)"
 msgstr "Ratsinformationssystem (RIS)"
 
-msgid "Participants"
-msgstr "Verfasser/Beteiligte"
-
 msgid "New Note"
 msgstr "Neue Notiz"
-
-msgid "Inquiry"
-msgstr "Anfrage"
-
-msgid "Proposal"
-msgstr "Antrag"
-
-msgid "Mandate"
-msgstr "Auftrag"
-
-msgid "Report"
-msgstr "Bericht"
-
-msgid "Report and Proposal"
-msgstr "Bericht und Antrag"
-
-msgid "Decision"
-msgstr "Beschluss"
-
-msgid "Message"
-msgstr "Botschaft"
-
-msgid "Urgent Interpellation"
-msgstr "Dringliche Interpellation"
-
-msgid "Invitation"
-msgstr "Einladung"
-
-msgid "Interpellation"
-msgstr "Interpellation"
-
-msgid "Commission Report"
-msgstr "Kommissionsbericht"
-
-msgid "Communication"
-msgstr "Mitteilung"
-
-msgid "Motion"
-msgstr "Motion"
-
-msgid "Postulate"
-msgstr "Postulat"
-
-msgid "Resolution"
-msgstr "Resolution"
-
-msgid "Regulation"
-msgstr "Verordnung"
-
-msgid "Miscellaneous"
-msgstr "Verschiedenes"
-
-msgid "Elections"
-msgstr "Wahlen"
-
-msgid "Business Type"
-msgstr "Geschäftsart"
 
 #~ msgid "Parliamentarian is not in this commission."
 #~ msgstr "Parlamentarier:in ist nicht in dieser Kommission."
@@ -2710,16 +2666,6 @@ msgstr "Geschäftsart"
 
 #~ msgid "City"
 #~ msgstr "Ort"
-
-msgid "Political Business"
-msgstr "Politisches Geschäft"
-
-msgid "Political Businesses"
-msgstr "Politische Geschäfte"
-
-msgid "No political businesses defined yet."
-msgstr "Es wurden noch keine politischen Geschäfte erfasst."
-
 
 #~ msgid "Sign up"
 #~ msgstr "Anmelden"

--- a/src/onegov/town6/locale/fr_CH/LC_MESSAGES/onegov.town6.po
+++ b/src/onegov/town6/locale/fr_CH/LC_MESSAGES/onegov.town6.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: OneGov Cloud 1.0\n"
-"POT-Creation-Date: 2025-07-02 14:13+0200\n"
+"POT-Creation-Date: 2025-07-03 09:15+0200\n"
 "PO-Revision-Date: 2021-03-03 14:04+0100\n"
 "Last-Translator: Lukas Burkhard <lukas.burkhard@seantis.ch>\n"
 "Language-Team: French\n"

--- a/src/onegov/town6/locale/fr_CH/LC_MESSAGES/onegov.town6.po
+++ b/src/onegov/town6/locale/fr_CH/LC_MESSAGES/onegov.town6.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: OneGov Cloud 1.0\n"
-"POT-Creation-Date: 2025-07-01 09:08+0200\n"
+"POT-Creation-Date: 2025-07-02 14:13+0200\n"
 "PO-Revision-Date: 2021-03-03 14:04+0100\n"
 "Last-Translator: Lukas Burkhard <lukas.burkhard@seantis.ch>\n"
 "Language-Team: French\n"
@@ -700,6 +700,9 @@ msgstr "Protection des données"
 msgid "Login"
 msgstr "Connexion"
 
+msgid "Citizen Login"
+msgstr "Connexion citoyen"
+
 msgid "About"
 msgstr "Impressum"
 
@@ -1224,6 +1227,18 @@ msgstr "Vous pouvez voir ci-dessous votre conversation de chat :"
 
 msgid "Have a great day!"
 msgstr "Passez une bonne journée!"
+
+msgid "Your e-mail address was just used to send a login link to ${homepage}."
+msgstr ""
+"Votre adresse e-mail vient d'être utilisée pour envoyer un lien de connexion "
+"à ${homepage}."
+
+msgid "Use the token below or click on the link to complete your login."
+msgstr ""
+"Utilisez le code ci-dessous ou cliquez sur le lien pour vous connecter."
+
+msgid "Complete Login"
+msgstr "Connexion complète"
 
 msgid "Hello"
 msgstr "Bonjour"
@@ -1950,8 +1965,8 @@ msgstr "Exporter une vCard de cette personne"
 msgid "Number"
 msgstr "Numéro"
 
-msgid "Type"
-msgstr "Type"
+msgid "Business Type"
+msgstr "Type d'activité"
 
 msgid "Status"
 msgstr "Statut"

--- a/src/onegov/town6/locale/it_CH/LC_MESSAGES/onegov.town6.po
+++ b/src/onegov/town6/locale/it_CH/LC_MESSAGES/onegov.town6.po
@@ -1,7 +1,7 @@
 # This file was generated from translations.town6.xlsx
 msgid ""
 msgstr ""
-"POT-Creation-Date: 2025-07-01 09:08+0200\n"
+"POT-Creation-Date: 2025-07-02 14:13+0200\n"
 "PO-Revision-Date: 2021-09-27 16:02+0200\n"
 "Language: it_CH\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -697,6 +697,9 @@ msgstr "Tutela della privacy"
 msgid "Login"
 msgstr "Accedi"
 
+msgid "Citizen Login"
+msgstr "Accesso cittadino"
+
 msgid "About"
 msgstr "Chi Siamo"
 
@@ -1225,6 +1228,18 @@ msgstr "Di seguito potete vedere la vostra conversazione in chat:"
 
 msgid "Have a great day!"
 msgstr "Ti auguro una buona giornata!"
+
+msgid "Your e-mail address was just used to send a login link to ${homepage}."
+msgstr ""
+"Il vostro indirizzo e-mail è stato appena utilizzato per inviare un link di "
+"accesso a ${homepage}."
+
+msgid "Use the token below or click on the link to complete your login."
+msgstr ""
+"Utilizzare il token sottostante o fare clic sul link per completare il login."
+
+msgid "Complete Login"
+msgstr "Accesso completo"
 
 msgid "Hello"
 msgstr "Ciao"
@@ -1944,8 +1959,8 @@ msgstr "Esporta una vCard di questa persona"
 msgid "Number"
 msgstr "Numero"
 
-msgid "Type"
-msgstr "Tipo"
+msgid "Business Type"
+msgstr "Tipo di attività"
 
 msgid "Status"
 msgstr "Stato"

--- a/src/onegov/town6/locale/it_CH/LC_MESSAGES/onegov.town6.po
+++ b/src/onegov/town6/locale/it_CH/LC_MESSAGES/onegov.town6.po
@@ -1,7 +1,7 @@
 # This file was generated from translations.town6.xlsx
 msgid ""
 msgstr ""
-"POT-Creation-Date: 2025-07-02 14:13+0200\n"
+"POT-Creation-Date: 2025-07-03 09:15+0200\n"
 "PO-Revision-Date: 2021-09-27 16:02+0200\n"
 "Language: it_CH\n"
 "Content-Type: text/plain; charset=UTF-8\n"

--- a/src/onegov/town6/templates/layout.pt
+++ b/src/onegov/town6/templates/layout.pt
@@ -96,7 +96,7 @@
             <main>
                 <header id="header" tal:define="header_options request.app.org.header_options or {}">
                     <div id="sticky-header-area">
-                        <div id="globals" class="globals" tal:define="toolbox global_tools|False" tal:condition="request.is_logged_in">
+                        <div id="globals" class="globals" tal:define="toolbox global_tools|False" tal:condition="request.is_logged_in or request.authenticated_email">
                             <div class="grid-container">
                             <div class="grid-x grid-padding-x">
                                 <div class="cell small-12">

--- a/src/onegov/town6/templates/macros.pt
+++ b/src/onegov/town6/templates/macros.pt
@@ -234,6 +234,7 @@
         <span>
             <a href="https://www.admin.digital">OneGov Cloud</a> | <a href="https://github.com/OneGov/onegov-cloud/blob/master/CHANGES.md#release-${layout.app.version.replace('.', '')}">${layout.app.version}</a>
         </span>
+        <br/>
         <span>
             <a href="https://www.admin.digital/datenschutz" i18n:translate>
                 Privacy Protection
@@ -243,6 +244,11 @@
     <span tal:condition="not request.is_logged_in">
         <a href="${layout.login_from_path()}" i18n:translate>
             Login
+        </a>
+    </span>
+    <span tal:condition="not request.authenticated_email">
+        <a href="${layout.citizen_login_from_path()}" i18n:translate>
+            Citizen Login
         </a>
     </span>
     <span tal:define="about_url layout.org.meta.about_url|nothing" tal:condition="about_url">

--- a/src/onegov/town6/templates/macros.pt
+++ b/src/onegov/town6/templates/macros.pt
@@ -230,7 +230,7 @@
 <metal:footer_links define-macro="footer_links" i18n:domain="onegov.town6">
 <div class="medium-4 cell"></div>
 <div class="small-12 medium-4 cell footer-links">
-    <tal:b condition="not request.app.org.hide_onegov_footer|True">
+    <tal:b tal:condition="not request.app.org.hide_onegov_footer|True">
         <span>
             <a href="https://www.admin.digital">OneGov Cloud</a> | <a href="https://github.com/OneGov/onegov-cloud/blob/master/CHANGES.md#release-${layout.app.version.replace('.', '')}">${layout.app.version}</a>
         </span>
@@ -246,7 +246,7 @@
             Login
         </a>
     </span>
-    <span tal:condition="not request.authenticated_email">
+    <span tal:condition="request.app.org.citizen_login_enabled and not request.authenticated_email">
         <a href="${layout.citizen_login_from_path()}" i18n:translate>
             Citizen Login
         </a>

--- a/src/onegov/town6/templates/mail_citizen_login.pt
+++ b/src/onegov/town6/templates/mail_citizen_login.pt
@@ -1,0 +1,28 @@
+<div metal:use-macro="layout.base" i18n:domain="onegov.town6">
+    <tal:b metal:fill-slot="title">
+        ${title}
+    </tal:b>
+    <tal:b metal:fill-slot="body">
+        <p i18n:translate>Hello!</p>
+
+        <p tal:define="homepage request.link(request.app.org)">
+            <span i18n:translate>Your e-mail address was just used to send a login link to <a href="${homepage}" tal:content='homepage' i18n:name='homepage' />.</span>
+        </p>
+
+        <p i18n:translate>
+            Use the token below or click on the link to complete your login.
+        </p>
+
+        <p class="token">
+            ${token}
+        </p>
+
+        <p>
+            <a href="${confirm_link}" i18n:translate>Complete Login</a>
+        </p>
+
+        <p i18n:translate>
+            If you believe this is an error, ignore this message and we'll never bother you again.
+        </p>
+    </tal:b>
+</div>

--- a/src/onegov/town6/templates/mail_layout.pt
+++ b/src/onegov/town6/templates/mail_layout.pt
@@ -228,6 +228,13 @@
         padding: 0;
     }
 
+    .token {
+        background-color: #f5f5f5;
+        Margin-bottom: 10px;
+        padding: 0;
+        font-size: 22px;
+    }
+
     .header {
         background-color: #eee;
         padding: 5px 10px;

--- a/src/onegov/town6/theme/styles/fullcalendar.scss
+++ b/src/onegov/town6/theme/styles/fullcalendar.scss
@@ -32,6 +32,7 @@
         z-index: 2;
         padding: 2px 4px;
         border-top-right-radius: 1.2rem;
+        white-space: nowrap;
 
         &::first-line {
             font-weight: bold;

--- a/src/onegov/town6/theme/styles/header.scss
+++ b/src/onegov/town6/theme/styles/header.scss
@@ -189,6 +189,7 @@ $settings-icon: '\f1de';
     .text-modules::before { @include icon('\f249'); }
     .forms::before { @include icon-bold('\f570'); }
     .surveys::before { @include icon-bold('\f681'); }
+    .citizen-login::before { @include icon-bold("\f2f6"); }
     .citizen-tickets::before { @include icon-bold('\f3ff'); }
     .citizen-reservations::before { @include icon('\f073'); }
 

--- a/src/onegov/town6/theme/styles/header.scss
+++ b/src/onegov/town6/theme/styles/header.scss
@@ -189,6 +189,8 @@ $settings-icon: '\f1de';
     .text-modules::before { @include icon('\f249'); }
     .forms::before { @include icon-bold('\f570'); }
     .surveys::before { @include icon-bold('\f681'); }
+    .citizen-tickets::before { @include icon-bold('\f3ff'); }
+    .citizen-reservations::before { @include icon('\f073'); }
 
     .with-count::before {
         border: 1px solid $primary-fg-color;

--- a/src/onegov/town6/views/auth.py
+++ b/src/onegov/town6/views/auth.py
@@ -3,12 +3,14 @@ from __future__ import annotations
 
 from onegov.core.security import Public
 from onegov.org.auth import MTANAuth
+from onegov.org.forms import CitizenLoginForm, ConfirmCitizenLoginForm
 from onegov.org.forms import PublicMTANForm, PublicRequestMTANForm
 from onegov.org.views.auth import (
     handle_login, handle_registration, handle_password_reset,
     handle_password_reset_request, handle_mtan_second_factor,
     handle_mtan_second_factor_setup, handle_request_mtan,
-    handle_authenticate_mtan, handle_totp_second_factor
+    handle_authenticate_mtan, handle_totp_second_factor,
+    handle_citizen_login, handle_confirm_citizen_login
 )
 from onegov.town6 import TownApp
 from onegov.town6.layout import DefaultLayout
@@ -190,6 +192,46 @@ def town_handle_authenticate_mtan(
     form: PublicMTANForm
 ) -> RenderData | Response:
     return handle_authenticate_mtan(
+        self,
+        request,
+        form,
+        DefaultLayout(self, request)
+    )
+
+
+@TownApp.form(
+    model=Auth,
+    name='citizen-login',
+    template='form.pt',
+    permission=Public,
+    form=CitizenLoginForm
+)
+def town_handle_citizen_login(
+    self: Auth,
+    request: TownRequest,
+    form: CitizenLoginForm
+) -> RenderData | Response:
+    return handle_citizen_login(
+        self,
+        request,
+        form,
+        DefaultLayout(self, request)
+    )
+
+
+@TownApp.form(
+    model=Auth,
+    name='confirm-citizen-login',
+    template='form.pt',
+    permission=Public,
+    form=ConfirmCitizenLoginForm
+)
+def town_handle_confirm_citizen_login(
+    self: Auth,
+    request: TownRequest,
+    form: ConfirmCitizenLoginForm
+) -> RenderData | Response:
+    return handle_confirm_citizen_login(
         self,
         request,
         form,

--- a/src/onegov/town6/views/resource.py
+++ b/src/onegov/town6/views/resource.py
@@ -9,16 +9,16 @@ from onegov.org.views.resource import (
     get_resource_form, handle_edit_resource, view_resource,
     handle_cleanup_allocations, view_occupancy,
     view_resource_subscribe, view_export_all, get_item_form,
-    handle_new_resource_item, view_export
+    handle_new_resource_item, view_export, view_my_reservations
 )
 from onegov.reservation import ResourceCollection, Resource
-from onegov.town6 import TownApp
 from onegov.org.forms import (
     FindYourSpotForm, ResourceCleanupForm, ResourceExportForm
 )
 from onegov.org.models.resource import FindYourSpotCollection
+from onegov.town6 import TownApp
 from onegov.town6.layout import (
-    FindYourSpotLayout, ResourcesLayout, ResourceLayout
+    DefaultLayout, FindYourSpotLayout, ResourcesLayout, ResourceLayout
 )
 
 
@@ -152,6 +152,19 @@ def town_view_occupancy(
     request: TownRequest
 ) -> RenderData:
     return view_occupancy(self, request, ResourceLayout(self, request))
+
+
+@TownApp.html(
+    model=ResourceCollection,
+    permission=Public,
+    name='my-reservations',
+    template='resource_occupancy.pt'
+)
+def town_view_my_reservations(
+    self: ResourceCollection,
+    request: TownRequest
+) -> RenderData:
+    return view_my_reservations(self, request, DefaultLayout(self, request))
 
 
 @TownApp.html(

--- a/src/onegov/town6/views/settings.py
+++ b/src/onegov/town6/views/settings.py
@@ -15,7 +15,7 @@ from onegov.org.forms.settings import (
     LinkHealthCheckForm, PeopleSettingsForm, SocialMediaSettingsForm,
     EventSettingsForm, GeverSettingsForm, OneGovApiSettingsForm,
     DataRetentionPolicyForm, FirebaseSettingsForm, VATSettingsForm,
-    KabaSettingsForm)
+    KabaSettingsForm, CitizenLoginSettingsForm)
 from onegov.org.models import Organisation
 from onegov.town6.forms.settings import RISEnableForm
 from onegov.org.views.settings import (
@@ -27,7 +27,7 @@ from onegov.org.views.settings import (
     handle_newsletter_settings, handle_generic_settings, handle_migrate_links,
     handle_link_health_check, handle_social_media_settings,
     handle_event_settings, handle_api_keys, handle_chat_settings,
-    handle_kaba_settings)
+    handle_kaba_settings, handle_citizen_login_settings)
 
 from onegov.town6.app import TownApp
 from onegov.town6.forms.settings import (
@@ -501,7 +501,7 @@ def handle_vat_settings(
 
 @TownApp.form(
     model=Organisation, name='people-settings', template='form.pt',
-    permission=Secret, form=PeopleSettingsForm, setting='People',
+    permission=Secret, form=PeopleSettingsForm, setting=_('People'),
     icon='fa-users', order=400,
 )
 def town_handle_people_settings(
@@ -525,4 +525,17 @@ def town_handle_ris_enable(
     return handle_generic_settings(
         self, request, form, _('Ratsinformationssystem (RIS)'),
         SettingsLayout(self, request)
+    )
+
+
+@TownApp.form(
+    model=Organisation, name='citizen-login-settings', template='form.pt',
+    permission=Secret, form=CitizenLoginSettingsForm,
+    setting=_('Citizen Login'), icon='fa-id-card', order=480,
+)
+def town_handle_citizen_login_settings(
+    self: Organisation, request: TownRequest, form: CitizenLoginSettingsForm
+) -> RenderData | Response:
+    return handle_citizen_login_settings(
+        self, request, form, SettingsLayout(self, request)
     )

--- a/src/onegov/town6/views/ticket.py
+++ b/src/onegov/town6/views/ticket.py
@@ -6,7 +6,8 @@ from onegov.org.views.ticket import (
     view_ticket, handle_new_note, handle_edit_note, message_to_submitter,
     view_ticket_status, view_tickets, view_archived_tickets,
     view_pending_tickets, assign_ticket, view_send_to_gever,
-    view_delete_all_archived_tickets, delete_ticket, change_tag)
+    view_delete_all_archived_tickets, delete_ticket, change_tag,
+    view_my_tickets)
 from onegov.ticket.collection import ArchivedTicketCollection
 from onegov.town6 import TownApp
 from onegov.org.forms import (
@@ -15,11 +16,11 @@ from onegov.org.forms import (
 from onegov.org.forms import TicketChatMessageForm
 from onegov.org.models import TicketNote
 from onegov.org.models.resource import FindYourSpotCollection
-from onegov.town6 import _
 from onegov.ticket import Ticket
 from onegov.ticket.collection import TicketCollection
+from onegov.town6 import _
 from onegov.town6.layout import (
-    FindYourSpotLayout, TicketLayout, TicketNoteLayout,
+    DefaultLayout, FindYourSpotLayout, TicketLayout, TicketNoteLayout,
     TicketChatMessageLayout, TicketsLayout, ArchivedTicketsLayout)
 
 
@@ -188,3 +189,17 @@ def town_delete_ticket(
 ) -> RenderData | Response:
     return delete_ticket(
         self, request, form=form, layout=TicketLayout(self, request))
+
+
+@TownApp.html(
+    model=TicketCollection,
+    name='my-tickets',
+    template='pending_tickets.pt',
+    permission=Public
+)
+def town_view_my_tickets(
+    self: TicketCollection,
+    request: TownRequest,
+    layout: DefaultLayout | None = None
+) -> RenderData:
+    return view_my_tickets(self, request, DefaultLayout(self, request))

--- a/src/onegov/translator_directory/app.py
+++ b/src/onegov/translator_directory/app.py
@@ -113,6 +113,12 @@ def get_create_new_organisation_factory(
     return create_new_organisation
 
 
+# NOTE: Feriennet doesn't need a citizen login
+@TranslatorDirectoryApp.setting(section='org', name='citizen_login_enabled')
+def get_citizen_login_enabled() -> bool:
+    return False
+
+
 @TranslatorDirectoryApp.setting(section='i18n', name='localedirs')
 def get_i18n_localedirs() -> list[str]:
     mine = utils.module_path('onegov.translator_directory', 'locale')

--- a/src/onegov/user/auth/core.py
+++ b/src/onegov/user/auth/core.py
@@ -95,7 +95,7 @@ class Auth:
         signup_token: str | None = None
     ) -> Self:
         return cls.from_request(
-            request, request.transform(request.path), skip, signup_token)
+            request, request.transform(request.path_qs), skip, signup_token)
 
     @property
     def users(self) -> UserCollection:

--- a/tests/onegov/agency/test_app.py
+++ b/tests/onegov/agency/test_app.py
@@ -16,6 +16,7 @@ class DummyRequest():
     is_supporter = False
     root_pages = ()
     current_user = Bunch(id=Bunch(hex='abcd'))
+    authenticated_email = None
     path = ''
     url = ''
 

--- a/tests/onegov/agency/test_app.py
+++ b/tests/onegov/agency/test_app.py
@@ -18,6 +18,7 @@ class DummyRequest():
     current_user = Bunch(id=Bunch(hex='abcd'))
     authenticated_email = None
     path = ''
+    path_qs = ''
     url = ''
 
     def class_link(self, cls, name='', variables: dict = None):

--- a/tests/onegov/org/test_layout.py
+++ b/tests/onegov/org/test_layout.py
@@ -27,7 +27,7 @@ class MockRequest:
     app = Bunch(
         org=Bunch(
             geo_provider='geo-mapbox',
-            open_files_target_blank=True
+            open_files_target_blank=True,
         ),
         version='1.0',
         sentry_dsn=None
@@ -173,6 +173,7 @@ def test_template_layout(postgres_dsn, redis_url):
         org.open_files_target_blank = True
         org.header_options = header_options
         org.analytics_code = None
+        org.citizen_login_enabled = False
 
         # disable LibresIntegration for this test
         def configure_libres(self, **cfg):

--- a/tests/onegov/org/test_views_auth.py
+++ b/tests/onegov/org/test_views_auth.py
@@ -713,12 +713,16 @@ def test_mtan_access_unauthorized_resource(org_app, client, smsdir):
 
 
 def test_citizen_login(client):
+    admin = client.spawn()
+    client2 = client.spawn()
+
     # by default it is off
     links = client.get('/').pyquery('.globals a.citizen-login')
     assert not list(links.items())
+    assert client.get('/auth/citizen-login', status=404)
+    assert client.get('/auth/confirm-citizen-login', status=404)
 
     # let's enable it
-    admin = client.spawn()
     admin.login_admin()
     settings = admin.get('/').click('Einstellungen').click('Kunden-Login')
     settings.form['citizen_login_enabled'].checked = True
@@ -739,6 +743,57 @@ def test_citizen_login(client):
 
     # finish login with the token
     confirm_page.form['token'] = token
+    index_page = confirm_page.form.submit().follow()
+
+    links = index_page.pyquery('.globals a.logout')
+    assert links.text() == 'Abmelden'
+
+    # visiting the login/confimation view while authenticated redirects you
+    assert client.get('/auth/citizen-login').follow().request.path == '/'
+    assert client.get(
+        '/auth/confirm-citizen-login'
+    ).follow().request.path == '/'
+
+    index_page = client.get(links.attr('href')).follow()
+    links = index_page.pyquery('.globals a.citizen-login')
+    assert links.text() == 'Kunden-Login'
+
+    # a second user can't use the same token to login as well
+    confirm_page = client.get('/auth/confirm-citizen-login')
+    confirm_page.form['token'] = token
+    confirm_page = confirm_page.form.submit()
+    assert 'Ungültiger oder abgelaufener Login-Code' in confirm_page
+
+
+def test_citizen_login_via_confirm_url(client):
+    admin = client.spawn()
+    client2 = client.spawn()
+
+    # by default it is off
+    links = client.get('/').pyquery('.globals a.citizen-login')
+    assert not list(links.items())
+
+    # let's enable it
+    admin.login_admin()
+    settings = admin.get('/').click('Einstellungen').click('Kunden-Login')
+    settings.form['citizen_login_enabled'].checked = True
+    settings.form.submit().follow()
+
+    # now it should be there
+    links = client.get('/').pyquery('.globals a.citizen-login')
+    assert links.text() == 'Kunden-Login'
+
+    login_page = client.get(links.attr('href'))
+    login_page.form['email'] = 'citizen@example.org'
+    confirm_page = login_page.form.submit().follow()
+    assert "Kunden-Login bestätigen" in confirm_page.text
+    assert len(os.listdir(client.app.maildir)) == 1
+    message = client.get_email(0)['TextBody']
+    assert 'confirm-citizen-login' in message
+    url = re.search(r'localhost(/auth/[^)]+)', message).group(1)
+
+    # finish login with the confirm url
+    confirm_page = client.get(url)
     index_page = confirm_page.form.submit().follow()
 
     links = index_page.pyquery('.globals a.logout')

--- a/tests/onegov/org/test_views_resources.py
+++ b/tests/onegov/org/test_views_resources.py
@@ -1,6 +1,7 @@
 import json
 import os
 import pytest
+import re
 import tempfile
 import textwrap
 import transaction
@@ -3371,3 +3372,54 @@ def test_reserve_fractions_of_hours_total_correct_in_price(client):
     reservations_data = client.get(reservations_url).json['reservations']
     assert len(reservations_data) == 1
     assert reservations_data[0]['price']['amount'] == 15.00
+
+
+@freeze_time("2015-08-28", tick=True)
+def test_my_reservations_view(client):
+    # prepate the required data
+    resources = ResourceCollection(client.app.libres_context)
+    resource = resources.by_name('tageskarte')
+    scheduler = resource.get_scheduler(client.app.libres_context)
+
+    allocations = scheduler.allocate(
+        dates=(datetime(2015, 8, 28), datetime(2015, 8, 28)),
+        whole_day=True
+    )
+
+    reserve = client.bound_reserve(allocations[0])
+    transaction.commit()
+
+    # create a reservation
+    assert reserve().json == {'success': True}
+    formular = client.get('/resource/tageskarte/form')
+    formular.form['email'] = 'info@example.org'
+    formular.form.submit().follow().form.submit()
+
+    # by default this view is disabled
+    client.get('/resources/my-reservations', status=404)
+    client.get('/resources/my-reservations-json', status=404)
+
+    # let's enable it
+    admin = client.spawn()
+    admin.login_admin()
+    settings = admin.get('/').click('Einstellungen').click('Kunden-Login')
+    settings.form['citizen_login_enabled'].checked = True
+    settings.form.submit().follow()
+
+    # now we don't have access yet
+    client.get('/resources/my-reservations-json', status=403)
+    login = client.get('/resources/my-reservations?date=20150828').follow()
+    login.form['email'] = 'info@example.org'
+    confirm = login.form.submit().follow()
+    assert len(os.listdir(client.app.maildir)) == 2
+    message = client.get_email(1)['TextBody']
+    token = re.search(r'&token=([^)]+)', message).group(1)
+    confirm.form['token'] = token
+    reservations = confirm.form.submit().follow()
+    assert reservations.request.path_qs == (
+        '/resources/my-reservations?date=20150828'
+    )
+    reservations = client.get(
+        '/resources/my-reservations-json?start=2015-08-28&end=2015-08-29'
+    )
+    assert reservations.status_code == 200

--- a/tests/onegov/town6/test_layout.py
+++ b/tests/onegov/town6/test_layout.py
@@ -176,6 +176,7 @@ def test_template_layout(postgres_dsn, redis_url):
         org.open_files_target_blank = True
         org.header_options = header_options
         org.always_show_partners = False
+        org.citizen_login_enabled = False
 
         # disable LibresIntegration for this test
         def configure_libres(self, **cfg):


### PR DESCRIPTION
## Commit message

Org: Adds a citizen login with access to tickets and reservations

Rather than requiring user registration, all citizens have to do is to request a login-link for their e-mail address with which they can gain access to all the tickets and reservations tied to that e-mail address.

TYPE: Feature
LINK: OGC-2098


## Checklist

- [x] I have performed a self-review of my code
- [x] I have updated the PO files
- [x] I made changes/features for both org and town6
- [x] I have tested my code thoroughly by hand
- [x] I have added tests for my changes/features
