### PR TITLE
Org: Makes the e-mail address for citizen login case-insensitive

### DIFF
--- a/src/onegov/org/custom.py
+++ b/src/onegov/org/custom.py
@@ -17,6 +17,7 @@ from onegov.ticket import TicketCollection, TicketInvoiceCollection
 from onegov.ticket.collection import ArchivedTicketCollection
 from onegov.user import Auth, UserCollection, UserGroupCollection
 from purl import URL
+from sqlalchemy import func
 
 
 from typing import Any, TYPE_CHECKING
@@ -303,7 +304,7 @@ def get_global_tools(
             attributes={'data-count': str(screen_count)}
         )
 
-    if citizen_login_enabled and request.authenticated_email:
+    if citizen_login_enabled and (email := request.authenticated_email):
         # This logout link is specific to citizens, if we're logged
         # in as another user, then we don't need this additional
         # logout link
@@ -329,7 +330,7 @@ def get_global_tools(
         if request.session.query(
             request.session.query(Reservation)
             .filter(Reservation.status == 'approved')
-            .filter(Reservation.email == request.authenticated_email)
+            .filter(func.lower(Reservation.email) == email.lower())
             .exists()
         ).scalar():
             yield Link(

--- a/src/onegov/org/views/resource.py
+++ b/src/onegov/org/views/resource.py
@@ -38,7 +38,7 @@ from onegov.pay import PaymentCollection
 from operator import attrgetter, itemgetter
 from purl import URL
 from sedate import utcnow, standardize_date
-from sqlalchemy import and_, select
+from sqlalchemy import and_, func, select
 from sqlalchemy.orm import object_session, undefer
 from webob import exc
 
@@ -1213,7 +1213,7 @@ def view_my_reservations_json(
     stmt = as_selectable_from_path(path)
 
     records = request.session.execute(select(stmt.c).where(and_(
-        stmt.c.email == request.authenticated_email,
+        func.lower(stmt.c.email) == request.authenticated_email.lower(),
         start <= stmt.c.start,
         stmt.c.start <= end
     )))
@@ -1390,7 +1390,7 @@ def view_my_reservations_ical(
     stmt = as_selectable_from_path(path)
 
     records = request.session.execute(select(stmt.c).where(and_(
-        stmt.c.email == email,
+        func.lower(stmt.c.email) == email.lower(),
         s <= stmt.c.start, stmt.c.start <= e,
         # only include accepted reservations in ICS file
         stmt.c.accepted.is_(True)

--- a/src/onegov/ticket/collection.py
+++ b/src/onegov/ticket/collection.py
@@ -282,7 +282,7 @@ class TicketCollection(TicketCollectionPagination):
 
     def by_ticket_email(self, ticket_email: str) -> Query[Ticket]:
         return self.query().filter(
-            Ticket.ticket_email == ticket_email)
+            func.lower(Ticket.ticket_email) == ticket_email.lower())
 
 
 # FIXME: Why is this its own subclass? shouldn't this at least override


### PR DESCRIPTION
## Commit message

Org: Makes the e-mail address for citizen login case-insensitive
Even though the local part can be treated case-sensitively by SMTP servers, in reality no-one really does that. The host is also case- insensitive. So treating the entire address as case-insensitive is most pragmatic. Otherwise people will end up needing multiple logins if their address has been spelled in multiple different ways.

TYPE: Bugfix
LINK: OGC-2601

## Checklist

- [x] I have performed a self-review of my code