### PR TITLE
Pro 1421 volunteers as recipients

### DIFF
--- a/src/onegov/feriennet/forms/notification_template.py
+++ b/src/onegov/feriennet/forms/notification_template.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from functools import cached_property
 from markupsafe import Markup, escape
 
-from onegov.activity import Activity, Attendee
+from onegov.activity import Activity, Attendee, OccasionNeed, Volunteer
 from onegov.activity import Booking, BookingCollection
 from onegov.activity import Occasion, OccasionCollection
 from onegov.core.orm import as_selectable_from_path
@@ -93,6 +93,9 @@ class NotificationTemplateSendForm(Form):
                 'Users with attenedees that have an occasion on their '
                 'wish- or booking-list'
             )),
+            (('volunteers', _(
+                'Volunteers'
+            )))
         ],
         default='by_role'
     )
@@ -120,6 +123,21 @@ class NotificationTemplateSendForm(Form):
             ('inactive', _('Inactive users')),
         ],
         default=['active'],
+        depends_on=(
+            'send_to', '!volunteers',
+            )
+    )
+
+    volunteer_state = RadioField(
+        label=_('State'),
+        choices=[
+            ('all', _('All')),
+            ('open', _('Open')),
+            ('contacted', _('Contacted')),
+            ('confirmed', _('Confirmed')),
+        ],
+        depends_on=('send_to', 'volunteers'),
+        default='all',
     )
 
     no_spam = BooleanField(
@@ -174,6 +192,9 @@ class NotificationTemplateSendForm(Form):
 
         elif self.send_to.data == 'with_no_wishes_or_bookings':
             recipients = self.recipients_with_no_wishes_or_bookings()
+
+        elif self.send_to.data == 'volunteers':
+            recipients = self.recipients_volunteers(self.volunteer_state.data)
 
         else:
             raise NotImplementedError
@@ -324,6 +345,19 @@ class NotificationTemplateSendForm(Form):
         organisers = {username for username, in uq}
 
         return attendees | organisers
+
+    def recipients_volunteers(self, state: str) -> set[str]:
+        query = (
+            self.request.session.query(distinct(Volunteer.email))
+            .join(OccasionNeed)
+            .join(Occasion)
+            .filter(Occasion.period_id == self.period.id)
+        )
+
+        if state != 'all':
+            query = query.filter(Volunteer.state == state)
+
+        return {v for v, in query}
 
     @property
     def occasion_choices(self) -> Iterator[tuple[str, Markup]]:

--- a/src/onegov/feriennet/forms/notification_template.py
+++ b/src/onegov/feriennet/forms/notification_template.py
@@ -194,7 +194,7 @@ class NotificationTemplateSendForm(Form):
             recipients = self.recipients_with_no_wishes_or_bookings()
 
         elif self.send_to.data == 'volunteers':
-            recipients = self.recipients_volunteers(self.volunteer_state.data)
+            return self.recipients_volunteers(self.volunteer_state.data)
 
         else:
             raise NotImplementedError

--- a/tests/onegov/feriennet/test_forms.py
+++ b/tests/onegov/feriennet/test_forms.py
@@ -323,7 +323,7 @@ def test_notification_template_send_form(session: Session) -> None:
 
     assert form.has_choices
     assert len(form.occasion.choices) == 2
-    assert len(form.send_to.choices) == 9
+    assert len(form.send_to.choices) == 10
 
     # if the period is not confirmed, we send to attendees wanting the occasion
     periods.query().one().confirmed = False

--- a/tests/onegov/feriennet/test_views.py
+++ b/tests/onegov/feriennet/test_views.py
@@ -3871,7 +3871,6 @@ def test_send_message_to_different_recipients(
 
     # Create notification
     client.login_admin()
-    page = client.get('/usermanagement')
     page = client.get('/notifications')
     page = page.click('Neue Mitteilungs-Vorlage')
     page.form['subject'] = 'with_no_wishes_or_bookings'
@@ -3897,7 +3896,82 @@ def test_send_message_to_different_recipients(
     page.form['no_spam'] = 'y'
     page.form.submit()
 
-    # Sue shouldn't get a message since the has an activity
+    # Sue shouldn't get a message since she has an activity
     assert len(os.listdir(client.app.maildir)) == 2
-    message = client.get_email(0)
+    message = client.get_email(1)
     assert message['To'] != 'sue@example.org'
+
+
+def test_send_message_to_volunteer(
+    client: Client,
+    scenario: Scenario
+) -> None:
+
+    scenario.add_period(title="2026", confirmed=True, finalized=False)
+    scenario.add_activity(title="Photography", state='accepted')
+    scenario.add_occasion(cost=100)
+    scenario.add_need(
+        name="Begleiter", number=NumericRange(1, 3), accept_signups=True)
+
+    scenario.commit()
+
+    client.login_admin()
+
+    page = client.get('/feriennet-settings')
+    page.form['volunteers'] = 'enabled'
+    page.form.submit()
+
+    scenario.add_volunteer(
+        first_name='Mia',
+        last_name='P',
+        address='street',
+        zip_code='12',
+        place='some place',
+        birth_date=date(2019, 1, 1),
+        email='mia@test.com',
+        phone='041 322 22 22',
+        state='open'
+    )
+    scenario.add_volunteer(
+        first_name='Emilia',
+        last_name='P',
+        address='street',
+        zip_code='12',
+        place='some place',
+        birth_date=date(2019, 1, 1),
+        email='emilia@test.com',
+        phone='041 322 22 22',
+        state='contacted'
+    )
+    scenario.add_volunteer(
+        first_name='Roy',
+        last_name='P',
+        address='street',
+        zip_code='12',
+        place='some place',
+        birth_date=date(2019, 1, 1),
+        email='roy@test.com',
+        phone='041 322 22 22',
+        state='confirmed'
+    )
+
+    scenario.commit()
+
+    page = client.get('/notifications')
+    page = page.click('Neue Mitteilungs-Vorlage')
+    page.form['subject'] = 'test_volunteers'
+    page.form['text'] = 'test'
+    page.form.submit()
+
+    # Send message to confirmed volunteers
+    page = client.get('/notifications')
+    page = page.click('Vorlage verwenden')
+    page.form['send_to'] = 'volunteers'
+    page.form['volunteer_state'] = 'confirmed'
+    page.form['no_spam'] = 'y'
+    page.form.submit()
+
+    # Only Roy should get a message
+    assert len(os.listdir(client.app.maildir)) == 1
+    message = client.get_email(0)
+    assert message['To'] == 'roy@test.com'


### PR DESCRIPTION
Please fill in the commit message below and work through the checklist. You can delete parts that are not needed, e.g. the optional description, the link to a ticket or irrelevant options of the checklist.

## Commit message

Feriennet: Volunteers as recipients

Add volunteers with different states as options for message recipients

TYPE: Feature
LINK: PRO-1421

## Checklist

- [x] I have performed a self-review of my code
- [x] I have tested my code thoroughly by hand
- [x] I have added tests for my changes/features