### PR TITLE
Add edit note as a format option

### DIFF
--- a/src/onegov/core/html.py
+++ b/src/onegov/core/html.py
@@ -56,7 +56,8 @@ SANE_HTML_ATTRS = {
     'a': ['href', 'title'],
     'abbr': ['title', ],
     'acronym': ['title', ],
-    'img': ['src', 'alt', 'title']
+    'img': ['src', 'alt', 'title'],
+    'p': ['class']
 }
 
 # lines without these plaintext characters are excluded in html_to_text

--- a/src/onegov/org/assets/js/editor.js
+++ b/src/onegov/org/assets/js/editor.js
@@ -33,6 +33,11 @@ $(function() {
                 {
                     tag: 'h4',
                     title: translation.subsubtitle
+                },
+                {
+                    tag: 'p',
+                    class: 'edit-note',
+                    title: translation.editnote
                 }
             ],
             /* defined in input_with_button.js */

--- a/src/onegov/org/assets/js/redactor.de.js
+++ b/src/onegov/org/assets/js/redactor.de.js
@@ -47,6 +47,7 @@ $.Redactor.opts.langs['de'] = {
 	title: 'Title',
     subtitle: 'Untertitel',
 	subsubtitle: 'Sub-Untertitel',
+	editnote: 'Editierhinweis',
 	image_view: 'Bilder',
 	image_position: 'Textumbruch',
 	none: 'Keine',

--- a/src/onegov/org/assets/js/redactor.fr.js
+++ b/src/onegov/org/assets/js/redactor.fr.js
@@ -47,6 +47,7 @@ $.Redactor.opts.langs['fr'] = {
     title: 'Titre',
     subtitle: 'Sous-titre',
     subsubtitle: 'Sous-Sous-titre',
+    editnote: 'Note de modification',
     image_view: 'Voir l\'image',
     image_position: 'Position de l\'image',
     none: 'aucun',

--- a/src/onegov/org/assets/js/redactor.it.js
+++ b/src/onegov/org/assets/js/redactor.it.js
@@ -44,6 +44,7 @@ $.Redactor.opts.langs['it'] = {
 	title: 'Titolo',
 	subtitle: 'Sottotitolo',
 	subsubtitle: 'Sotto-Sottotitolo',
+	editnote: 'Nota di modifica',
 	image_position: 'Posizione',
 	none: 'Nessuno',
 	left: 'Sinistra',

--- a/src/onegov/town6/theme/styles/typography.scss
+++ b/src/onegov/town6/theme/styles/typography.scss
@@ -129,3 +129,15 @@ a {
         color: $anchor-color;
     }
 }
+
+p.edit-note,
+.redactor-dropdown .redactor-formatting-p-edit-note {
+    color: $aluminum;
+    font-size: .875rem;
+    font-style: italic;
+
+    &::before {
+        @include icon('\f249');
+        margin-right: .25rem;
+    }
+}


### PR DESCRIPTION
Please fill in the commit message below and work through the checklist. You can delete parts that are not needed, e.g. the optional description, the link to a ticket or irrelevant options of the checklist.

## Commit message

Town6: Add edit note as a format option

TYPE: Feature
LINK: OGC-2274
