### PR TITLE
Allow links on root level

### DIFF
--- a/src/onegov/org/layout.py
+++ b/src/onegov/org/layout.py
@@ -4101,14 +4101,30 @@ class HomepageLayout(DefaultLayout):
                     self.request.link(self.model, 'sort'),
                     attrs={'class': ('sort-link')}
                 ),
-                Link(
-                    _('Add'),
-                    self.request.link(Editor('new-root', self.model, 'page')),
-                    attrs={'class': ('new-page')},
-                    classes=(
-                        'new-page',
-                        'show-new-content-placeholder'
-                    ),
+                LinkGroup(
+                    title=_('Add'),
+                    links=(
+                        Link(
+                            _('Topic'),
+                            self.request.link(
+                                Editor('new-root', self.model, 'page')),
+                            attrs={'class': ('new-page')},
+                            classes=(
+                                'new-page',
+                                'show-new-content-placeholder'
+                            ),
+                        ),
+                        Link(
+                            _('Link'),
+                            self.request.link(
+                                Editor('new-root', self.model, 'link')),
+                            attrs={'class': 'new-root-link'},
+                            classes=(
+                                'new-root-link',
+                                'show-new-content-placeholder'
+                            )
+                        )
+                    )
                 ),
             ]
         return None

--- a/src/onegov/org/theme/styles/org.scss
+++ b/src/onegov/org/theme/styles/org.scss
@@ -1829,6 +1829,7 @@ $editbar-bg-color: $topbar-link-bg-hover;
     .new-form::before { @include icon($new-form-icon); }
     .new-document-form::before { @include icon($new-document-form-icon); }
     .new-link::before { @include icon($new-link-icon); }
+    .new-root-link::before { @include icon($new-link-icon); }
     .new-iframe::before { @include icon($new-iframe-icon); }
     .new-news::before { @include icon($new-news-icon); }
     .new-newsletter::before { @include icon($new-newsletter-icon); }

--- a/src/onegov/org/views/editor.py
+++ b/src/onegov/org/views/editor.py
@@ -7,7 +7,7 @@ from webob.exc import HTTPForbidden, HTTPNotFound
 from onegov.core.elements import BackLink, Link
 from onegov.core.security import Private
 from onegov.org import _, OrgApp
-from onegov.org.forms.page import MovePageForm, PageUrlForm, PageForm
+from onegov.org.forms.page import MovePageForm, PageUrlForm, PageForm, LinkForm
 from onegov.org.layout import EditorLayout, PageLayout
 from onegov.org.management import PageNameChange
 from onegov.org.models import Clipboard, Editor
@@ -43,8 +43,12 @@ def get_form_class(
     if editor.action == 'move':
         return MovePageForm
     if editor.action == 'new-root':
-        # this is the case when adding a new 'root' page (parent = None)
-        return PageForm
+        if editor.trait == 'page':
+            # this is the case when adding a new 'root' page (parent = None)
+            return PageForm
+        if editor.trait == 'link':
+            # this is the case when adding a new 'root' link (parent = None)
+            return LinkForm
 
     assert editor.page is not None
     return editor.page.get_form_class(editor.trait, editor.action, request)
@@ -131,7 +135,7 @@ def handle_new_root_page(
     form: Form,
     layout: EditorLayout | PageLayout | None = None
 ) -> RenderData | Response:
-    site_title = _('New Topic')
+    site_title = _('New Topic') if self.trait == 'page' else _('New Link')
 
     if layout:
         layout.site_title = site_title  # type:ignore[union-attr]
@@ -141,12 +145,15 @@ def handle_new_root_page(
         page = pages.add(
             parent=None,  # root page
             title=form['title'].data,
-            type='topic',
-            meta={'trait': 'page'},
+            type='topic',  # also for links
+            meta={'trait': self.trait},
         )
         form.populate_obj(page)
 
-        request.success(_('Added a new topic'))
+        if self.trait == 'link':
+            request.success(_('Added a new link'))
+        else:
+            request.success(_('Added a new topic'))
         return morepath.redirect(request.link(page))
 
     if not request.POST:

--- a/src/onegov/town6/theme/styles/header.scss
+++ b/src/onegov/town6/theme/styles/header.scss
@@ -570,6 +570,7 @@ $editbar-fg-color-active: $white;
     .new-form::before { @include icon($new-form-icon); }
     .new-document-form::before { @include icon-bold($new-document-form-icon); }
     .new-link::before { @include icon-bold($new-link-icon); }
+    .new-root-link::before { @include icon-bold($new-link-icon); }
     .new-iframe::before { @include icon-bold($new-iframe-icon); }
     .new-news::before { @include icon($new-news-icon); }
     .new-newsletter::before { @include icon($new-newsletter-icon); }

--- a/tests/onegov/org/test_views_homepage.py
+++ b/tests/onegov/org/test_views_homepage.py
@@ -39,9 +39,10 @@ def test_add_new_root_topic(client: Client) -> None:
     client.login_admin().follow()
 
     page = client.get('/')
-    assert "Hinzufügen" in page
+    assert 'Hinzufügen' in page
+    assert 'Thema' in page
 
-    page = page.click('Hinzufügen')
+    page = page.click('Thema')
     page.form['title'] = 'Super Org Thema'
     page = page.form.submit().follow()
     assert page.status_code == 200

--- a/tests/onegov/org/test_views_pages.py
+++ b/tests/onegov/org/test_views_pages.py
@@ -141,13 +141,6 @@ def test_pages(client: Client) -> None:
     assert "<script>alert('yes')</script>" not in page
     assert "&lt;script&gt;alert('yes')&lt;/script&gt;" in page
 
-    # create new root page
-    root_page = client.get('/').click('Thema')
-    root_page.form['title'] = "Root Page"
-    root_page.form['text'] = "root page text"
-    root_page = root_page.form.submit().follow()
-    assert root_page.pyquery('.main-title').text() == "Root Page"
-
     client.get('/auth/logout')
 
     assert page.pyquery('.main-title').text() == "Living in Govikon is Awful"

--- a/tests/onegov/org/test_views_pages.py
+++ b/tests/onegov/org/test_views_pages.py
@@ -469,9 +469,10 @@ def test_move_page_assigning_a_child_as_parent(client: Client) -> None:
 
 
 def test_links(client: Client) -> None:
-    root_url = client.get('/').pyquery('.top-bar-section a').attr('href')
+    root_page = client.get('/')
+    root_topic_url = client.get('/').pyquery('.top-bar-section a').attr('href')
     client.login_admin()
-    root_page = client.get(root_url)
+    root_page = client.get(root_topic_url)
 
     assert 'URL ändern' in edit_bar_links(root_page, 'text')
     new_link = root_page.click("Verknüpfung")
@@ -485,7 +486,7 @@ def test_links(client: Client) -> None:
     assert 'https://www.google.ch' in link
 
     new_link = root_page.click("Verknüpfung")
-    new_link.form['url'] = root_url
+    new_link.form['url'] = root_topic_url
     new_link.form['title'] = 'Link to Org'
     internal_link = new_link.form.submit().follow()
 
@@ -499,20 +500,34 @@ def test_links(client: Client) -> None:
     assert '1 Links werden nach dieser Aktion ersetzt.' in callout
     change_url_check.form['test'] = False
     root_page = change_url_check.form.submit().follow()
-    root_url = root_page.request.url
+    root_topic_url = root_page.request.url
     # check the link to org is updated getting 200 OK
     link_page = root_page.click('Link to Org', index=0)
 
     assert internal_link.request.url != link_page.request.url
 
+    # create link on root level
+    root_link = root_page.click('Verknüpfung')
+    assert "Neue Verknüpfung" in root_link
+
+    root_link.form['title'] = 'seantis'
+    root_link.form['url'] = 'https://www.seantis.ch'
+    link = root_link.form.submit().follow()
+    assert "Sie wurden nicht automatisch weitergeleitet" in link
+    assert 'https://www.seantis.ch' in link
+
     client.get('/auth/logout')
 
-    root_page = client.get(root_url)
+    root_page = client.get(root_topic_url)
     assert "Google" in root_page
     google = root_page.click("Google", index=0)
-
     assert google.status_code == 302
     assert google.location == 'https://www.google.ch'
+
+    assert 'seantis' in root_page
+    seantis = root_page.click('seantis', index=0)
+    assert seantis.status_code == 302
+    assert seantis.location == 'https://www.seantis.ch'
 
 
 def test_copy_paste_with_same_trait_only(client: Client) -> None:

--- a/tests/onegov/org/test_views_pages.py
+++ b/tests/onegov/org/test_views_pages.py
@@ -80,8 +80,8 @@ def test_pages_cache(client: Client) -> None:
 
 
 def test_pages(client: Client) -> None:
-    root_url = client.get('/').pyquery('.top-bar-section a').attr('href')
-    assert len(client.get(root_url).pyquery('.edit-bar')) == 0
+    root_topic = client.get('/').pyquery('.top-bar-section a').attr('href')
+    assert len(client.get(root_topic).pyquery('.edit-bar')) == 0
 
     admin = client.spawn()
     admin.login_admin()
@@ -100,7 +100,7 @@ def test_pages(client: Client) -> None:
     client.login_admin()
     editor = client.spawn()
     editor.login_editor()
-    root_page = client.get(root_url)
+    root_page = client.get(root_topic)
     new_page = root_page.click('Thema')
     assert "Neues Thema" in new_page
 
@@ -140,6 +140,13 @@ def test_pages(client: Client) -> None:
     assert page.pyquery('.page-text i').text().startswith("Experts say hiring")
     assert "<script>alert('yes')</script>" not in page
     assert "&lt;script&gt;alert('yes')&lt;/script&gt;" in page
+
+    # create new root page
+    root_page = client.get('/').click('Thema')
+    root_page.form['title'] = "Root Page"
+    root_page.form['text'] = "root page text"
+    root_page = root_page.form.submit().follow()
+    assert root_page.pyquery('.main-title').text() == "Root Page"
 
     client.get('/auth/logout')
 
@@ -469,10 +476,9 @@ def test_move_page_assigning_a_child_as_parent(client: Client) -> None:
 
 
 def test_links(client: Client) -> None:
-    root_page = client.get('/')
-    root_topic_url = client.get('/').pyquery('.top-bar-section a').attr('href')
+    root_topic = client.get('/').pyquery('.top-bar-section a').attr('href')
     client.login_admin()
-    root_page = client.get(root_topic_url)
+    root_page = client.get(root_topic)
 
     assert 'URL ändern' in edit_bar_links(root_page, 'text')
     new_link = root_page.click("Verknüpfung")
@@ -486,7 +492,7 @@ def test_links(client: Client) -> None:
     assert 'https://www.google.ch' in link
 
     new_link = root_page.click("Verknüpfung")
-    new_link.form['url'] = root_topic_url
+    new_link.form['url'] = root_topic
     new_link.form['title'] = 'Link to Org'
     internal_link = new_link.form.submit().follow()
 
@@ -500,14 +506,14 @@ def test_links(client: Client) -> None:
     assert '1 Links werden nach dieser Aktion ersetzt.' in callout
     change_url_check.form['test'] = False
     root_page = change_url_check.form.submit().follow()
-    root_topic_url = root_page.request.url
+    root_topic = root_page.request.url
     # check the link to org is updated getting 200 OK
     link_page = root_page.click('Link to Org', index=0)
 
     assert internal_link.request.url != link_page.request.url
 
     # create link on root level
-    root_link = root_page.click('Verknüpfung')
+    root_link = client.get('/').click('Verknüpfung')
     assert "Neue Verknüpfung" in root_link
 
     root_link.form['title'] = 'seantis'
@@ -518,7 +524,7 @@ def test_links(client: Client) -> None:
 
     client.get('/auth/logout')
 
-    root_page = client.get(root_topic_url)
+    root_page = client.get(root_topic)
     assert "Google" in root_page
     google = root_page.click("Google", index=0)
     assert google.status_code == 302

--- a/tests/onegov/town6/test_views_homepage.py
+++ b/tests/onegov/town6/test_views_homepage.py
@@ -84,9 +84,10 @@ def test_add_new_root_topic(client: Client) -> None:
     client.login_admin().follow()
 
     page = client.get('/')
-    assert "Hinzufügen" in page
+    assert 'Hinzufügen' in page
+    assert 'Thema' in page
 
-    page = page.click('Hinzufügen')
+    page = page.click('Thema')
     page.form['title'] = 'Super Thema'
     page = page.form.submit().follow()
     assert page.status_code == 200


### PR DESCRIPTION
Org: Allow links creation directly on root level (as for pages)

The current workaround is to create it on any level and move it to the root level.

TYPE: Feature
LINK: ogc-3118
