### PR TITLE
Org: Allows forms and resources to define a reply-to address

### DIFF
--- a/src/onegov/form/models/definition.py
+++ b/src/onegov/form/models/definition.py
@@ -151,6 +151,10 @@ class FormDefinition(Base, ContentMixin, TimestampMixin,
     #: be submitted
     minimum_price_total: dict_property[float | None] = meta_property()
 
+    #: the reply_to address to supersede the global reply_to address for
+    #: tickets created through this form
+    reply_to: dict_property[str | None] = meta_property()
+
     __mapper_args__ = {
         'polymorphic_on': 'type',
         'polymorphic_identity': 'generic'

--- a/src/onegov/org/forms/form_definition.py
+++ b/src/onegov/org/forms/form_definition.py
@@ -9,6 +9,7 @@ from onegov.org import _
 from onegov.org.forms.fields import HtmlField
 from onegov.org.forms.generic import PaymentForm
 from wtforms.fields import BooleanField
+from wtforms.fields import EmailField
 from wtforms.fields import StringField
 from wtforms.fields import TextAreaField
 from wtforms.validators import InputRequired
@@ -60,6 +61,12 @@ class FormDefinitionBaseForm(Form):
         description=_('Describes how this resource can be picked up. '
                       'This text is used on the ticket status page to '
                       'inform the user')
+    )
+
+    reply_to = EmailField(
+        label=_('E-Mail Reply Address (Reply-To)'),
+        fieldset=_('Tickets'),
+        description=_('Replies to automated e-mails go to this address.')
     )
 
     show_vat = BooleanField(

--- a/src/onegov/org/forms/resource.py
+++ b/src/onegov/org/forms/resource.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from wtforms.fields import BooleanField
 from wtforms.fields import DecimalField
+from wtforms.fields import EmailField
 from wtforms.fields import IntegerField
 from wtforms.fields import RadioField
 from wtforms.fields import StringField
@@ -198,6 +199,12 @@ class ResourceBaseForm(Form):
         coerce=coerce_component_tuple,
         fieldset='dormakaba',
         widget=ComponentSelectWidget(multiple=True)
+    )
+
+    reply_to = EmailField(
+        label=_('E-Mail Reply Address (Reply-To)'),
+        fieldset=_('Tickets'),
+        description=_('Replies to automated e-mails go to this address.')
     )
 
     pricing_method = RadioField(

--- a/src/onegov/org/mail.py
+++ b/src/onegov/org/mail.py
@@ -162,6 +162,9 @@ def send_ticket_mail(
     if 'ticket' not in content:
         content['ticket'] = ticket
 
+    if 'reply_to' not in kwargs and ticket.handler.reply_to:
+        kwargs['reply_to'] = ticket.handler.reply_to
+
     send_transactional_html_mail(
         request=request,
         template=template,

--- a/src/onegov/org/models/ticket.py
+++ b/src/onegov/org/models/ticket.py
@@ -393,6 +393,12 @@ class FormSubmissionHandler(Handler):
 
         return False
 
+    @property
+    def reply_to(self) -> str | None:
+        if self.submission and self.submission.form:
+            return self.submission.form.reply_to
+        return self.ticket.snapshot.get('reply_to')
+
     def get_summary(
         self,
         request: OrgRequest  # type:ignore[override]
@@ -752,6 +758,14 @@ class ReservationHandler(Handler):
                 return False
 
         return True
+
+    @property
+    def reply_to(self) -> str | None:
+        if self.deleted:
+            return self.ticket.snapshot.get('reply_to')
+
+        assert self.resource is not None
+        return self.resource.reply_to
 
     def prepare_delete_ticket(self) -> None:
         for reservation in self.reservations or ():

--- a/src/onegov/reservation/models/resource.py
+++ b/src/onegov/reservation/models/resource.py
@@ -10,7 +10,8 @@ from libres import new_scheduler
 from libres.db.models import Allocation
 from libres.db.models.base import ORMBase
 from onegov.core.orm import ModelBase
-from onegov.core.orm.mixins import content_property, dict_property
+from onegov.core.orm.mixins import (
+    content_property, dict_property, meta_property)
 from onegov.core.orm.mixins import ContentMixin, TimestampMixin
 from onegov.core.orm.types import UUID
 from onegov.file import MultiAssociatedFiles
@@ -164,6 +165,10 @@ class Resource(ORMBase, ModelBase, ContentMixin,
 
     #: hint on how to get to the resource
     pick_up: dict_property[str | None] = content_property()
+
+    #: the reply_to address to supersede the global reply_to address for
+    #: tickets created through this form
+    reply_to: dict_property[str | None] = meta_property()
 
     __mapper_args__ = {
         'polymorphic_on': 'type',

--- a/src/onegov/ticket/handler.py
+++ b/src/onegov/ticket/handler.py
@@ -228,6 +228,19 @@ class Handler:
 
         return False
 
+    @property
+    def reply_to(self) -> str | None:
+        """ An optional email address which will be used as a Reply-To
+        in mails instead of any global setting.
+
+        For example for a certain subset of forms you may want replies
+        to end up with the department in charge of those specific forms
+        instead of a global bucket.
+
+        """
+
+        return None
+
     @classmethod
     def handle_extra_parameters(
         cls,

--- a/src/onegov/ticket/models/ticket.py
+++ b/src/onegov/ticket/models/ticket.py
@@ -388,6 +388,7 @@ class Ticket(Base, TimestampMixin, ORMSearchable):
 
         self.snapshot['summary'] = self.handler.get_summary(request)
         self.snapshot['email'] = self.handler.email
+        self.snapshot['reply_to'] = self.handler.reply_to
         for info in ('name', 'address', 'phone'):
             data = getattr(self.handler, f'submitter_{info}')
             if data:


### PR DESCRIPTION
## Commit message

Org: Allows forms and resources to define a reply-to address

This supersedes the global reply-to address for ticket emails sent by
FRM and RSV tickets linked to their respective form or resource.

TYPE: Feature
LINK: OGC-2538

## Checklist

- [x] I have performed a self-review of my code
