### PR TITLE
Fix unpublished events getting deleted by cron job

### DIFF
--- a/src/onegov/org/cronjobs.py
+++ b/src/onegov/org/cronjobs.py
@@ -831,6 +831,7 @@ def delete_content_marked_deletable(request: OrgRequest) -> None:
             count += 1
 
         query = request.session.query(Event)
+        query = query.filter(Event.end < now)
         for obj in query:
             if not obj.future_occurrences(limit=1).all():
                 log.info(f'Cron: Delete past event for {name}: '

--- a/src/onegov/org/cronjobs.py
+++ b/src/onegov/org/cronjobs.py
@@ -804,6 +804,7 @@ def delete_content_marked_deletable(request: OrgRequest) -> None:
     now = to_timezone(utcnow(), 'Europe/Zurich')
     count = 0
 
+    name = request.app.org.title or 'unknown'
     for base in request.app.session_manager.bases:
         for model in find_models(base, lambda cls: issubclass(
                 cls, DeletableContentExtension)):
@@ -811,9 +812,11 @@ def delete_content_marked_deletable(request: OrgRequest) -> None:
             query = request.session.query(model)
             query = query.filter(model.delete_when_expired == True)
             for obj in query:
-                # delete entry if end date passed
+                # delete entry if the end date passed
                 if isinstance(obj, (News, ExtendedDirectoryEntry)):
                     if obj.publication_end and obj.publication_end < now:
+                        log.info(f'Cron: Delete expired obj for {name}: '
+                                 f'{obj.title}')
                         request.session.delete(obj)
                         count += 1
 
@@ -822,12 +825,16 @@ def delete_content_marked_deletable(request: OrgRequest) -> None:
         query = request.session.query(Occurrence)
         query = query.filter(Occurrence.end < now)
         for obj in query:
+            log.info(f'Cron: Delete past occurrence for {name}: '
+                     f'{obj.title} - {obj.end}')
             request.session.delete(obj)
             count += 1
 
         query = request.session.query(Event)
         for obj in query:
             if not obj.future_occurrences(limit=1).all():
+                log.info(f'Cron: Delete past event for {name}: '
+                         f'{obj.title} - {obj.end}')
                 request.session.delete(obj)
                 count += 1
 

--- a/tests/onegov/org/test_cronjobs.py
+++ b/tests/onegov/org/test_cronjobs.py
@@ -1441,7 +1441,7 @@ def test_delete_content_marked_deletable__events_occurrences_ogc_2562(
         return (OccurrenceCollection(org_app.session(), outdated=True)
                 .query().filter_by(title=title).count())
 
-    with (freeze_time(datetime(2024, 4, 18, tzinfo=tz))):
+    with (freeze_time(datetime(2025, 9, 2, tzinfo=tz))):
         assert org_app.org.delete_past_events is True
 
         assert count_events(title) == 1
@@ -1449,6 +1449,13 @@ def test_delete_content_marked_deletable__events_occurrences_ogc_2562(
 
         client.get(get_cronjob_url(job))
         assert count_events(title) == 1
+        assert count_occurrences(title) == 0
+
+    # even unpublished event gets deleted
+    with (freeze_time(datetime(2025, 9, 3, tzinfo=tz))):
+        client.get(get_cronjob_url(job))
+
+        assert count_events(title) == 0
         assert count_occurrences(title) == 0
 
 


### PR DESCRIPTION
Org: Fix cronjob deletes unpublished events prior its end date

TYPE: Bugfix
LINK: ogc-2562
