### PR TITLE
Town6: Makes possible values for API query filters machine readable

### DIFF
--- a/src/onegov/api/models.py
+++ b/src/onegov/api/models.py
@@ -23,7 +23,7 @@ from wtforms import HiddenField
 
 from typing import TYPE_CHECKING, Any, ClassVar, NoReturn, Self, overload
 if TYPE_CHECKING:
-    from collections.abc import Iterator, Mapping
+    from collections.abc import Collection, Iterator, Mapping
     from onegov.core import Framework
     from onegov.core.collection import PKType
     from onegov.core.request import CoreRequest
@@ -194,9 +194,11 @@ class ApiEndpoint[M: DeclarativeBase]:
         self.batch_size = 100
 
     @cached_property
-    def filters(self) -> Mapping[str, str | None]:
+    def filters(self) -> Mapping[str, Collection[str] | str | None]:
         """ A mapping of the available filter params to their corresponding
-        description.
+        description or a collection of possible values. If possible values
+        are specified it is assumed that the filter can be specfied multiple
+        times.
 
         The description is optional and should only be used for non-trivial
         filters that don't just accept arbitrary strings.

--- a/src/onegov/api/views.py
+++ b/src/onegov/api/views.py
@@ -76,7 +76,7 @@ def view_api_endpoints(
                             # NOTE: This is a custom extension of
                             #       Collection+JSON, that is a little
                             #       bit more machine-readable.
-                            'values': sorted(prompt)
+                            'values': list(prompt)
                         }
                         for name, prompt in endpoint.filters.items()
                     ]

--- a/src/onegov/api/views.py
+++ b/src/onegov/api/views.py
@@ -65,10 +65,19 @@ def view_api_endpoints(
                     'title': endpoint.title,
                     'description': endpoint.description,
                     'data': [
-                        {
+                        {'name': name} if not prompt else {
                             'name': name,
                             'prompt': prompt
-                        } if prompt else {'name': name}
+                        } if isinstance(prompt, str) else {
+                            'name': name,
+                            'prompt': 'One of the given values '
+                                      '(Can be specified multiple '
+                                      'times or left unspecified)',
+                            # NOTE: This is a custom extension of
+                            #       Collection+JSON, that is a little
+                            #       bit more machine-readable.
+                            'values': sorted(prompt)
+                        }
                         for name, prompt in endpoint.filters.items()
                     ]
                 }

--- a/src/onegov/town6/api.py
+++ b/src/onegov/town6/api.py
@@ -7,6 +7,7 @@ from onegov.api.models import ApiInvalidParamException
 from onegov.core.converters import extended_date_decode
 from onegov.event.collections import OccurrenceCollection
 from onegov.gis import Coordinates
+from onegov.org.forms.event import TAGS
 from onegov.org.models.directory import (
     ExtendedDirectory, ExtendedDirectoryEntry,
     ExtendedDirectoryEntryCollection)
@@ -58,23 +59,31 @@ class EventApiEndpoint(ApiEndpoint['Occurrence']):
     endpoint = 'events'
 
     @cached_property
-    def filters(self) -> Mapping[str, str | None]:
+    def filters(self) -> Mapping[str, Collection[str] | str | None]:
         collection = self._base_collection
-        filters = {
+        filters: dict[str, Collection[str] | str | None] = {
             'start': 'Earliest event date '
                 '(ISO-8601 encoded date: YYYY-MM-DD, defaults to today)',
             'end': 'Latest event date (ISO-8601 encoded date: YYYY-MM-DD)',
             'locations': 'Can be specified multiple times',
-            'sources': format_multiple_choice_prompt(collection.used_sources)
+            'sources': collection.used_sources
         }
 
         filter_type = self.app.org.event_filter_type
         if filter_type in ('tags', 'tags_and_filters'):
-            filters['tags'] = format_multiple_choice_prompt(
-                collection.used_tags)
+            used_tags = collection.used_tags
+            if not self.app.custom_event_tags:
+                # built-in tags need to be translated
+                used_tags = {
+                    self.request.translate(_(tag))
+                    for tag in used_tags
+                }
+            filters['tags'] = used_tags
 
-        for name, __, choices in collection.available_filters():
-            filters[name] = format_multiple_choice_prompt(choices)
+        filters.update(
+            (name, choices)
+            for name, __, choices in collection.available_filters()
+        )
         return filters
 
     @property
@@ -135,6 +144,17 @@ class EventApiEndpoint(ApiEndpoint['Occurrence']):
                 value = self.get_date_filter(key, values)
                 result = result.for_filter(end=value)
             elif key == 'tags':
+                if not self.app.custom_event_tags:
+                    # built-in tags are translated and need to be
+                    # transformed back to the stored tag name
+                    translated_to_orginal = {
+                        self.request.translate(tag): str(tag)
+                        for tag in TAGS
+                    }
+                    values = [
+                        translated_to_orginal.get(value, value)
+                        for value in values
+                    ]
                 result = result.for_filter(tags=values)
             elif key == 'sources':
                 result = result.for_filter(sources=values)
@@ -172,7 +192,11 @@ class EventApiEndpoint(ApiEndpoint['Occurrence']):
 
         filter_type = self.app.org.event_filter_type
         if filter_type in ('tags', 'tags_and_filters'):
-            data['tags'] = item.event.tags
+            tags = item.event.tags
+            if not self.app.custom_event_tags:
+                # built-in tags need to be translated
+                tags = [self.request.translate(_(tag)) for tag in tags]
+            data['tags'] = tags
 
         if filter_type in ('filters', 'tags_and_filters'):
             data.update(item.event.filter_keywords)

--- a/src/onegov/town6/api.py
+++ b/src/onegov/town6/api.py
@@ -66,7 +66,7 @@ class EventApiEndpoint(ApiEndpoint['Occurrence']):
                 '(ISO-8601 encoded date: YYYY-MM-DD, defaults to today)',
             'end': 'Latest event date (ISO-8601 encoded date: YYYY-MM-DD)',
             'locations': 'Can be specified multiple times',
-            'sources': collection.used_sources
+            'sources': sorted(collection.used_sources)
         }
 
         filter_type = self.app.org.event_filter_type
@@ -78,7 +78,7 @@ class EventApiEndpoint(ApiEndpoint['Occurrence']):
                     self.request.translate(_(tag))
                     for tag in used_tags
                 }
-            filters['tags'] = used_tags
+            filters['tags'] = sorted(used_tags)
 
         filters.update(
             (name, choices)

--- a/tests/onegov/api/test_views.py
+++ b/tests/onegov/api/test_views.py
@@ -59,8 +59,22 @@ def patch_collection_json(monkeypatch: pytest.MonkeyPatch) -> None:
         self.prompt = prompt
         self.data = data
 
+    def Data__init__(
+        self: Any,
+        name: str,
+        value: Any | None = None,
+        prompt: str | None = None,
+        values: list[str] | None = None,
+        **extra: Any,
+    ) -> None:
+        self.name = name
+        self.value = value
+        self.prompt = prompt
+        self.values = values
+
     monkeypatch.setattr(Collection, '__init__', Collection__init__)
     monkeypatch.setattr('collection_json.Query.__init__', Query__init__)
+    monkeypatch.setattr('collection_json.Data.__init__', Data__init__)
 
 
 def test_view_api(client: Client, app: App) -> None:

--- a/tests/onegov/town6/test_api.py
+++ b/tests/onegov/town6/test_api.py
@@ -37,7 +37,7 @@ def test_view_api(
         return {x.name: x.value for x in item.data}
 
     def filters(item: Any) -> dict[str, Any]:
-        return {x.name: x.prompt for x in item.data}
+        return {x.name: x.values or x.prompt for x in item.data}
 
     def links(item: Any) -> dict[str, str]:
         return {x.rel: x.href for x in item.links}
@@ -96,12 +96,13 @@ def test_view_api(
         'altersgruppe',
         'highlight',
     }
-    assert event_fiters['altersgruppe'] == (
-        "One of 'Kind', 'Jugend', 'Familie', 'Alter'"
-        " (Can be specified multiple times)"
-    )
-    assert event_fiters['highlight'] == "Either 'Ja' or left unspecified"
-
+    assert event_fiters['altersgruppe'] == [
+        'Kind',
+        'Jugend',
+        'Familie',
+        'Alter'
+    ]
+    assert event_fiters['highlight'] == ['Ja']
     # Configure tags and filters
     settings = client.get('/event-settings')
     settings.form['event_filter_type'] = 'tags_and_filters'


### PR DESCRIPTION
## Commit message

Town6: Makes possible values for API query filters machine readable

This also fixes built-in event tags being reported in English instead
of the configured language within the event API.

TYPE: Feature
LINK: OGC-3087

## Checklist

- [x] I have performed a self-review of my code
- [x] I have tested my code thoroughly by hand