### PR TITLE
Add political business to collection without files

### DIFF
--- a/src/onegov/org/forms/political_business.py
+++ b/src/onegov/org/forms/political_business.py
@@ -267,6 +267,7 @@ class PoliticalBusinessForm(Form):
     def get_useful_data(self) -> dict[str, Any]:  # type:ignore[override]
         result = super().get_useful_data()
         result.pop('participants', None)
+        result.pop('files', None)
         result['parliamentary_group_id'] = (
             result.get('parliamentary_group_id') or None)
         return result

--- a/src/onegov/org/forms/political_business.py
+++ b/src/onegov/org/forms/political_business.py
@@ -264,14 +264,6 @@ class PoliticalBusinessForm(Form):
         ]
         self.parliamentary_group_id.choices.insert(0, ('', '-'))
 
-    def get_useful_data(self) -> dict[str, Any]:  # type:ignore[override]
-        result = super().get_useful_data()
-        result.pop('participants', None)
-        result.pop('files', None)
-        result['parliamentary_group_id'] = (
-            result.get('parliamentary_group_id') or None)
-        return result
-
     def populate_obj(  # type: ignore[override]
         self,
         obj: PoliticalBusiness,  # type: ignore[override]

--- a/src/onegov/town6/views/political_business.py
+++ b/src/onegov/town6/views/political_business.py
@@ -149,8 +149,10 @@ def view_add_political_business(
     layout = PoliticalBusinessCollectionLayout(self, request)
 
     if form.submitted(request):
-        data = form.get_useful_data()
-        political_business = self.add(**data)
+        political_business = self.add(
+            title=form.title.data,
+            political_business_type=form.political_business_type.data,
+        )
         form.populate_obj(political_business)
         request.success(_('Added a new political business'))
 


### PR DESCRIPTION
RIS: Resolve issue when creating political business with files

As files cannot be handled in the collection `add` from `get_useful_data` moving to `populate_obj` approach

TYPE: Bugfix
LINK: ogc-2551