### PR TITLE
Core: Ensures commands that create a new schema run `morepath.autoscan`

### DIFF
--- a/src/onegov/core/cli/core.py
+++ b/src/onegov/core/cli/core.py
@@ -594,6 +594,10 @@ def run_processors(
                 # disable debug options in cli (like query output)
                 pass
 
+            def configure_search(self, **cfg: Any) -> None:
+                # disable search options in cli
+                self.es_client = None
+
         @CliApplication.path(path=view_path)
         class Model:
             pass
@@ -631,7 +635,12 @@ def run_processors(
         Config({
             'applications': applications,
         }),
-        configure_morepath=False,
+        # NOTE: For commands that create a new schema this is essential
+        #       otherwise the SQLAlchemy metadata may be incomplete
+        # FIXME: For some reason when this is enabled we get noisy logging
+        #        related to i18n, so we should replace the affected logger
+        #        with a NullHandler...
+        configure_morepath=group_context.creates_path,
         configure_logging=False
     )
 

--- a/src/onegov/pay/models/invoice.py
+++ b/src/onegov/pay/models/invoice.py
@@ -101,7 +101,7 @@ class Invoice(Base, TimestampMixin):
     #       constaints on the columns.
     __table_args__ = (
         CheckConstraint(
-            '(period_id IS NOT NULL AND user_id IS NOT NULL)'
+            '(period_id IS NOT NULL AND user_id IS NOT NULL) '
             "OR type != 'booking_period'",
             name='ck_booking_period_required_columns'
         ),


### PR DESCRIPTION
## Commit message

Core: Ensures commands that create a new schema run `morepath.autoscan`

This way the SQLAlchemy table metadata is guaranteed to be complete
and matches what it looks like when we run the server.

TYPE: Bugfix
LINK: OGC-2583

## Checklist

- [x] I have performed a self-review of my code
