### PR TITLE
Add missing type fix

### DIFF
--- a/src/onegov/org/cli.py
+++ b/src/onegov/org/cli.py
@@ -2834,6 +2834,7 @@ def ris_rename_imported_participation_types_to_english(
         'Erstunterzeichner/in': 'First signatory',
         'Mitunterzeichner/in': 'Co-signatory',
         'Vorstösser/in': 'First signatory',
+        'Vorstösser/-in': 'First signatory',
     }
 
     def rename_participation_types(request: OrgRequest, app: OrgApp) -> None:


### PR DESCRIPTION
RIS: Fix/Translate political business participation types

TYPE: Bugfix
LINK: ogc-2534
HINT: `onegov-org --select /onegov_town6/wil ris-rename-imported-participation-types-to-english` or `sudo ogc org --select /onegov_town6/wil ris-rename-imported-participation-types-to-english`

