### PR TITLE
Org: Improves robustness of Kaba key revocation

### DIFF
--- a/src/onegov/org/kaba.py
+++ b/src/onegov/org/kaba.py
@@ -133,7 +133,8 @@ class KabaClient:
             timeout=(5, 10)
         )
         self.raise_for_status(res)
-        if res.json()['revoked'] is True:
+        data = res.json()
+        if data.get('revoked') is True or data.get('expired') is True:
             return
 
         res = self.session.post(


### PR DESCRIPTION
## Commit message

Org: Improves robustness of Kaba key revocation

Previously it was possible for a `KeyError` to be emitted, which would have been caught by the views, since they do a `clients[site_id]`, even though it definitely should not have been caught.

TYPE: Bugfix
LINK: OGC-2579

## Checklist

- [x] I have performed a self-review of my code
