### PR TITLE
Org: Allows specifying a custom reservation confirmation text

### DIFF
--- a/src/onegov/org/forms/resource.py
+++ b/src/onegov/org/forms/resource.py
@@ -93,7 +93,16 @@ class ResourceBaseForm(Form):
     )
 
     text = HtmlField(
-        label=_('Text'))
+        label=_('Text')
+    )
+
+    confirmation_text = HtmlField(
+        label=_('Additional information for confirmed reservations'),
+        description=_('This text will be included in the confirmation '
+                      'and reservation summary e-mails sent out to '
+                      'customers. As well as displayed on the ticket '
+                      'status page, once reservations have been accepted.')
+    )
 
     pick_up = TextAreaField(
         label=_('Pick-Up'),

--- a/src/onegov/org/locale/de_CH/LC_MESSAGES/onegov.org.po
+++ b/src/onegov/org/locale/de_CH/LC_MESSAGES/onegov.org.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE 1.0\n"
-"POT-Creation-Date: 2025-09-10 10:26+0200\n"
+"POT-Creation-Date: 2025-09-10 11:28+0200\n"
 "PO-Revision-Date: 2022-03-15 10:21+0100\n"
 "Last-Translator: Marc Sommerhalder <marc.sommerhalder@seantis.ch>\n"
 "Language-Team: German\n"
@@ -1646,6 +1646,18 @@ msgstr "Dient zur Gruppierung in der Übersicht"
 
 msgid "Subgroup"
 msgstr "Untergruppe"
+
+msgid "Additional information for confirmed reservations"
+msgstr "Zusätzliche Informationen für bestätigte Reservationen"
+
+msgid ""
+"This text will be included in the confirmation and reservation summary e-"
+"mails sent out to customers. As well as displayed on the ticket status page, "
+"once reservations have been accepted."
+msgstr ""
+"Dieser Text wird im Kunden-E-Mail für die Reservationsbestätigung und die "
+"Terminübersicht angezeigt. Zusätzlich wird es nach der Bestätigung auf der "
+"Status-Seite des Tickets angezeigt."
 
 msgid "Extra Fields Definition"
 msgstr "Extra-Felder Definition"

--- a/src/onegov/org/locale/fr_CH/LC_MESSAGES/onegov.org.po
+++ b/src/onegov/org/locale/fr_CH/LC_MESSAGES/onegov.org.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE 1.0\n"
-"POT-Creation-Date: 2025-09-10 10:26+0200\n"
+"POT-Creation-Date: 2025-09-10 11:28+0200\n"
 "PO-Revision-Date: 2022-03-15 10:50+0100\n"
 "Last-Translator: Marc Sommerhalder <marc.sommerhalder@seantis.ch>\n"
 "Language-Team: French\n"
@@ -1646,6 +1646,18 @@ msgstr "Utilisé pour grouper la ressource dans la vue d'ensemble"
 
 msgid "Subgroup"
 msgstr "Sous-groupe"
+
+msgid "Additional information for confirmed reservations"
+msgstr "Informations supplémentaires pour les réservations confirmées"
+
+msgid ""
+"This text will be included in the confirmation and reservation summary e-"
+"mails sent out to customers. As well as displayed on the ticket status page, "
+"once reservations have been accepted."
+msgstr ""
+"Ce texte sera inclus dans les e-mails de confirmation et de résumé de "
+"réservation envoyés aux clients. Il sera également affiché sur la page "
+"d'état des billets, une fois les réservations acceptées."
 
 msgid "Extra Fields Definition"
 msgstr "Définition de champs supplémentaires"

--- a/src/onegov/org/locale/it_CH/LC_MESSAGES/onegov.org.po
+++ b/src/onegov/org/locale/it_CH/LC_MESSAGES/onegov.org.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"POT-Creation-Date: 2025-09-10 10:26+0200\n"
+"POT-Creation-Date: 2025-09-10 11:28+0200\n"
 "PO-Revision-Date: 2022-03-15 10:52+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -1650,6 +1650,18 @@ msgstr "Utilizzato per raggruppare la risorsa nella panoramica"
 
 msgid "Subgroup"
 msgstr "Sottogruppo"
+
+msgid "Additional information for confirmed reservations"
+msgstr "Informazioni aggiuntive per prenotazioni confermate"
+
+msgid ""
+"This text will be included in the confirmation and reservation summary e-"
+"mails sent out to customers. As well as displayed on the ticket status page, "
+"once reservations have been accepted."
+msgstr ""
+"Questo testo sarà incluso nelle e-mail di conferma e di riepilogo della "
+"prenotazione inviate ai clienti. Inoltre, una volta accettate le "
+"prenotazioni, sarà visualizzato nella pagina dello stato dei biglietti."
 
 msgid "Extra Fields Definition"
 msgstr "Definizione dei campi aggiuntivi"

--- a/src/onegov/org/models/resource.py
+++ b/src/onegov/org/models/resource.py
@@ -71,6 +71,7 @@ class SharedMethods:
 
     lead: dict_property[str | None] = meta_property()
     text = dict_markup_property('content')
+    confirmation_text = dict_markup_property('content')
     occupancy_is_visible_to_members: dict_property[bool | None]
     occupancy_is_visible_to_members = meta_property()
 

--- a/src/onegov/org/templates/mail_reservation_accepted.pt
+++ b/src/onegov/org/templates/mail_reservation_accepted.pt
@@ -18,6 +18,11 @@
         <tal:b metal:use-macro="layout.macros['reservations']"></tal:b>
         <p tal:condition="code"><b><tal:b i18n:translate>Key Code</tal:b>:</b> ${code}</p>
 
+        <tal:b tal:condition="resource.confirmation_text">
+            <p><b i18n:translate>Additional Information</b></p>
+            ${resource.confirmation_text}
+        </tal:b>
+
         <p>
             <a href="${request.link(ticket, 'status')}" i18n:translate>Check request status</a>
         </p>

--- a/src/onegov/org/templates/mail_reservation_summary.pt
+++ b/src/onegov/org/templates/mail_reservation_summary.pt
@@ -11,6 +11,11 @@
 
         <p tal:condition="code"><b><tal:b i18n:translate>Key Code</tal:b>:</b> ${code}</p>
 
+        <tal:b tal:condition="resource.confirmation_text">
+            <p><b i18n:translate>Additional Information</b></p>
+            ${resource.confirmation_text}
+        </tal:b>
+
         <p>
             <a href="${request.link(ticket, 'status')}" i18n:translate>Check request status</a>
         </p>

--- a/src/onegov/org/templates/ticket_status.pt
+++ b/src/onegov/org/templates/ticket_status.pt
@@ -28,6 +28,9 @@
             <div class="field-display-data ticket-state">
                 <tal:b metal:use-macro="layout.macros['ticket_status']" />
             </div>
+            <div tal:condition="extra_information">
+                <h2 i18n:translate>Additional Information</h2>${extra_information}
+            </div>
             <tal:b tal:condition="ticket.handler.payment">
                 <tal:b tal:define="payment ticket.handler.payment; show_vat ticket.handler.show_vat" metal:use-macro="layout.macros['payment']" />
             </tal:b>

--- a/src/onegov/org/views/ticket.py
+++ b/src/onegov/org/views/ticket.py
@@ -1308,8 +1308,11 @@ def view_ticket_status(
     )
 
     pick_up_hint = None
+    extra_information = None
     if resource := getattr(self.handler, 'resource', None):
         pick_up_hint = resource.pick_up
+        if not self.handler.deleted and not self.handler.undecided:
+            extra_information = resource.confirmation_text
     if submission := getattr(self.handler, 'submission', None):
         if form_definition := getattr(submission, 'form', None):
             pick_up_hint = form_definition.pick_up
@@ -1322,7 +1325,8 @@ def view_ticket_status(
             view_messages_feed(messages, request)
         ) or None,
         'form': form,
-        'pick_up_hint': pick_up_hint
+        'pick_up_hint': pick_up_hint,
+        'extra_information': extra_information,
     }
 
 

--- a/src/onegov/town6/templates/mail_reservation_accepted.pt
+++ b/src/onegov/town6/templates/mail_reservation_accepted.pt
@@ -18,6 +18,11 @@
         <tal:b metal:use-macro="layout.macros['reservations']"></tal:b>
         <p tal:condition="code"><b><tal:b i18n:translate>Key Code</tal:b>:</b> ${code}</p>
 
+        <tal:b tal:condition="resource.confirmation_text">
+            <p><b i18n:translate>Additional Information</b></p>
+            ${resource.confirmation_text}
+        </tal:b>
+
         <p>
             <a href="${request.link(ticket, 'status')}" i18n:translate>Check request status</a>
         </p>

--- a/src/onegov/town6/templates/mail_reservation_summary.pt
+++ b/src/onegov/town6/templates/mail_reservation_summary.pt
@@ -11,6 +11,11 @@
 
         <p tal:condition="code"><b><tal:b i18n:translate>Key Code</tal:b>:</b> ${code}</p>
 
+        <tal:b tal:condition="resource.confirmation_text">
+            <p><b i18n:translate>Additional Information</b></p>
+            ${resource.confirmation_text}
+        </tal:b>
+
         <p>
             <a href="${request.link(ticket, 'status')}" i18n:translate>Check request status</a>
         </p>

--- a/src/onegov/town6/templates/ticket_status.pt
+++ b/src/onegov/town6/templates/ticket_status.pt
@@ -34,6 +34,9 @@
             <div class="field-display-data ticket-state">
                 <tal:b metal:use-macro="layout.macros['ticket_status']" />
             </div>
+            <div tal:condition="extra_information">
+                <h2 i18n:translate>Additional Information</h2>${extra_information}
+            </div>
             <tal:b tal:condition="ticket.handler.payment">
                 <tal:b tal:define="payment ticket.handler.payment; show_vat ticket.handler.show_vat" metal:use-macro="layout.macros['payment']" />
             </tal:b>


### PR DESCRIPTION
## Commit message

Org: Allows specifying a custom reservation confirmation text

This text will be included in reservation confirmation and summary e-mails as well as on the ticket status page, after the reservation(s) have been confirmed.

TYPE: Feature
LINK: OGC-2589

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have updated the PO files
- [ ] I made changes/features for both org and town6
- [ ] I have tested my code thoroughly by hand
