### PR TITLE
PAS: Restrict attendance forms to active Kantonsrat members

### DIFF
--- a/src/onegov/pas/cli.py
+++ b/src/onegov/pas/cli.py
@@ -15,7 +15,10 @@ from onegov.pas.excel_header_constants import (
     commission_expected_headers_variant_2,
 )
 from onegov.pas.data_import import import_commissions_excel
-from onegov.pas.utils import is_active_kantonsrat_member
+from onegov.pas.utils import (
+    fetch_clex_kantonsrat_members,
+    is_active_kantonsrat_member,
+)
 from onegov.pas.log import ClickOutputHandler, CompositeOutputHandler
 from onegov.pas.importer.output_handlers import DatabaseOutputHandler
 from onegov.pas.importer.orchestrator import (
@@ -27,6 +30,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from collections.abc import Callable
     from onegov.pas.app import PasApp
+    from onegov.pas.models.parliamentarian import PASParliamentarian
     from onegov.pas.request import PasRequest
 
     type Processor = Callable[[PasRequest, PasApp], None]
@@ -325,14 +329,25 @@ def sync_user_accounts_cli(dry_run: bool) -> Processor:
 
 
 @cli.command('list-kantonsrat', context_settings={'singular': True})
-def list_kantonsrat_cli() -> Processor:
+@click.option(
+    '--compare-clex',
+    is_flag=True,
+    default=False,
+    help='Compare internal list against CLEX frontend',
+)
+def list_kantonsrat_cli(compare_clex: bool) -> Processor:
     """List parliamentarians by Kantonsrat membership status.
 
-    Shows who has an active Kantonsrat role (no party, no group,
-    no additional_information, end is NULL or >= today).
+    Shows who has an active Kantonsrat role (meta.org_type ==
+    'Kantonsrat', end is NULL or >= today).
+
+    With --compare-clex, fetches the public member table from
+    zg-compwork.clex.ch and shows differences.
 
     Example:
         onegov-pas --select '/onegov_pas/zug' list-kantonsrat
+        onegov-pas --select '/onegov_pas/zug' list-kantonsrat \
+            --compare-clex
     """
 
     def do_list(request: PasRequest, app: PasApp) -> None:
@@ -379,7 +394,59 @@ def list_kantonsrat_cli() -> Processor:
             f'Not in: {len(not_in_kantonsrat)}'
         )
 
+        if compare_clex:
+            _compare_with_clex(in_kantonsrat, today)
+
     return do_list
+
+
+def _compare_with_clex(
+    internal: list[PASParliamentarian],
+    reference_date: date,
+) -> None:
+    from onegov.pas.utils import CLEX_URL
+
+    click.secho(
+        f'\n=== CLEX comparison ({CLEX_URL}) ===',
+        fg='cyan',
+    )
+    try:
+        clex_members = fetch_clex_kantonsrat_members(reference_date)
+    except Exception as e:
+        click.secho(f'Failed to fetch CLEX data: {e}', fg='red')
+        return
+
+    internal_set = {(p.last_name, p.first_name) for p in internal}
+
+    only_internal = sorted(internal_set - clex_members)
+    only_clex = sorted(clex_members - internal_set)
+
+    if not only_internal and not only_clex:
+        click.secho('Lists match perfectly.', fg='green')
+        return
+
+    if only_internal:
+        click.secho(
+            f'\nOnly in internal DB ({len(only_internal)}):',
+            fg='yellow',
+        )
+        for last, first in only_internal:
+            click.echo(f'  {last}, {first}')
+
+    if only_clex:
+        click.secho(
+            f'\nOnly on CLEX ({len(only_clex)}):',
+            fg='yellow',
+        )
+        for last, first in only_clex:
+            click.echo(f'  {last}, {first}')
+
+    click.echo(
+        f'\nInternal: {len(internal_set)} | '
+        f'CLEX: {len(clex_members)} | '
+        f'Only internal: {len(only_internal)} | '
+        f'Only CLEX: {len(only_clex)}'
+    )
 
 
 @cli.command('update-custom-data')

--- a/src/onegov/pas/forms/attendence.py
+++ b/src/onegov/pas/forms/attendence.py
@@ -12,6 +12,10 @@ from onegov.pas import _
 from onegov.pas.custom import get_current_settlement_run
 from onegov.pas.collections import PASCommissionCollection
 from onegov.pas.collections import PASParliamentarianCollection
+from onegov.pas.utils import (
+    get_active_kantonsrat_parliamentarians,
+    is_active_kantonsrat_member,
+)
 from onegov.pas.custom import AttendenceCollection
 from onegov.pas.models import PASCommissionMembership, SettlementRun
 from onegov.pas.models.attendence import TYPES
@@ -285,10 +289,10 @@ class AttendenceForm(Form, SettlementRunBoundMixin):
                 self.request.warn_no_parliamentarian()  # type:ignore[attr-defined]
         else:
             self.parliamentarian_id.choices = [
-                (str(parliamentarian.id), parliamentarian.title)
-                for parliamentarian in PASParliamentarianCollection(
+                (str(p.id), p.title)
+                for p in get_active_kantonsrat_parliamentarians(
                     self.request.app
-                ).query()
+                )
             ]
 
         # Filter commission choices based on user role
@@ -377,11 +381,11 @@ class AttendenceAddForm(AttendenceForm):
             else:
                 self.parliamentarian_id.choices = []
         else:
-            # Admins, editors can select any active parliamentarian
             self.parliamentarian_id.choices = [
-                (str(parliamentarian.id), parliamentarian.title)
-                for parliamentarian in PASParliamentarianCollection(
-                    self.request.app, active=[True]).query()
+                (str(p.id), p.title)
+                for p in get_active_kantonsrat_parliamentarians(
+                    self.request.app
+                )
             ]
 
 
@@ -411,10 +415,8 @@ class AttendenceAddPlenaryForm(Form, SettlementRunBoundMixin):
     def on_request(self) -> None:
         self.set_default_value_to_settlement_run_start()
         self.parliamentarian_id.choices = [
-            (str(parliamentarian.id), parliamentarian.title)
-            for parliamentarian
-            in PASParliamentarianCollection(
-                self.request.app, active=[True]).query()
+            (str(p.id), p.title)
+            for p in get_active_kantonsrat_parliamentarians(self.request.app)
         ]
         self.parliamentarian_id.data = [
             choice[0] for choice in self.parliamentarian_id.choices
@@ -476,14 +478,10 @@ class AttendenceAddCommissionBulkForm(Form, SettlementRunBoundMixin):
             for commission
             in PASCommissionCollection(self.request.session).query()
         ]
-        # Set choices for all possible parliamentarians so WTForms can validate
         self.parliamentarian_id.choices = [
-            (str(parliamentarian.id), parliamentarian.title)
-            for parliamentarian
-            in PASParliamentarianCollection(
-                self.request.app, active=[True]).query()
+            (str(p.id), p.title)
+            for p in get_active_kantonsrat_parliamentarians(self.request.app)
         ]
-        # JavaScript will handle selection based on commission
         self.parliamentarian_id.data = []
 
         self.request.warn_no_parliamentarian()  # type: ignore[attr-defined]
@@ -537,12 +535,9 @@ class AttendenceEditBulkForm(Form, SettlementRunBoundMixin):
             for commission
             in PASCommissionCollection(self.request.session).query()
         ]
-        # Set choices for all possible parliamentarians so WTForms can validate
         self.parliamentarian_id.choices = [
-            (str(parliamentarian.id), parliamentarian.title)
-            for parliamentarian
-            in PASParliamentarianCollection(
-                self.request.app, active=[True]).query()
+            (str(p.id), p.title)
+            for p in get_active_kantonsrat_parliamentarians(self.request.app)
         ]
 
 
@@ -565,6 +560,7 @@ class AttendenceCommissionBulkEditForm(AttendenceEditBulkForm):
         self.parliamentarian_id.choices = [
             (str(m.parliamentarian.id), m.parliamentarian.title)
             for m in memberships
+            if is_active_kantonsrat_member(m.parliamentarian)
         ]
 
         self.duration.data = obj.duration / 60
@@ -622,10 +618,8 @@ class AttendencePlenaryBulkEditForm(AttendenceEditBulkForm):
         ]
 
         self.parliamentarian_id.choices = [
-            (str(parliamentarian.id), parliamentarian.title)
-            for parliamentarian
-            in PASParliamentarianCollection(
-                self.request.app, active=[True]).query()
+            (str(p.id), p.title)
+            for p in get_active_kantonsrat_parliamentarians(self.request.app)
         ]
 
         self.parliamentarian_id.data = [

--- a/src/onegov/pas/utils.py
+++ b/src/onegov/pas/utils.py
@@ -9,14 +9,25 @@ from onegov.pas.models.parliamentarian_role import PASParliamentarianRole
 from onegov.pas.models.presidential_allowance import (
     PresidentialAllowance,
 )
+from onegov.pas.collections import PASParliamentarianCollection
 from decimal import Decimal, ROUND_HALF_UP
 from babel.numbers import format_decimal
 from datetime import date
+from lxml import html
 from uuid import UUID
 
+import requests
+
+
+from sqlalchemy.orm import selectinload
 
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:
+    from onegov.core import Framework
+    from onegov.parliament.models.parliamentarian import Parliamentarian
+    from onegov.parliament.models.parliamentarian_role import (
+        ParliamentarianRole,
+    )
     from onegov.pas.models import SettlementRun
     from onegov.pas.models.attendence import Attendence
     from onegov.user import User
@@ -24,26 +35,19 @@ if TYPE_CHECKING:
 
 
 def _is_kantonsrat_role(
-    role: PASParliamentarianRole,
+    role: PASParliamentarianRole | ParliamentarianRole,
 ) -> bool:
     """A Kantonsrat role has meta.org_type == 'Kantonsrat' (set
-    by the KUB importer). Falls back to the legacy heuristic
-    (all of party_id, parliamentary_group_id, and
-    additional_information being NULL) for rows imported before
-    org_type was persisted.
+    by the KUB importer).
     """
     org_type = role.meta.get('org_type')
     if org_type is not None:
         return org_type == 'Kantonsrat'
-    return (
-        role.party_id is None
-        and role.parliamentary_group_id is None
-        and role.additional_information is None
-    )
+    return False
 
 
 def is_active_kantonsrat_member(
-    parliamentarian: PASParliamentarian,
+    parliamentarian: PASParliamentarian | Parliamentarian,
     reference_date: date | None = None,
 ) -> bool:
     if reference_date is None:
@@ -52,6 +56,67 @@ def is_active_kantonsrat_member(
         _is_kantonsrat_role(r) and (r.end is None or r.end >= reference_date)
         for r in parliamentarian.roles
     )
+
+
+def get_active_kantonsrat_parliamentarians(
+    app: Framework,
+    reference_date: date | None = None,
+) -> list[PASParliamentarian]:
+    parliamentarians = (
+        PASParliamentarianCollection(app)
+        .query()
+        .options(selectinload(PASParliamentarian.roles))
+        .all()
+    )
+    return [
+        p
+        for p in parliamentarians
+        if is_active_kantonsrat_member(p, reference_date)
+    ]
+
+
+CLEX_URL = 'https://zg-compwork.clex.ch/frontend/people'
+
+
+def fetch_clex_kantonsrat_members(
+    reference_date: date | None = None,
+) -> set[tuple[str, str]]:
+    """Fetch active Kantonsrat members from the CLEX frontend.
+
+    Returns set of (last_name, first_name) tuples for members
+    without an exit date or with an exit date >= reference_date.
+    """
+    if reference_date is None:
+        reference_date = date.today()
+
+    resp = requests.get(CLEX_URL, timeout=30)
+    resp.raise_for_status()
+
+    tree = html.fromstring(resp.content)
+    rows = tree.xpath('//table//tr')
+
+    members: set[tuple[str, str]] = set()
+    for row in rows:
+        cells = row.xpath('td')
+        if len(cells) < 6:
+            continue
+        last_name = (cells[1].text_content() or '').strip()
+        first_name = (cells[2].text_content() or '').strip()
+        exit_text = (cells[6].text_content() or '').strip()
+        if not last_name:
+            continue
+
+        if exit_text and exit_text != '—':
+            try:
+                parts = exit_text.split('.')
+                exit_date = date(int(parts[2]), int(parts[1]), int(parts[0]))
+                if exit_date < reference_date:
+                    continue
+            except (ValueError, IndexError):
+                pass
+
+        members.add((last_name, first_name))
+    return members
 
 
 def format_swiss_number(value: Decimal | int) -> str:

--- a/src/onegov/pas/views/attendence.py
+++ b/src/onegov/pas/views/attendence.py
@@ -12,7 +12,6 @@ from onegov.pas import _
 from onegov.pas import PasApp
 from onegov.pas.collections import (
     AttendenceCollection,
-    PASParliamentarianCollection,
     SettlementRunCollection,
 )
 from onegov.pas.custom import (
@@ -31,6 +30,10 @@ from onegov.pas.models import Change
 from onegov.pas.models import SettlementRun
 from onegov.pas.models.attendence import TYPES
 from onegov.pas.models.commission_membership import PASCommissionMembership
+from onegov.pas.utils import (
+    get_active_kantonsrat_parliamentarians,
+    is_active_kantonsrat_member,
+)
 
 
 from typing import TYPE_CHECKING
@@ -360,10 +363,7 @@ def edit_plenary_bulk_attendence(
         return request.redirect(request.class_link(AttendenceCollection))
 
     all_parliamentarians = [
-        str(parliamentarian.id)
-        for parliamentarian
-        in PASParliamentarianCollection(
-            request.app, active=[True]).query()
+        str(p.id) for p in get_active_kantonsrat_parliamentarians(request.app)
     ]
 
     if form.submitted(request):
@@ -504,6 +504,7 @@ def edit_commission_bulk_attendence(
             commission_parliamentarians = [
                 str(membership.parliamentarian_id)
                 for membership in memberships
+                if is_active_kantonsrat_member(membership.parliamentarian)
             ]
             unselected_parliamentarians = [
                 pid for pid in commission_parliamentarians

--- a/src/onegov/pas/views/commission.py
+++ b/src/onegov/pas/views/commission.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from datetime import date
 from itertools import groupby
 
 from onegov.core.elements import Link
@@ -10,7 +11,9 @@ from onegov.pas.layouts import PASCommissionCollectionLayout
 from onegov.pas.layouts import PASCommissionLayout
 from onegov.pas.models import PASCommission
 from onegov.pas.models import PASCommissionMembership
+from onegov.pas.utils import is_active_kantonsrat_member
 from onegov.user import User
+from sqlalchemy import or_
 
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:
@@ -107,10 +110,6 @@ def commissions_parliamentarians_json(
     self: PASCommissionCollection, request: TownRequest
 ) -> JSON_ro:
     """Returns all commissions with their parliamentarians."""
-    # TODO: Should we consider all that have been active in
-    # current settlement run to be more precise?
-    # It might happen that some have been active just recently
-    # but not anymore, these will not be selectable currently.
     if not request.is_admin:
         if (not hasattr(request.identity, 'role')
             or request.identity.role not in (
@@ -118,7 +117,17 @@ def commissions_parliamentarians_json(
             return {}
 
     session = request.session
-    memberships = session.query(PASCommissionMembership).all()
+    today = date.today()
+    memberships = (
+        session.query(PASCommissionMembership)
+        .filter(
+            or_(
+                PASCommissionMembership.end.is_(None),
+                PASCommissionMembership.end >= today,
+            )
+        )
+        .all()
+    )
 
     # If user is parliamentarian, filter to only their commissions
     if (hasattr(request.identity, 'role')
@@ -182,6 +191,7 @@ def commissions_parliamentarians_json(
                 'title': m.parliamentarian.title
             }
             for m in group
+            if is_active_kantonsrat_member(m.parliamentarian)
         ]
         for commission_id, group in groupby(sorted_memberships, key=key_func)
     }

--- a/tests/onegov/pas/test_forms.py
+++ b/tests/onegov/pas/test_forms.py
@@ -108,7 +108,11 @@ def test_attendence_forms(session: Session, dummy_admin_request: Any) -> None:
     parliamentarians.add(first_name='p', last_name='q')
 
     roles = PASParliamentarianRoleCollection(session)
-    roles.add(parliamentarian_id=parliamentarian.id, end=date(2023, 1, 1))
+    roles.add(
+        parliamentarian_id=parliamentarian.id,
+        end=date(2025, 1, 1),
+        meta={'org_type': 'Kantonsrat'},
+    )
 
     commissions = PASCommissionCollection(session)
     commission = commissions.add(name='x')
@@ -120,7 +124,7 @@ def test_attendence_forms(session: Session, dummy_admin_request: Any) -> None:
     form.request = dummy_admin_request
     form.on_request()
 
-    assert len(form.parliamentarian_id.choices) == 2
+    assert len(form.parliamentarian_id.choices) == 1
     assert len(form.commission_id.choices) == 4
 
     form = AttendenceAddForm()
@@ -232,7 +236,11 @@ def test_add_plenary_attendence_form(
     parliamentarians.add(first_name='p', last_name='q')
 
     roles = PASParliamentarianRoleCollection(session)
-    roles.add(parliamentarian_id=parliamentarian.id, end=date(2023, 1, 1))
+    roles.add(
+        parliamentarian_id=parliamentarian.id,
+        end=date(2025, 1, 1),
+        meta={'org_type': 'Kantonsrat'},
+    )
 
     # on request
     form = AttendenceAddPlenaryForm()

--- a/tests/onegov/pas/test_views.py
+++ b/tests/onegov/pas/test_views.py
@@ -112,6 +112,7 @@ def test_views_manage(client_with_fts: Client[TestPasApp]) -> None:
             parliamentarian_id=parl.id,
             role='member',
             start=datetime.date(2020, 1, 1),
+            meta={'org_type': 'Kantonsrat'},
         )
     )
 
@@ -437,6 +438,7 @@ def test_simple_attendence_add(client: Client[TestPasApp]) -> None:
             parliamentarian_id=parl.id,
             role='member',
             start=datetime.date(2020, 1, 1),
+            meta={'org_type': 'Kantonsrat'},
         )
     )
 
@@ -520,6 +522,15 @@ def test_attendance_blocked_outside_any_settlement_run(
 
     commissions = PASCommissionCollection(session)
     commission = commissions.add(name='Test Commission')
+
+    session.add(
+        PASParliamentarianRole(
+            parliamentarian_id=parl.id,
+            role='member',
+            start=datetime.date(2020, 1, 1),
+            meta={'org_type': 'Kantonsrat'},
+        )
+    )
 
     memberships = PASCommissionMembershipCollection(session)
     memberships.add(
@@ -613,6 +624,13 @@ def test_fetch_commissions_parliamentarians_json(
         last_name='Johnson',
     )
 
+    for p in (parl1, parl2, parl3):
+        session.add(PASParliamentarianRole(
+            parliamentarian_id=p.id,
+            role='member',
+            meta={'org_type': 'Kantonsrat'},
+        ))
+
     memberships = PASCommissionMembershipCollection(session)
 
     # Commission A has John and Jane
@@ -682,6 +700,11 @@ def test_fetch_commissions_parliamentarians_json(
         email_primary='alice.president@example.org',
         zg_username='zgalice',
     )
+    session.add(PASParliamentarianRole(
+        parliamentarian_id=parl_president.id,
+        role='member',
+        meta={'org_type': 'Kantonsrat'},
+    ))
 
     # Add president to Commission A (using the ID we saved earlier)
     president_membership = PASCommissionMembership(
@@ -872,6 +895,13 @@ def test_settlement_run_complete_translation(
     commissions = PASCommissionCollection(session)
     commission = commissions.add(name='TestCommission')
 
+    session.add(PASParliamentarianRole(
+        parliamentarian_id=parl.id,
+        role='member',
+        start=datetime.date(2020, 1, 1),
+        meta={'org_type': 'Kantonsrat'},
+    ))
+
     memberships = PASCommissionMembershipCollection(session)
     memberships.add(
         commission_id=commission.id,
@@ -932,6 +962,13 @@ def test_commission_president_bulk_add(
         email_primary='alice.president@example.org',
         zg_username='zgalice',
     )
+
+    for p in (bob, alice):
+        session.add(PASParliamentarianRole(
+            parliamentarian_id=p.id,
+            role='member',
+            meta={'org_type': 'Kantonsrat'},
+        ))
 
     commissions = PASCommissionCollection(session)
     commission = commissions.add(name='Finanzkommission')
@@ -1122,6 +1159,13 @@ def test_abschluss_email_uses_commission_name(
         last_name='Muster',
         email_primary='max.muster@example.org',
     )
+
+    session.add(PASParliamentarianRole(
+        parliamentarian_id=parl.id,
+        role='member',
+        start=datetime.date(2024, 1, 1),
+        meta={'org_type': 'Kantonsrat'},
+    ))
 
     commissions = PASCommissionCollection(session)
     commission = commissions.add(name='Finanzkommission')


### PR DESCRIPTION
Bulk-add and edit forms previously showed all active parliamentarians regardless of Kantonsrat membership. Now filters using org_type metadata set by the KUB importer, ensuring only actual Kantonsrat members appear in attendance selection.

TYPE: Bugfix
LINK: OGC-2949
