### PR TITLE
Use event id instead of schedule id

### DIFF
--- a/src/onegov/event/collections/events.py
+++ b/src/onegov/event/collections/events.py
@@ -577,6 +577,7 @@ class EventCollection(Pagination[Event]):
             }
 
         for event in root.xpath('//ns:event', namespaces=ns):
+            event_id = find_element_text(event, 'uuid7')
             title = find_element_text(event, 'title')
             abstract = find_element_text(event, 'abstract')
             description = find_element_text(event, 'description')
@@ -683,7 +684,7 @@ class EventCollection(Pagination[Event]):
                             external_event_url=event_url or provider_url,
                             tags=tags,
                             filter_keywords=None,
-                            source=schedule_id,
+                            source=event_id,
                         ),
                         image=event_image,
                         image_filename=event_image_name,


### PR DESCRIPTION
Town6: Wil event import prevent duplicates

TYPE: Bugfix
LINK: ogc-2447

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I considered adding a reviewer
- [ ] I have added an upgrade hint such as data migration commands to be run
- [ ] I have updated the PO files
- [ ] I have added new modules to the docs
- [ ] I made changes/features for both org and town6
- [ ] I have updated the election_day API docs
- [ ] I have tested my code thoroughly by hand
    - [ ] I have tested styling changes/features on different browsers
    - [ ] I have tested javascript changes/features on different browsers
    - [ ] I have tested database upgrades
    - [ ] I have tested sending mails
    - [ ] I have tested building the documentation
- [ ] I have added tests for my changes/features
    - [ ] I am using freezegun for tests depending on date and times
    - [ ] I considered using browser tests für javascript changes/features
    - [ ] I have added/updated jest tests for d3rendering (election_day, swissvotes)
