### PR TITLE
Make ris main url configurable

### DIFF
--- a/src/onegov/org/models/organisation.py
+++ b/src/onegov/org/models/organisation.py
@@ -299,6 +299,7 @@ class Organisation(Base, TimestampMixin):
 
     # RIS settings
     ris_enabled: dict_property[bool] = meta_property(default=False)
+    ris_main_url: dict_property[str | None] = meta_property(default=None)
 
     # MTAN Settings
     mtan_access_window_seconds: dict_property[int | None] = meta_property()

--- a/src/onegov/town6/forms/settings.py
+++ b/src/onegov/town6/forms/settings.py
@@ -286,3 +286,10 @@ class RISEnableForm(Form):
         description=_('Enables the RIS integration for this organisation.'),
         default=False
     )
+
+    # the url breadcrumbs shall point to for non-logged-in users
+    ris_main_url = StringField(
+        label=_('Default URL for RIS'),
+        description=_('The URL for the RIS main page.'),
+        default='',
+    )

--- a/src/onegov/town6/layout.py
+++ b/src/onegov/town6/layout.py
@@ -244,10 +244,13 @@ class DefaultLayout(OrgDefaultLayout, Layout):
         if self.request.is_logged_in:
             return self.request.link(self.request.app.org, 'ris-settings')
 
-        return self.request.link(
-            self.request.app.org,
-            'topics/stadt-politik-und-recht/stadtparlament'
-        )
+        if self.request.app.org.ris_main_url:
+            return self.request.link(
+                self.request.app.org, self.request.app.org.ris_main_url
+            )
+
+        # fallback to the homepage
+        return self.request.link(self.request.app.org, '')
 
 
 class DefaultMailLayout(OrgDefaultMailLayout, Layout):


### PR DESCRIPTION
RIS: main url for RIS is now configurable

TYPE: Feature
LINK: ogc-2371