### PR TITLE
Town Align padding for menu group

### DIFF
--- a/src/onegov/town6/theme/styles/header.scss
+++ b/src/onegov/town6/theme/styles/header.scss
@@ -464,10 +464,6 @@ $editbar-fg-color-active: $white;
     margin-bottom: 2px;
     margin-top: -2px;
 
-    li.is-dropdown-submenu-parent > a {
-        padding-top: .9rem !important;
-    }
-
     li {
         a::before, button::before {
             margin-right: 2 * $default-icon-margin;


### PR DESCRIPTION
Town6: Align padding for menu group

TYPE: Feature
LINK: None

Examples are the `Add` menu items for e.g. events or parliamentarians

<img width="1298" height="342" alt="image" src="https://github.com/user-attachments/assets/11259073-d9d0-425f-b590-8a1175c66c9b" />
<img width="1298" height="342" alt="Screenshot from 2025-08-22 08-06-49" src="https://github.com/user-attachments/assets/3af18d9f-9bd5-4698-b7d3-db1b973b2075" />
