### PR TITLE
Fixes wrong ids for parliamentary group in form choices

### DIFF
--- a/src/onegov/org/forms/political_business.py
+++ b/src/onegov/org/forms/political_business.py
@@ -260,7 +260,7 @@ class PoliticalBusinessForm(Form):
             .all()
         )
         self.parliamentary_group_id.choices = [
-            (str(g.id.hex), g.name) for g in groups
+            (str(g.id), g.name) for g in groups
         ]
         self.parliamentary_group_id.choices.insert(0, ('', '-'))
 


### PR DESCRIPTION
RIS: Fixes parliamentary group does not get processed when editing political business

TYPE: Bugfix
LINK: ogc-2245