### PR TITLE
Org: Allows members to view tickets if they know the URL

### DIFF
--- a/src/onegov/feriennet/security.py
+++ b/src/onegov/feriennet/security.py
@@ -11,7 +11,8 @@ from onegov.feriennet.collections import OccasionAttendeeCollection
 from onegov.feriennet.const import VISIBLE_ACTIVITY_STATES
 from onegov.feriennet.const import OWNER_EDITABLE_STATES
 from onegov.feriennet.models import NotificationTemplate
-from onegov.org.models import ImageFileCollection, SiteCollection
+from onegov.org.models import ImageFileCollection, SiteCollection, TicketNote
+from onegov.ticket import Ticket
 
 
 from typing import Any, TYPE_CHECKING
@@ -255,3 +256,21 @@ def has_private_permission_occasion_attendee_collection(
         return True
 
     return local_has_permission_logged_in(app, identity, model, permission)
+
+
+@FeriennetApp.permission_rule(model=Ticket, permission=Personal)
+@FeriennetApp.permission_rule(model=TicketNote, permission=Personal)
+def restrict_personal_ticket_views(
+    app: FeriennetApp,
+    identity: Identity,
+    model: Ticket | TicketNote,
+    permission: type[Personal]
+) -> bool:
+    """
+    Ensure that only managers may view ticket details.
+
+    Since members in feriennet are customers which shouldn't be able to
+    view other customer's private information.
+    """
+
+    return identity.role in ('admin', 'editor')

--- a/src/onegov/org/layout.py
+++ b/src/onegov/org/layout.py
@@ -1747,9 +1747,8 @@ class TicketLayout(DefaultLayout):
 
     @cached_property
     def editbar_links(self) -> list[Link | LinkGroup] | None:
-        if self.request.is_manager_for_model(self.model):
-
-            links: list[Link | LinkGroup]
+        links: list[Link | LinkGroup] = []
+        if is_manager := self.request.is_manager_for_model(self.model):
 
             # only show the model related links when the ticket is pending
             if self.model.state == 'pending':
@@ -1830,6 +1829,7 @@ class TicketLayout(DefaultLayout):
                     attrs={'class': ('ticket-button', 'ticket-assign')},
                 ))
 
+        if self.request.is_logged_in:
             # ticket notes are always enabled
             links.append(
                 Link(
@@ -1845,17 +1845,17 @@ class TicketLayout(DefaultLayout):
                     attrs={'class': 'ticket-pdf'}
                 )
             )
-            if self.has_submission_files:
-                links.append(
-                    Link(
-                        text=_('Download files'),
-                        url=self.request.link(self.model, 'files'),
-                        attrs={'class': 'ticket-files'}
-                    )
-                )
 
-            return links
-        return None
+        if is_manager and self.has_submission_files:
+            links.append(
+                Link(
+                    text=_('Download files'),
+                    url=self.request.link(self.model, 'files'),
+                    attrs={'class': 'ticket-files'}
+                )
+            )
+
+        return links or None
 
     @cached_property
     def has_submission_files(self) -> bool:

--- a/src/onegov/org/models/message.py
+++ b/src/onegov/org/models/message.py
@@ -113,6 +113,13 @@ class TicketNote(Message, TicketMessageMixin):
             layout.request, paragraphify(linkify(self.text)))
 
     def links(self, layout: DefaultLayout) -> Iterator[Link]:
+        # unprivileged members can only modify their own notes
+        if (
+            self.owner != layout.request.current_username
+            and not layout.request.is_manager_for_model(self.ticket)
+        ):
+            return
+
         yield Link(_('Edit'), layout.request.link(self, 'edit'))
         yield Link(
             _('Delete'), layout.csrf_protected_url(layout.request.link(self)),

--- a/src/onegov/org/models/ticket.py
+++ b/src/onegov/org/models/ticket.py
@@ -825,12 +825,13 @@ class ReservationHandler(Handler):
 
         layout = DefaultLayout(self.resource, request)
 
+        is_manager = request.is_manager_for_model(self.ticket)
         parts = []
         parts.append(
             render_macro(layout.macros['reservations'], request, {
                 'reservations': self.reservations,
                 'get_links': self.get_reservation_links
-                if self.ticket.state == 'pending' else None,
+                if is_manager and self.ticket.state == 'pending' else None,
                 'get_occupancy_url': self.get_occupancy_url,
                 'layout': layout
             })
@@ -848,7 +849,7 @@ class ReservationHandler(Handler):
             ))
 
         # render internal tag meta data
-        if request.is_manager_for_model(self.ticket) and self.ticket.tag_meta:
+        if is_manager and self.ticket.tag_meta:
             parts.append(
                 Markup('').join(
                     Markup(
@@ -977,6 +978,9 @@ class ReservationHandler(Handler):
     ) -> str | None:
 
         if self.deleted:
+            return None
+
+        if not request.is_manager_for_model(self.ticket):
             return None
 
         assert self.resource is not None

--- a/src/onegov/org/templates/ticket.pt
+++ b/src/onegov/org/templates/ticket.pt
@@ -2,7 +2,7 @@
     <tal:b metal:fill-slot="title">
         ${title}
     </tal:b>
-    <tal:b metal:fill-slot="content">
+    <tal:b metal:fill-slot="content" tal:define="is_manager request.is_manager_for_model(ticket)">
         <div class="row">
 
             <!--! note that the following snippet is DUPLICATED below, because when
@@ -56,7 +56,7 @@
                             Ticket updates by e-mail
                         </span>
 
-                        <a class="button small secondary" href="${request.link(ticket, 'mute')}">
+                        <a tal:condition="is_manager" class="button small secondary" href="${request.link(ticket, 'mute')}">
                             <i class="fa fa-fw fa-microphone-slash" aria-hidden="true"></i>
                             <span i18n:translate>Disable E-Mails</span>
                         </a>
@@ -70,14 +70,14 @@
                         </span>
 
                         <tal:b condition="not event_source">
-                            <a class="button small secondary" href="${request.link(ticket, 'unmute')}">
+                            <a tal:condition="is_manager" class="button small secondary" href="${request.link(ticket, 'unmute')}">
                                 <i class="fa fa-fw fa-microphone" aria-hidden="true"></i>
                                 <span i18n:translate>Enable E-Mails</span>
                             </a>
                         </tal:b>
 
                         <tal:b condition="event_source">
-                            <a class="button small secondary confirm disabled"
+                            <a tal:condition="is_manager" class="button small secondary confirm disabled"
                                data-confirm="E-Mails can not be sent for tickets of imported events"
                                 data-confirm-no="Cancel"
                                i18n:attributes="data-confirm;data-confirm-no"
@@ -90,14 +90,14 @@
                     </div>
 
                     <tal:b condition="not event_source and ticket.state != 'closed'">
-                        <a class="button small primary" href="${request.link(ticket, 'message-to-submitter')}">
+                        <a tal:condition="is_manager" class="button small primary" href="${request.link(ticket, 'message-to-submitter')}">
                             <i class="fa fa-fw fa-comment-o" aria-hidden="true"></i>
                             <span i18n:translate>Send Message</span>
                         </a>
                     </tal:b>
 
                     <tal:b condition="not event_source and ticket.state == 'closed'">
-                        <a class="button small disabled confirm"
+                        <a tal:condition="is_manager" class="button small disabled confirm"
                             data-confirm="Messages cannot be sent when the ticket is closed"
                             data-confirm-extra="Please reopen the ticket to send a message"
                             data-confirm-no="Cancel"
@@ -109,7 +109,7 @@
                     </tal:b>
 
                     <tal:b condition="event_source">
-                        <a class="button small disabled confirm"
+                        <a tal:condition="is_manager" class="button small disabled confirm"
                             data-confirm="Messages cannot be sent for imported events"
                             data-confirm-no="Cancel"
                             i18n:attributes="data-confirm;data-confirm-no">
@@ -176,7 +176,7 @@
 
                     <tal:b tal:condition="payment_button" tal:replace="payment_button(layout)" />
 
-                    <a tal:condition="invoice" href="${request.link(ticket, 'invoice')}" class="button small primary view-invoice" i18n:translate>View Invoice</a>
+                    <a tal:condition="is_manager and invoice" href="${request.link(ticket, 'invoice')}" class="button small primary view-invoice" i18n:translate>View Invoice</a>
                 </div>
 
                 <div class="ticket-panel">
@@ -197,8 +197,8 @@
                         </div>
                     </div>
 
-                    <div tal:condition="request.is_manager_for_model(ticket) and ticket.handler_code == 'RSV' and request.app.org.ticket_tags" class="field-display-block">
-                        <div class="field-display-label"><span i18n:translate>Tag</span> <a href="${request.link(ticket, 'change-tag')}" class="ticket-change-tag" title="Change tag" i18n:attributes="title" tal:condition="ticket.state == 'pending'"></a></div>
+                    <div tal:condition="ticket.handler_code == 'RSV' and request.app.org.ticket_tags" class="field-display-block">
+                        <div class="field-display-label"><span i18n:translate>Tag</span> <a href="${request.link(ticket, 'change-tag')}" class="ticket-change-tag" title="Change tag" i18n:attributes="title" tal:condition="is_manager and ticket.state == 'pending'"></a></div>
                         <div class="field-display-data ticket-tag">
                             <tal:b tal:condition="ticket.tag">${ticket.tag}</tal:b>
                             <tal:b tal:condition="not:ticket.tag" i18n:translate>Without</tal:b>

--- a/src/onegov/town6/templates/ticket.pt
+++ b/src/onegov/town6/templates/ticket.pt
@@ -2,7 +2,7 @@
     <tal:b metal:fill-slot="title">
         ${title}
     </tal:b>
-    <tal:b metal:fill-slot="content">
+    <tal:b metal:fill-slot="content" tal:define="is_manager request.is_manager_for_model(ticket)">
         <div class="grid-x grid-padding-x">
 
             <!--! note that the following snippet is DUPLICATED below, because when
@@ -57,7 +57,7 @@
                             Ticket updates by e-mail
                         </span>
 
-                        <a class="button small secondary" href="${request.link(ticket, 'mute')}">
+                        <a tal:condition="is_manager" class="button small secondary" href="${request.link(ticket, 'mute')}">
                             <i class="fa fa-fw fa-microphone-slash" aria-hidden="true"></i>
                             <span i18n:translate>Disable E-Mails</span>
                         </a>
@@ -71,14 +71,14 @@
                         </span>
 
                         <tal:b condition="not event_source">
-                            <a class="button small secondary" href="${request.link(ticket, 'unmute')}">
+                            <a tal:condition="is_manager" class="button small secondary" href="${request.link(ticket, 'unmute')}">
                                 <i class="fa fa-fw fa-microphone" aria-hidden="true"></i>
                                 <span i18n:translate>Enable E-Mails</span>
                             </a>
                         </tal:b>
 
                         <tal:b condition="event_source">
-                            <a class="button small secondary confirm disabled"
+                            <a tal:condition="is_manager" class="button small secondary confirm disabled"
                                data-confirm="E-Mails can not be sent for tickets of imported events"
                                 data-confirm-no="Cancel"
                                i18n:attributes="data-confirm;data-confirm-no"
@@ -91,14 +91,14 @@
                     </div>
 
                     <tal:b condition="not event_source and ticket.state != 'closed'">
-                        <a class="button small primary" href="${request.link(ticket, 'message-to-submitter')}">
+                        <a tal:condition="is_manager" class="button small primary" href="${request.link(ticket, 'message-to-submitter')}">
                             <i class="fa fa-fw fa-comment-o" aria-hidden="true"></i>
                             <span i18n:translate>Send Message</span>
                         </a>
                     </tal:b>
 
                     <tal:b condition="not event_source and ticket.state == 'closed'">
-                        <a class="button small disabled confirm"
+                        <a tal:condition="is_manager" class="button small disabled confirm"
                             data-confirm="Messages cannot be sent when the ticket is closed"
                             data-confirm-extra="Please reopen the ticket to send a message"
                             data-confirm-no="Cancel"
@@ -110,7 +110,7 @@
                     </tal:b>
 
                     <tal:b condition="event_source">
-                        <a class="button small disabled confirm"
+                        <a tal:condition="is_manager" class="button small disabled confirm"
                             data-confirm="Messages cannot be sent for imported events"
                             data-confirm-no="Cancel"
                             i18n:attributes="data-confirm;data-confirm-no">
@@ -177,7 +177,7 @@
 
                     <tal:b tal:condition="payment_button" tal:replace="payment_button(layout)" />
 
-                    <a tal:condition="invoice" href="${request.link(ticket, 'invoice')}" class="button small primary view-invoice" i18n:translate>View Invoice</a>
+                    <a tal:condition="is_manager and invoice" href="${request.link(ticket, 'invoice')}" class="button small primary view-invoice" i18n:translate>View Invoice</a>
                 </div>
 
                 <div class="ticket-panel">
@@ -198,8 +198,8 @@
                         </div>
                     </div>
 
-                    <div tal:condition="request.is_manager_for_model(ticket) and ticket.handler_code == 'RSV' and request.app.org.ticket_tags" class="field-display-block">
-                        <div class="field-display-label"><span i18n:translate>Tag</span> <a href="${request.link(ticket, 'change-tag')}" class="ticket-change-tag" title="Change tag" i18n:attributes="title" tal:condition="ticket.state == 'pending'"></a></div>
+                    <div tal:condition="ticket.handler_code == 'RSV' and request.app.org.ticket_tags" class="field-display-block">
+                        <div class="field-display-label"><span i18n:translate>Tag</span> <a href="${request.link(ticket, 'change-tag')}" class="ticket-change-tag" title="Change tag" i18n:attributes="title" tal:condition="is_manager and ticket.state == 'pending'"></a></div>
                         <div class="field-display-data ticket-tag">
                             <tal:b tal:condition="ticket.tag">${ticket.tag}</tal:b>
                             <tal:b tal:condition="not:ticket.tag" i18n:translate>Without</tal:b>

--- a/src/onegov/town6/views/ticket.py
+++ b/src/onegov/town6/views/ticket.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from onegov.core.security import Public, Private, Secret
+from onegov.core.security import Public, Personal, Private, Secret
 from onegov.form import Form
 from onegov.org.views.ticket import (
     view_ticket, handle_new_note, handle_edit_note, message_to_submitter,
@@ -32,13 +32,13 @@ if TYPE_CHECKING:
     from webob import Response
 
 
-@TownApp.html(model=Ticket, template='ticket.pt', permission=Private)
+@TownApp.html(model=Ticket, template='ticket.pt', permission=Personal)
 def town_view_ticket(self: Ticket, request: TownRequest) -> RenderData:
     return view_ticket(self, request, TicketLayout(self, request))
 
 
 @TownApp.form(
-    model=Ticket, name='note', permission=Private,
+    model=Ticket, name='note', permission=Personal,
     template='ticket_note_form.pt', form=TicketNoteForm
 )
 def town_handle_new_note(
@@ -51,7 +51,7 @@ def town_handle_new_note(
 
 
 @TownApp.form(
-    model=TicketNote, name='edit', permission=Private,
+    model=TicketNote, name='edit', permission=Personal,
     template='ticket_note_form.pt', form=TicketNoteForm
 )
 def town_handle_edit_note(


### PR DESCRIPTION
## Commit message

Org: Allows members to view tickets if they know the URL

They can also create notes and edit/delete their own notes, but they
cannot perform any other actions on the ticket.

This allows involving interested third parties to be involved in the
ticket process, like e.g. a janitor for a reservation ticket.

TYPE: Feature
LINK: OGC-2285

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I made changes/features for both org and town6
- [ ] I have tested my code thoroughly by hand