### PR TITLE
Core: Moves `sentry_tween_factory` over `transaction_tween_factory`

### DIFF
--- a/src/onegov/core/sentry.py
+++ b/src/onegov/core/sentry.py
@@ -6,7 +6,7 @@ import weakref
 
 from onegov.core.framework import Framework
 from onegov.core.orm import DB_CONNECTION_ERRORS
-from morepath.core import excview_tween_factory  # type:ignore[import-untyped]
+from more.transaction.main import transaction_tween_factory
 from sentry_sdk import capture_event, get_client
 from sentry_sdk.integrations import Integration
 from sentry_sdk.integrations._wsgi_common import RequestExtractor
@@ -56,10 +56,14 @@ class OneGovCloudIntegration(Integration):
         #       consider the possibility of monkeypatching morepath
         #       or more specifically morepath.App.publish
         #
-        # NOTE: We need to be on top of the excview_tween so we
-        #       don't forward errors to sentry that have a view
-        #       registered. (mostly webob.exc.HTTPException)
-        @Framework.tween_factory(over=excview_tween_factory)
+        # NOTE: We need to be on top of the transaction_tween, which
+        #       sits on top of excview_tween, so we don't forward
+        #       errors to sentry that have a registered view (mostly
+        #       `webob.exc.HTTPException`) but we always include the
+        #       whole request in the trace, including any potential
+        #       retries due to serialization failures, which may lead
+        #       to a successful request eventually.
+        @Framework.tween_factory(over=transaction_tween_factory)
         def sentry_tween_factory(
             app: Framework,
             handler: Callable[[CoreRequest], Response]

--- a/tests/onegov/feriennet/test_browser.py
+++ b/tests/onegov/feriennet/test_browser.py
@@ -3,10 +3,8 @@ from __future__ import annotations
 import time
 import json
 import pytest
-import os
 
 from datetime import datetime
-from pathlib import Path
 from datetime import timedelta
 from psycopg2.extras import NumericRange
 from pytest import mark
@@ -406,7 +404,6 @@ def test_volunteers_export(
     assert volunteer_export == volunteer_json
 
 
-@pytest.mark.flaky(reruns=3)
 def test_volunteer_subscription(
     browser: ExtendedBrowser,
     scenario: Scenario,
@@ -459,15 +456,10 @@ def test_volunteer_subscription(
     })
     browser.find_by_value("Absenden").click()
 
-    mail = Path(client.app.maildir) / os.listdir(client.app.maildir)[0]
-    with open(mail, 'r') as file:
-        mail_content = file.read()
-        assert (
-            "Sie haben sich als Hilfsperson"
-            in mail_content
-        )
-        assert ("Photography" in mail_content)
-        assert ("Dancing" in mail_content)
+    mail = client.get_email(0, flush_queue=True)
+    assert "Sie haben sich als Hilfsperson" in mail['HtmlBody']
+    assert "Photography" in mail['HtmlBody']
+    assert "Dancing" in mail['HtmlBody']
 
     browser.login_admin()
     browser.visit('/tickets/ALL/open')
@@ -492,14 +484,9 @@ def test_volunteer_subscription(
     assert browser.is_text_present(
         "1 E-Mails erfolgreich gesendet")
 
-    mail = Path(client.app.maildir) / os.listdir(client.app.maildir)[1]
-    with open(mail, 'r') as file:
-        mail_content = file.read()
-        assert (
-            "dies ist die finale Liste"
-            in mail_content
-        )
-        assert ("Photography" in mail_content)
-        assert ("Dancing" in mail_content)
-        assert ("Abgelehnt" in mail_content)
-        assert ("Best\\u00e4tigt" in mail_content)
+    mail = client.get_email(0, flush_queue=True)
+    assert "dies ist die finale Liste" in mail['HtmlBody']
+    assert "Photography" in mail['HtmlBody']
+    assert "Dancing" in mail['HtmlBody']
+    assert "Abgelehnt" in mail['HtmlBody']
+    assert "Bestätigt" in mail['HtmlBody']


### PR DESCRIPTION
## Commit message

Core: Moves `sentry_tween_factory` over `transaction_tween_factory`

This way retries on retryable transaction errors properly show up as
one transaction, instead of separate transactions for each try.

TYPE: Bugfix
LINK: ONEGOV-CLOUD-5FN

## Checklist

- [x] I have performed a self-review of my code
