### PR TITLE
Pas: Persist org_type on ParliamentarianRole via meta column

### DIFF
--- a/src/onegov/core/markdown.py
+++ b/src/onegov/core/markdown.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
     from mistletoe.span_token import HTMLBlock, HTMLSpan  # type:ignore
 
 
-RENDERER_INSTANCES = {}
+RENDERER_INSTANCES: dict[type[HtmlRenderer], HtmlRenderer] = {}
 
 
 class HTMLRendererWithoutInlineHtml(HtmlRenderer):

--- a/src/onegov/election_day/app.py
+++ b/src/onegov/election_day/app.py
@@ -216,7 +216,7 @@ def override_language_tween_factory(
 
         locale = request.params.get('locale')
         if locale in app.locales:
-            request.locale = locale  # type:ignore[assignment]
+            request.locale = locale
 
         return handler(request)
 

--- a/src/onegov/parliament/models/parliamentarian_role.py
+++ b/src/onegov/parliament/models/parliamentarian_role.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from datetime import date
 from onegov.core.orm import Base
+from onegov.core.orm.mixins import ContentMixin
 from onegov.core.orm.mixins import TimestampMixin
 from onegov.parliament import _
 from sqlalchemy import Enum
@@ -69,7 +70,7 @@ PARLIAMENTARY_GROUP_ROLES: dict[ParliamentaryGroupRole, str] = {
 }
 
 
-class ParliamentarianRole(Base, TimestampMixin):
+class ParliamentarianRole(Base, ContentMixin, TimestampMixin):
 
     __tablename__ = 'par_parliamentarian_roles'
 

--- a/src/onegov/parliament/upgrade.py
+++ b/src/onegov/parliament/upgrade.py
@@ -6,6 +6,7 @@ upgraded on the server. See :class:`onegov.core.upgrade.upgrade_task`.
 from __future__ import annotations
 
 from sqlalchemy import Column
+from sqlalchemy import JSON
 from sqlalchemy import Text
 
 from onegov.core.orm.types import UTCDateTime
@@ -279,3 +280,14 @@ def migrate_into_par_political_business_parliamentary_groups(
         )
         context.operations.drop_column(
             'par_political_businesses', 'parliamentary_group_id')
+
+
+@upgrade_task('Add meta and content columns to parliamentarian roles')
+def add_meta_content_to_parliamentarian_roles(
+    context: UpgradeContext,
+) -> None:
+    table = 'par_parliamentarian_roles'
+    if not context.has_column(table, 'meta'):
+        context.operations.add_column(table, Column('meta', JSON()))
+    if not context.has_column(table, 'content'):
+        context.operations.add_column(table, Column('content', JSON()))

--- a/src/onegov/pas/cli.py
+++ b/src/onegov/pas/cli.py
@@ -15,6 +15,7 @@ from onegov.pas.excel_header_constants import (
     commission_expected_headers_variant_2,
 )
 from onegov.pas.data_import import import_commissions_excel
+from onegov.pas.utils import is_active_kantonsrat_member
 from onegov.pas.log import ClickOutputHandler, CompositeOutputHandler
 from onegov.pas.importer.output_handlers import DatabaseOutputHandler
 from onegov.pas.importer.orchestrator import (
@@ -321,6 +322,64 @@ def sync_user_accounts_cli(dry_run: bool) -> Processor:
             click.secho('Dry run - changes aborted', fg='yellow')
 
     return do_sync
+
+
+@cli.command('list-kantonsrat', context_settings={'singular': True})
+def list_kantonsrat_cli() -> Processor:
+    """List parliamentarians by Kantonsrat membership status.
+
+    Shows who has an active Kantonsrat role (no party, no group,
+    no additional_information, end is NULL or >= today).
+
+    Example:
+        onegov-pas --select '/onegov_pas/zug' list-kantonsrat
+    """
+
+    def do_list(request: PasRequest, app: PasApp) -> None:
+        from onegov.pas.models import PASParliamentarian
+
+        session = request.session
+        today = date.today()
+
+        all_parls = (
+            session.query(PASParliamentarian)
+            .order_by(
+                PASParliamentarian.last_name,
+                PASParliamentarian.first_name,
+            )
+            .all()
+        )
+
+        in_kantonsrat = []
+        not_in_kantonsrat = []
+
+        for p in all_parls:
+            if is_active_kantonsrat_member(p, today):
+                in_kantonsrat.append(p)
+            else:
+                not_in_kantonsrat.append(p)
+
+        click.secho(
+            f'\n=== IN Kantonsrat ({len(in_kantonsrat)}) ===',
+            fg='green',
+        )
+        for p in in_kantonsrat:
+            click.echo(f'  {p.last_name}, {p.first_name}')
+
+        click.secho(
+            f'\n=== NOT in Kantonsrat ({len(not_in_kantonsrat)}) ===',
+            fg='red',
+        )
+        for p in not_in_kantonsrat:
+            click.echo(f'  {p.last_name}, {p.first_name}')
+
+        click.echo(
+            f'\nTotal: {len(all_parls)} | '
+            f'In: {len(in_kantonsrat)} | '
+            f'Not in: {len(not_in_kantonsrat)}'
+        )
+
+    return do_list
 
 
 @cli.command('update-custom-data')

--- a/src/onegov/pas/importer/json_import.py
+++ b/src/onegov/pas/importer/json_import.py
@@ -1110,6 +1110,7 @@ class MembershipImporter(DataImporter):
                             party_role=('member' if party else 'none'),
                             start_date=start_date_str,
                             end_date=end_date_str,
+                            org_type=org_type_title,
                         )
                         if updated:
                             parliamentarian_roles_to_update.append(
@@ -1133,6 +1134,7 @@ class MembershipImporter(DataImporter):
                             party_role=('member' if party else 'none'),
                             start_date=start_date_str,
                             end_date=end_date_str,
+                            org_type=org_type_title,
                         )
                         if role_obj:
                             parliamentarian_roles_to_create.append(role_obj)
@@ -1186,6 +1188,7 @@ class MembershipImporter(DataImporter):
                             role=role,
                             start_date=start_date_str,
                             end_date=end_date_str,
+                            org_type=org_type_title,
                         )
                         if updated:
                             parliamentarian_roles_to_update.append(
@@ -1202,6 +1205,7 @@ class MembershipImporter(DataImporter):
                             role=role,
                             start_date=start_date_str,
                             end_date=end_date_str,
+                            org_type=org_type_title,
                         )
                         if role_obj:
                             parliamentarian_roles_to_create.append(role_obj)
@@ -1256,6 +1260,7 @@ class MembershipImporter(DataImporter):
                             additional_information=additional_info,
                             start_date=start_date_str,
                             end_date=end_date_str,
+                            org_type=org_type_title,
                         )
                         if updated:
                             parliamentarian_roles_to_update.append(
@@ -1273,6 +1278,7 @@ class MembershipImporter(DataImporter):
                             additional_information=additional_info,
                             start_date=start_date_str,
                             end_date=end_date_str,
+                            org_type=org_type_title,
                         )
                         if role_obj:
                             parliamentarian_roles_to_create.append(role_obj)
@@ -1470,6 +1476,7 @@ class MembershipImporter(DataImporter):
         additional_information: str | None = None,
         start_date: str | None = None,
         end_date: str | None = None,
+        org_type: str | None = None,
     ) -> PASParliamentarianRole | None:
         try:
             # Ensure parliamentarian has an ID
@@ -1481,6 +1488,10 @@ class MembershipImporter(DataImporter):
                     f'{parliamentarian.last_name}'
                 )
                 return None
+
+            meta: dict[str, str] = {}
+            if org_type:
+                meta['org_type'] = org_type
 
             assert parliamentarian.id is not None
             return PASParliamentarianRole(
@@ -1494,6 +1505,7 @@ class MembershipImporter(DataImporter):
                 additional_information=additional_information,
                 start=self.parse_date(start_date),
                 end=self.parse_date(end_date),
+                meta=meta,
             )
         except Exception:
             self.logger.exception(
@@ -1512,6 +1524,7 @@ class MembershipImporter(DataImporter):
         additional_information: str | None = None,
         start_date: str | None = None,
         end_date: str | None = None,
+        org_type: str | None = None,
     ) -> bool:
         """
         Updates an existing ParliamentarianRole object.
@@ -1554,6 +1567,9 @@ class MembershipImporter(DataImporter):
             changed = True
         if role_obj.end != new_end:
             role_obj.end = new_end
+            changed = True
+        if org_type and role_obj.meta.get('org_type') != org_type:
+            role_obj.meta['org_type'] = org_type
             changed = True
 
         return changed

--- a/src/onegov/pas/utils.py
+++ b/src/onegov/pas/utils.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from onegov.pas.collections import AttendenceCollection
 from onegov.pas.models.attendence import Attendence
 from onegov.pas.models.commission import PASCommission
 from onegov.pas.models.commission_membership import PASCommissionMembership
@@ -20,9 +19,39 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from onegov.pas.models import SettlementRun
     from onegov.pas.models.attendence import Attendence
-    from onegov.town6.request import TownRequest
     from onegov.user import User
     from sqlalchemy.orm import Session
+
+
+def _is_kantonsrat_role(
+    role: PASParliamentarianRole,
+) -> bool:
+    """A Kantonsrat role has meta.org_type == 'Kantonsrat' (set
+    by the KUB importer). Falls back to the legacy heuristic
+    (all of party_id, parliamentary_group_id, and
+    additional_information being NULL) for rows imported before
+    org_type was persisted.
+    """
+    org_type = role.meta.get('org_type')
+    if org_type is not None:
+        return org_type == 'Kantonsrat'
+    return (
+        role.party_id is None
+        and role.parliamentary_group_id is None
+        and role.additional_information is None
+    )
+
+
+def is_active_kantonsrat_member(
+    parliamentarian: PASParliamentarian,
+    reference_date: date | None = None,
+) -> bool:
+    if reference_date is None:
+        reference_date = date.today()
+    return any(
+        _is_kantonsrat_role(r) and (r.end is None or r.end >= reference_date)
+        for r in parliamentarian.roles
+    )
 
 
 def format_swiss_number(value: Decimal | int) -> str:
@@ -247,90 +276,3 @@ def get_commissions_with_memberships(
         .order_by(PASCommission.name)
         .all()
     )
-
-
-# FIXME: Should these two functions be a CLI command instead? Maybe switch
-#        to `click.echo` from `print` depending on the answer.
-def debug_party_export(
-    settlement_run: SettlementRun,
-    request: TownRequest,
-    party: Party
-) -> None:
-    """Debug function to trace party export data retrieval"""
-    session = request.session
-
-    # 1. Check basic party info
-    print(f'Party ID: {party.id}, Name: {party.name}')  # noqa: T201
-
-    # 2. Check date range
-    print(f'Date range: {settlement_run.start} to {settlement_run.end}')  # noqa: T201
-
-    # 3. Get all attendances without party filter first
-    base_attendances = (
-        AttendenceCollection(session)
-        .query()
-        .filter(
-            Attendence.date >= settlement_run.start,
-            Attendence.date <= settlement_run.end
-        )
-        .all()
-    )
-    print(f'Total attendances in date range: {len(base_attendances)}')  # noqa: T201
-
-    # 4. Check parliamentarian roles
-    for attendance in base_attendances:
-        parl = attendance.parliamentarian
-        print(f'\nParliamentarian: {parl.first_name} {parl.last_name}')  # noqa: T201
-        print(f'Attendance date: {attendance.date}')  # noqa: T201
-
-        roles = session.query(PASParliamentarianRole).filter(
-            PASParliamentarianRole.parliamentarian_id == parl.id,
-            PASParliamentarianRole.party_id == party.id,
-            ).all()
-
-        print('Roles:')  # noqa: T201
-        for role in roles:
-            print(f'- Start: {role.start}, End: {role.end}')  # noqa: T201
-
-        # Check if this attendance should be included
-        should_include = any(
-            (role.start is None or role.start <= attendance.date) and
-            (role.end is None or role.end >= attendance.date)
-            for role in roles
-        )
-        print(f'Should include: {should_include}')  # noqa: T201
-
-    # 5. Try the actual party filter
-    party_attendances = (
-        AttendenceCollection(session)
-        .by_party(
-            party_id=str(party.id),
-            start_date=settlement_run.start,
-            end_date=settlement_run.end
-        )
-        .query()
-        .all()
-    )
-    print(f'\nFinal filtered attendances: {len(party_attendances)}')  # noqa: T201
-
-
-def debug_party_export2(
-    request: TownRequest,
-    party: Party
-) -> None:
-    session = request.session
-    print(f'Party ID: {party.id}')  # noqa: T201
-
-    # Check roles directly
-    all_roles = session.query(PASParliamentarianRole).filter(
-        PASParliamentarianRole.party_id == party.id
-    ).all()
-    print(f'\nTotal roles for party: {len(all_roles)}')  # noqa: T201
-    for role in all_roles:
-        print(f'Role: {role.party_id} -> {role.parliamentarian_id}')  # noqa: T201
-
-    # Check all parties
-    all_parties = session.query(Party).all()
-    print('\nAll parties:')  # noqa: T201
-    for p in all_parties:
-        print(f'ID: {p.id}, Name: {p.name}')  # noqa: T201

--- a/src/onegov/user/auth/provider.py
+++ b/src/onegov/user/auth/provider.py
@@ -43,7 +43,7 @@ if TYPE_CHECKING:
         def namespace(self) -> str: ...
 
 
-AUTHENTICATION_PROVIDERS = {}
+AUTHENTICATION_PROVIDERS: dict[str, type[AuthenticationProvider]] = {}
 
 
 class Conclusion:


### PR DESCRIPTION

## Commit message

PAS: Persist org_type on ParliamentarianRole via meta column


The KUB importer knows whether a role belongs to Kantonsrat, Fraktion,
or Sonstige (via organizationTypeTitle), but this information was
discarded after import. Detecting Kantonsrat membership required a
fragile heuristic checking three columns for NULL.

TYPE: Bugfix
LINK: OGC-3143

## Checklist

- [x] I have performed a self-review of my code

