### PR TITLE
Org: Avoids minimum price total validation if the minimum total is 0

### DIFF
--- a/src/onegov/org/views/form_submission.py
+++ b/src/onegov/org/views/form_submission.py
@@ -126,7 +126,7 @@ def handle_pending_submission(
 
     # check minimum price total if set
     minimum_total_amount = self.minimum_price_total or 0.0
-    if current_total_amount < minimum_total_amount:
+    if minimum_total_amount and current_total_amount < minimum_total_amount:
         _currency = currency_for_submission(form, self)
         completable = False
         request.alert(


### PR DESCRIPTION
## Commit message

Org: Avoids minimum price total validation if the minimum total is 0

The price can be negative to offset the prices that originate from outside the form submission, like prices per entry or prices per hour.

TYPE: Bugfix
LINK: OGC-2540

## Checklist

- [x] I have performed a self-review of my code
