### PR TITLE
Core: Fixes making ElasticSearch unavailable in all CLI commands

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
         exclude: .pre-commit-config.yaml
       - id: pt_structure
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.12.11
+    rev: v0.13.0
     hooks:
       - id: ruff
         args: [ "--fix" ]
@@ -27,7 +27,7 @@ repos:
         additional_dependencies:
         - flake8-type-checking>=3.0.0
   - repo: https://github.com/thibaudcolas/pre-commit-stylelint
-    rev: v16.23.1
+    rev: v16.24.0
     hooks:
     - id: stylelint
       files: '^src/.*\.scss'
@@ -35,7 +35,7 @@ repos:
         - stylelint@16.19.1
         - stylelint-config-standard-scss@15.0.0
   - repo: https://github.com/pre-commit/mirrors-eslint
-    rev: v9.34.0
+    rev: v9.35.0
     hooks:
     - id: eslint
       files: '^src/.*\.jsx?$'

--- a/src/onegov/core/cli/commands.py
+++ b/src/onegov/core/cli/commands.py
@@ -159,6 +159,7 @@ def sendmail(group_context: GroupContext, queue: str, limit: int) -> None:
 
 @cli.group(context_settings={
     'matches_required': False,
+    'skip_es_client': True,
     'default_selector': '*'
 })
 @pass_group_context

--- a/src/onegov/core/cli/core.py
+++ b/src/onegov/core/cli/core.py
@@ -224,12 +224,14 @@ if TYPE_CHECKING:
         matches_required: bool
         singular: bool
         creates_path: bool
+        skip_es_client: bool
 
     class ContextSpecificSettings(TypedDict, total=False):
         default_selector: str
         creates_path: bool
         singular: bool
         matches_required: bool
+        skip_es_client: bool
 
 else:
     _GroupContextAttrs = object
@@ -240,7 +242,8 @@ CONTEXT_SPECIFIC_SETTINGS = (
     'default_selector',
     'creates_path',
     'singular',
-    'matches_required'
+    'matches_required',
+    'skip_es_client'
 )
 
 
@@ -362,6 +365,11 @@ class GroupContext(GroupContextGuard):
     :param singular:
         True if the selector may not match multiple applications.
 
+    :param skip_es_client:
+        True if no ElasticSearch integration is required. Should result
+        in a free speed-up in commands that don't modify data that's also
+        stored in the search index.
+
     :param matches_required:
         True if the selector *must* match at least one application.
 
@@ -374,6 +382,7 @@ class GroupContext(GroupContextGuard):
         default_selector: str | None = None,
         creates_path: bool = False,
         singular: bool = False,
+        skip_es_client: bool = False,
         matches_required: bool = True
     ):
 
@@ -384,6 +393,7 @@ class GroupContext(GroupContextGuard):
 
         self.selector = selector or default_selector
         self.creates_path = creates_path
+        self.skip_es_client = skip_es_client
 
         if self.creates_path:
             self.singular = True
@@ -594,9 +604,10 @@ def run_processors(
                 # disable debug options in cli (like query output)
                 pass
 
-            def configure_search(self, **cfg: Any) -> None:
-                # disable search options in cli
-                self.es_client = None
+            if group_context.skip_es_client:
+                def configure_search(self, **cfg: Any) -> None:
+                    # disable search options in cli
+                    self.es_client = None
 
         @CliApplication.path(path=view_path)
         class Model:

--- a/src/onegov/user/cli.py
+++ b/src/onegov/user/cli.py
@@ -105,7 +105,10 @@ def delete(username: str) -> Callable[[CoreRequest, Framework], None]:
     return delete_user
 
 
-@cli.command(context_settings={'default_selector': '*'})
+@cli.command(context_settings={
+    'default_selector': '*',
+    'skip_es_client': True
+})
 @click.argument('username')
 @click.option('-r', '--recursive', is_flag=True, default=False)
 def exists(
@@ -131,7 +134,7 @@ def exists(
     return find_user
 
 
-@cli.command(context_settings={'singular': True})
+@cli.command(context_settings={'singular': True, 'skip_es_client': True})
 @click.argument('username')
 def activate(username: str) -> Callable[[CoreRequest, Framework], None]:
     """ Activates the given user. """
@@ -148,7 +151,7 @@ def activate(username: str) -> Callable[[CoreRequest, Framework], None]:
     return activate_user
 
 
-@cli.command(context_settings={'singular': True})
+@cli.command(context_settings={'singular': True, 'skip_es_client': True})
 @click.argument('username')
 def deactivate(username: str) -> Callable[[CoreRequest, Framework], None]:
     """ Deactivates the given user. """
@@ -166,7 +169,7 @@ def deactivate(username: str) -> Callable[[CoreRequest, Framework], None]:
     return deactivate_user
 
 
-@cli.command(context_settings={'singular': True})
+@cli.command(context_settings={'singular': True, 'skip_es_client': True})
 @click.argument('username')
 def logout(username: str) -> Callable[[CoreRequest, Framework], None]:
     """ Logs out the given user on all sessions. """
@@ -183,7 +186,10 @@ def logout(username: str) -> Callable[[CoreRequest, Framework], None]:
     return logout_user
 
 
-@cli.command(name='logout-all', context_settings={'singular': True})
+@cli.command(name='logout-all', context_settings={
+    'singular': True,
+    'skip_es_client': True
+})
 def logout_all() -> Callable[[CoreRequest, Framework], None]:
     """ Logs out all users on all sessions. """
 
@@ -196,7 +202,10 @@ def logout_all() -> Callable[[CoreRequest, Framework], None]:
     return logout_user
 
 
-@cli.command(context_settings={'default_selector': '*'})
+@cli.command(context_settings={
+    'default_selector': '*',
+    'skip_es_client': True
+})
 @click.option('--active-only', help='Only show active users', is_flag=True)
 @click.option('--inactive-only', help='Only show inactive users', is_flag=True)
 @click.option('--sources', help='Display sources', is_flag=True, default=False)
@@ -237,7 +246,10 @@ def list(
     return list_users
 
 
-@cli.command(name='change-password', context_settings={'singular': True})
+@cli.command(name='change-password', context_settings={
+    'singular': True,
+    'skip_es_client': True
+})
 @click.argument('username')
 @click.option('--password', help='Password to use', default=None)
 def change_password(
@@ -264,7 +276,10 @@ def change_password(
     return change
 
 
-@cli.command(name='change-yubikey', context_settings={'singular': True})
+@cli.command(name='change-yubikey', context_settings={
+    'singular': True,
+    'skip_es_client': True
+})
 @click.argument('username')
 @click.option('--yubikey', help='Yubikey to use', default=None)
 def change_yubikey(
@@ -298,7 +313,10 @@ def change_yubikey(
     return change
 
 
-@cli.command(name='change-mtan', context_settings={'singular': True})
+@cli.command(name='change-mtan', context_settings={
+    'singular': True,
+    'skip_es_client': True
+})
 @click.argument('username')
 @click.option('--phone-number', help='Phone number to use', default=None)
 def change_mtan(
@@ -347,7 +365,10 @@ def change_mtan(
     return change
 
 
-@cli.command(name='change-totp', context_settings={'singular': True})
+@cli.command(name='change-totp', context_settings={
+    'singular': True,
+    'skip_es_client': True
+})
 @click.argument('username')
 @click.option('--secret', help='TOTP secret to use', default=None)
 @click.option(
@@ -394,7 +415,10 @@ def change_totp(
     return change
 
 
-@cli.command(name='transfer-yubikey', context_settings={'singular': True})
+@cli.command(name='transfer-yubikey', context_settings={
+    'singular': True,
+    'skip_es_client': True
+})
 @click.argument('source')
 @click.argument('target')
 def transfer_yubikey(
@@ -433,7 +457,10 @@ def transfer_yubikey(
     return transfer
 
 
-@cli.command(name='change-role', context_settings={'singular': True})
+@cli.command(name='change-role', context_settings={
+    'singular': True,
+    'skip_es_client': True
+})
 @click.argument('username')
 @click.argument('role')
 def change_role(
@@ -460,7 +487,10 @@ def change_role(
     return change
 
 
-@cli.command(name='list-sessions', context_settings={'singular': True})
+@cli.command(name='list-sessions', context_settings={
+    'singular': True,
+    'skip_es_client': True
+})
 def list_sessions() -> Callable[[CoreRequest, Framework], None]:
     """ Lists all sessions of all users. """
 

--- a/tests/stubtest/depot_allowlist.txt
+++ b/tests/stubtest/depot_allowlist.txt
@@ -3,5 +3,3 @@
 # The interface on StoredFile.close is a bit wacky, it doesn't really
 # make sense for it to accept arbirary parameters
 depot.io.interfaces.StoredFile.close
-# this seems like a false positive due to the use of ABCMeta
-depot.fields.sqlalchemy.UploadedFileField.__init__

--- a/tests/stubtest/more.webassets_allowlist.txt
+++ b/tests/stubtest/more.webassets_allowlist.txt
@@ -1,7 +1,5 @@
 # Error: variable differs from runtime
 # ======================
-# These are false positives due to Action using ABCMeta
-more\.webassets\.directives\.Webasset([A-Z]\w+)?\.group_class
 # bound directives are very complex and can't be verified properly
 more\.webassets\.(core\.)?WebassetsApp\.webasset_path
 more\.webassets\.(core\.)?WebassetsApp\.webasset_output

--- a/tests/stubtest/morepath_allowlist.txt
+++ b/tests/stubtest/morepath_allowlist.txt
@@ -1,7 +1,5 @@
 # Error: variable differs from runtime
 # ======================
-# These are false positives due to Action using ABCMeta
-morepath\.directive\.[A-Z]\w+Action\.group_class
 # bound directives are very complex and can't be verified properly
 morepath\.(app\.)?App\.setting
 morepath\.(app\.)?App\.setting_section

--- a/tests/stubtest/transaction_allowlist.txt
+++ b/tests/stubtest/transaction_allowlist.txt
@@ -17,12 +17,6 @@ transaction.interfaces.ISynchronizer
 transaction.interfaces.ITransaction
 transaction.interfaces.ITransactionManager
 
-# Error: is inconsistent
-# ================================
-# False positive for positional only overloads with different
-# argument name, see: https://github.com/python/mypy/issues/16956
-transaction(\._manager)?\.(Thread)?TransactionManager\.run
-
 # Error: failed to find stubs
 # ================================
 # Tests should not be part of the stubs


### PR DESCRIPTION
## Commit message

Core: Fixes making ElasticSearch unavailable in all CLI commands

This adds a new context specific setting `skip_es_client` which allows skipping initializing ElasticSearch for commands that don't need it.

TYPE: Bugfix

## Checklist

- [x] I have performed a self-review of my code
- [x] I have tested my code thoroughly by hand
