### PR TITLE
Handle empty status for older political businesses

### DIFF
--- a/src/onegov/org/models/political_business.py
+++ b/src/onegov/org/models/political_business.py
@@ -352,7 +352,7 @@ class PoliticalBusinessCollection(
 
         return self.__class__(
             self.session,
-            page=self.page,
+            page=0,
             status=status_,
             types=types,
             years=years,

--- a/src/onegov/town6/templates/political_businesses.pt
+++ b/src/onegov/town6/templates/political_businesses.pt
@@ -20,8 +20,13 @@
                     <tbody tal:repeat="business businesses">
                         <tr>
                             <td><span>${layout.format_date(business.entry_date, 'date')}</span></td>
-                            <td><span>${type_map[business.political_business_type]}</span></td>
-                            <td><span>${status_map[business.status]}</span></td>
+                            <td>
+                                <span tal:condition="python: business.political_business_type in type_map">${type_map[business.political_business_type]}</span>
+                                <span tal:condition="python: business.political_business_type not in type_map">-</span>
+                            </td>
+                            <td>
+                                <span tal:condition="python: business.status in status_map">${status_map[business.status]}</span>
+                                <span tal:condition="python: business.status not in status_map">-</span>
                             <td>
                                 <a tal:attributes="href request.link(business)">${business.title}</a>
                             </td>


### PR DESCRIPTION
RIS: Handle empty status for political businesses

Older political businesses may have no `status` assigned

TYPE: Bugfix
LINK: ogc-2549