### PR TITLE
Core: Allows tenant-specific email senders to be configured

### DIFF
--- a/onegov.yml.example
+++ b/onegov.yml.example
@@ -103,14 +103,21 @@ configuration: &global-config
   # marketing e-mail. Though they can both have different configurations
   # Each mail config can write to one of the mail_queues defined in
   # global scope. This could all be the same queue. Use *aliases
-  # to refer to the mail queue &anchors declared above.
+  # to refer to the mail queue &anchors declared above. In addition
+  # individual tenants can override the default sender.
   mail:
     transactional:
       sender: service@onegovcloud.ch
       <<: *local_smtp
+      # tenants:
+      #   "onegov_town6/govikon":
+      #     sender: info@govikon.ch
     marketing:
       sender: newsletters@onegovcloud.ch
       <<: *local_smtp
+      # tenants:
+      #   "onegov_town6/govikon":
+      #     sender: marketing@govikon.ch
 
   # SMS delivery works a little differently from mail delivery, from the onset
   # we assume that each schema has its own queue with its own ASPSM account and

--- a/src/onegov/core/framework.py
+++ b/src/onegov/core/framework.py
@@ -28,7 +28,7 @@ import random
 import sys
 import traceback
 
-from base64 import b64encode
+from base64 import b64encode, urlsafe_b64encode
 from cryptography.fernet import Fernet
 from cryptography.hazmat.primitives.hashes import SHA256
 from cryptography.hazmat.primitives.kdf.hkdf import HKDF
@@ -1002,6 +1002,9 @@ class Framework(
         assert category in ('transactional', 'marketing')
         assert self.mail is not None
         sender = self.mail[category]['sender']
+        tenants = self.mail[category].get('tenants', {})
+        config = tenants.get(self.application_id, {})
+        sender = config.get('sender') or sender
         assert sender
 
         # Postmark requires E-Mails in the marketing stream to contain
@@ -1529,7 +1532,7 @@ class Framework(
         """ Take the sha-256 because we want a key that is 32 bytes long. """
         hash_object = hashlib.sha256()
         hash_object.update(self.identity_secret.encode('utf-8'))
-        return b64encode(hash_object.digest())
+        return urlsafe_b64encode(hash_object.digest())
 
     def encrypt(self, plaintext: str) -> bytes:
         """ Encrypts the given text using Fernet (symmetric encryption).

--- a/tests/onegov/core/test_cli.py
+++ b/tests/onegov/core/test_cli.py
@@ -196,6 +196,7 @@ def test_sendmail(
     assert result.exit_code == 0
     assert len(os.listdir(maildir)) == 0
 
+    app.set_application_id('test/foo')
     app.send_email(
         reply_to='Govikon <info@example.org>',
         receivers=['recipient@example.org'],
@@ -250,6 +251,7 @@ def test_sendmail_invalid_queue(
     maildir = os.path.join(temporary_directory, 'mails')
     app = maildir_app
 
+    app.set_application_id('test/foo')
     app.send_email(
         reply_to='Govikon <info@example.org>',
         receivers=['recipient@example.org'],
@@ -292,6 +294,7 @@ def test_sendmail_smtp(
     assert len(os.listdir(maildir)) == 0
     assert len(smtp.outbox) == 0
 
+    app.set_application_id('test/foo')
     app.send_email(
         reply_to='Govikon <info@example.org>',
         receivers=['recipient@example.org'],
@@ -356,6 +359,7 @@ def test_sendmail_limit(
     assert result.exit_code == 0
     assert len(os.listdir(maildir)) == 0
 
+    app.set_application_id('test/foo')
     app.send_email(
         reply_to='Govikon <info@example.org>',
         receivers=['recipient@example.org'],
@@ -448,6 +452,7 @@ def test_sendmail_exception(
     )
     maildir = os.path.join(temporary_directory, 'mails')
     app = maildir_app
+    app.set_application_id('test/foo')
     app.send_email(
         reply_to='Gövikon <info@example.org>',
         receivers=['recipient@example.org'],

--- a/tests/onegov/core/test_framework.py
+++ b/tests/onegov/core/test_framework.py
@@ -712,13 +712,96 @@ def test_send_email(tmp_path: Path) -> None:
     maildir = tmp_path / 'mail'
     maildir.mkdir()
     app = Framework()
-
+    app.namespace = 'test'
     app.mail = {
         'marketing': {
             'directory': str(maildir),
             'sender': 'noreply@example.org'
         }
     }
+    app.set_application_id('test/foo')
+
+    app.send_email(
+        reply_to='info@example.org',
+        receivers=['recipient@example.org'],
+        subject="Test E-Mail",
+        content='This e-mail is just a test. '
+        '<a href="mailto:unsubscribe@example.org">unsubscribe</a>',
+        headers={'List-Unsubscribe': '<mailto:unsubscribe@example.org>'}
+    )
+
+    transaction.commit()
+
+    files = list(maildir.iterdir())
+    assert len(files) == 1
+    messages = json.loads(files[0].read_text('utf-8'))
+    assert len(messages) == 1
+    message = messages[0]
+
+    assert message['From'] == 'noreply@example.org'
+    assert message['ReplyTo'] == 'info@example.org'
+    assert message['Subject'] == 'Test E-Mail'
+    assert message['MessageStream'] == 'marketing'
+    headers = {h['Name']: h['Value'] for h in message['Headers']}
+    assert headers['List-Unsubscribe'] == '<mailto:unsubscribe@example.org>'
+
+
+def test_send_email_tenants_sender_override(tmp_path: Path) -> None:
+    maildir = tmp_path / 'mail'
+    maildir.mkdir()
+    app = Framework()
+    app.namespace = 'test'
+    app.mail = {
+        'marketing': {
+            'directory': str(maildir),
+            'sender': 'noreply@example.org',
+            'tenants': {
+                'test/foo': {'sender': 'noreply@foo.org'}
+            }
+        }
+    }
+    app.set_application_id('test/foo')
+
+    app.send_email(
+        reply_to='info@example.org',
+        receivers=['recipient@example.org'],
+        subject="Test E-Mail",
+        content='This e-mail is just a test. '
+        '<a href="mailto:unsubscribe@example.org">unsubscribe</a>',
+        headers={'List-Unsubscribe': '<mailto:unsubscribe@example.org>'}
+    )
+
+    transaction.commit()
+
+    files = list(maildir.iterdir())
+    assert len(files) == 1
+    messages = json.loads(files[0].read_text('utf-8'))
+    assert len(messages) == 1
+    message = messages[0]
+
+    assert message['From'] == 'noreply@foo.org'
+    assert message['ReplyTo'] == 'info@example.org'
+    assert message['Subject'] == 'Test E-Mail'
+    assert message['MessageStream'] == 'marketing'
+    headers = {h['Name']: h['Value'] for h in message['Headers']}
+    assert headers['List-Unsubscribe'] == '<mailto:unsubscribe@example.org>'
+
+
+def test_send_email_tenants_no_sender_override(tmp_path: Path) -> None:
+    maildir = tmp_path / 'mail'
+    maildir.mkdir()
+    app = Framework()
+    app.namespace = 'test'
+    app.mail = {
+        'marketing': {
+            'directory': str(maildir),
+            'sender': 'noreply@example.org',
+            'tenants': {
+                'test/foo': {'sender': 'noreply@foo.org'}
+            }
+        }
+    }
+    app.set_application_id('test/foo2')
 
     app.send_email(
         reply_to='info@example.org',
@@ -749,12 +832,14 @@ def test_send_email_with_name(tmp_path: Path) -> None:
     maildir = tmp_path / 'mail'
     maildir.mkdir()
     app = Framework()
+    app.namespace = 'test'
     app.mail = {
         'transactional': {
             'directory': str(maildir),
             'sender': 'noreply@example.org'
         }
     }
+    app.set_application_id('test/foo')
 
     app.send_email(
         reply_to='Govikon <info@example.org>',
@@ -781,12 +866,14 @@ def test_email_attachments(tmp_path: Path) -> None:
     maildir = tmp_path / 'mail'
     maildir.mkdir()
     app = Framework()
+    app.namespace = 'test'
     app.mail = {
         'transactional': {
             'directory': str(maildir),
             'sender': 'noreply@example.org'
         }
     }
+    app.set_application_id('test/foo')
 
     tempfile = NamedTemporaryFile(suffix='.txt', mode='w', delete=False)
     tempfile.write('First')
@@ -938,12 +1025,14 @@ def test_send_email_plaintext_alternative(tmp_path: Path) -> None:
     maildir = tmp_path / 'mail'
     maildir.mkdir()
     app = Framework()
+    app.namespace = 'test'
     app.mail = {
         'transactional': {
             'directory': str(maildir),
             'sender': 'noreply@example.org'
         }
     }
+    app.set_application_id('test/foo')
 
     app.send_email(
         reply_to='Govikon <info@example.org>',
@@ -976,13 +1065,14 @@ def test_send_transactional_email_batch(tmp_path: Path) -> None:
     maildir = tmp_path / 'mail'
     maildir.mkdir()
     app = Framework()
-
+    app.namespace = 'test'
     app.mail = {
         'transactional': {
             'directory': str(maildir),
             'sender': 'noreply@example.org'
         }
     }
+    app.set_application_id('test/foo')
 
     # NOTE: We use plaintext only to speed up the test
     mails = [
@@ -1035,13 +1125,14 @@ def test_send_marketing_email_batch(tmp_path: Path) -> None:
     maildir = tmp_path / 'mail'
     maildir.mkdir()
     app = Framework()
-
+    app.namespace = 'test'
     app.mail = {
         'marketing': {
             'directory': str(maildir),
             'sender': 'noreply@example.org'
         }
     }
+    app.set_application_id('test/foo')
 
     unsubscribe = 'mailto:info@example.org'
 
@@ -1093,13 +1184,14 @@ def test_send_marketing_email_batch_size_limit(tmp_path: Path) -> None:
     maildir = tmp_path / 'mail'
     maildir.mkdir()
     app = Framework()
-
+    app.namespace = 'test'
     app.mail = {
         'marketing': {
             'directory': str(maildir),
             'sender': 'noreply@example.org'
         }
     }
+    app.set_application_id('test/foo')
 
     unsubscribe = 'mailto:info@example.org'
     content = 'a' * 1_000_000  # 1 MB
@@ -1150,7 +1242,7 @@ def test_send_marketing_email_batch_missing_unsubscribe(
     maildir = tmp_path / 'mail'
     maildir.mkdir()
     app = Framework()
-
+    app.namespace = 'test'
     app.mail = {
         'marketing': {
             'directory': str(maildir),
@@ -1161,6 +1253,7 @@ def test_send_marketing_email_batch_missing_unsubscribe(
             'sender': 'noreply@example.org'
         },
     }
+    app.set_application_id('test/foo')
 
     # NOTE: We use plaintext only to speed up the test
     with pytest.raises(AssertionError):
@@ -1179,7 +1272,7 @@ def test_send_marketing_email_batch_illegal_category(tmp_path: Path) -> None:
     maildir = tmp_path / 'mail'
     maildir.mkdir()
     app = Framework()
-
+    app.namespace = 'test'
     app.mail = {
         'marketing': {
             'directory': str(maildir),
@@ -1190,6 +1283,7 @@ def test_send_marketing_email_batch_illegal_category(tmp_path: Path) -> None:
             'sender': 'noreply@example.org'
         },
     }
+    app.set_application_id('test/foo')
 
     # NOTE: We use plaintext only to speed up the test
     mails = [

--- a/tests/onegov/org/test_app.py
+++ b/tests/onegov/org/test_app.py
@@ -36,6 +36,7 @@ def test_send_email(maildir: str) -> None:
             )
 
     app = App()
+    app.namespace = 'test'
     app.mail = {
         'marketing': {
             'directory': maildir,
@@ -46,6 +47,7 @@ def test_send_email(maildir: str) -> None:
             'sender': 'mails@govikon.ch'
         }
     }
+    app.set_application_id('test/foo')
     app.maildir = maildir  # type: ignore[attr-defined]
     client = Client(app)
 


### PR DESCRIPTION
## Commit message

Core: Allows tenant-specific email senders to be configured

TYPE: Feature
LINK: OGC-3078

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes/features
