### PR TITLE
Add hint for ideal event image size

### DIFF
--- a/src/onegov/org/forms/event.py
+++ b/src/onegov/org/forms/event.py
@@ -119,6 +119,7 @@ class EventForm(Form):
 
     image = UploadFileWithORMSupport(
         label=_('Image'),
+        description=_('Ideal size: 700 x 420 px (5:3)'),
         file_class=EventFile,
         validators=[
             Optional(),

--- a/src/onegov/org/locale/de_CH/LC_MESSAGES/onegov.org.po
+++ b/src/onegov/org/locale/de_CH/LC_MESSAGES/onegov.org.po
@@ -843,6 +843,9 @@ msgstr "Freuen Sie sich auf ein klassisches Konzert im Schlossgarten."
 msgid "Image"
 msgstr "Bild"
 
+msgid "Ideal size: 700 x 420 px (5:3)"
+msgstr "Ideale Größe: 700 x 420 px (5:3)"
+
 msgid "Additional Information (PDF)"
 msgstr "Zusätzliche Informationen (PDF)"
 

--- a/src/onegov/org/locale/fr_CH/LC_MESSAGES/onegov.org.po
+++ b/src/onegov/org/locale/fr_CH/LC_MESSAGES/onegov.org.po
@@ -844,6 +844,9 @@ msgstr "Profitez d'un concerto dans le jardin du château."
 msgid "Image"
 msgstr "Image"
 
+msgid "Ideal size: 700 x 420 px (5:3)"
+msgstr "Taille idéale : 700 x 420 px (5:3)"
+
 msgid "Additional Information (PDF)"
 msgstr "Informations complémentaires (PDF)"
 

--- a/src/onegov/org/locale/it_CH/LC_MESSAGES/onegov.org.po
+++ b/src/onegov/org/locale/it_CH/LC_MESSAGES/onegov.org.po
@@ -847,7 +847,7 @@ msgid "Image"
 msgstr "Immagine"
 
 msgid "Ideal size: 700 x 420 px (5:3)"
-msgstr "Ideale dimensione: 700 x 420 px (5:3)"
+msgstr "Dimensione ideale: 700 x 420 px (5:3)"
 
 msgid "Additional Information (PDF)"
 msgstr "Informazioni aggiuntive (PDF)"

--- a/src/onegov/org/locale/it_CH/LC_MESSAGES/onegov.org.po
+++ b/src/onegov/org/locale/it_CH/LC_MESSAGES/onegov.org.po
@@ -846,6 +846,9 @@ msgstr "Goditi un concerto nel giardino del castello."
 msgid "Image"
 msgstr "Immagine"
 
+msgid "Ideal size: 700 x 420 px (5:3)"
+msgstr "Ideale dimensione: 700 x 420 px (5:3)"
+
 msgid "Additional Information (PDF)"
 msgstr "Informazioni aggiuntive (PDF)"
 


### PR DESCRIPTION
Please fill in the commit message below and work through the checklist. You can delete parts that are not needed, e.g. the optional description, the link to a ticket or irrelevant options of the checklist.

## Commit message

Ogc: Add hint for ideal event image size

TYPE: Feature
LINK: OGC-2338