### PR TITLE
Propagate psql error while updating search index

### DIFF
--- a/src/onegov/core/framework.py
+++ b/src/onegov/core/framework.py
@@ -67,7 +67,8 @@ from psycopg2.extensions import TransactionRollbackError
 from purl import URL
 from sqlalchemy.exc import OperationalError
 from urllib.parse import urlencode
-from webob.exc import HTTPConflict, HTTPServiceUnavailable
+from translationstring import TranslationString
+from webob.exc import HTTPConflict, HTTPSeeOther, HTTPServiceUnavailable
 
 
 from typing import overload, Any, Literal, TYPE_CHECKING
@@ -1771,6 +1772,24 @@ def http_conflict_tween_factory(
                 raise
 
             log.warning('A transaction failed because there was a conflict')
+
+            # Redis-backed browser_session is not rolled back with the postgres
+            # transaction, so stale flash messages must be cleared manually.
+            request.browser_session.pop('messages', None)
+
+            # POST form: redirect back so user sees the alert and can retry.
+            if (request.method == 'POST'
+                    and not request.is_xhr
+                    and request.content_type in (
+                        'application/x-www-form-urlencoded',
+                        'multipart/form-data',
+                    )):
+                request.alert(request.translate(TranslationString(
+                    'Your request could not be completed because of a '
+                    'simultaneous conflicting request. Please try again.',
+                    domain='onegov.org'
+                )))
+                return HTTPSeeOther(location=request.path)
 
             return HTTPConflict()
 

--- a/src/onegov/org/locale/de_CH/LC_MESSAGES/onegov.org.po
+++ b/src/onegov/org/locale/de_CH/LC_MESSAGES/onegov.org.po
@@ -6816,6 +6816,14 @@ msgstr "Ihre Veranstaltung wurde abgelehnt"
 msgid "Access Denied"
 msgstr "Zugriff verweigert"
 
+msgid ""
+"Your request could not be completed because of a simultaneous conflicting "
+"request. Please try again."
+msgstr ""
+"Ihre Anfrage konnte nicht abgeschlossen werden, da gleichzeitig eine "
+"konfliktverursachende Anfrage verarbeitet wurde. Bitte versuchen Sie es "
+"erneut."
+
 msgid "Not Found"
 msgstr "Seite nicht gefunden"
 

--- a/src/onegov/org/locale/fr_CH/LC_MESSAGES/onegov.org.po
+++ b/src/onegov/org/locale/fr_CH/LC_MESSAGES/onegov.org.po
@@ -6828,6 +6828,13 @@ msgstr "Votre événement a été rejeté"
 msgid "Access Denied"
 msgstr "Accès refusé"
 
+msgid ""
+"Your request could not be completed because of a simultaneous conflicting "
+"request. Please try again."
+msgstr ""
+"Votre demande n'a pas pu être traitée en raison d'une demande conflictuelle "
+"simultanée. Veuillez réessayer."
+
 msgid "Not Found"
 msgstr "Pas trouvé"
 

--- a/src/onegov/org/locale/it_CH/LC_MESSAGES/onegov.org.po
+++ b/src/onegov/org/locale/it_CH/LC_MESSAGES/onegov.org.po
@@ -6791,6 +6791,13 @@ msgstr "Il tuo evento è stato rifiutato"
 msgid "Access Denied"
 msgstr "Accesso negato"
 
+msgid ""
+"Your request could not be completed because of a simultaneous conflicting "
+"request. Please try again."
+msgstr ""
+"La sua richiesta non ha potuto essere completata a causa di una richiesta "
+"conflittuale simultanea. La preghiamo di riprovare."
+
 msgid "Not Found"
 msgstr "Non trovato"
 

--- a/src/onegov/search/indexer.py
+++ b/src/onegov/search/indexer.py
@@ -12,6 +12,7 @@ from onegov.search.utils import language_from_locale
 from operator import itemgetter
 from psycopg2.extensions import TransactionRollbackError
 from sqlalchemy import and_, bindparam, delete, func, text, String
+from sqlalchemy.exc import OperationalError
 from sqlalchemy.orm import object_session
 from sqlalchemy.orm.exc import ObjectDeletedError
 from sqlalchemy.dialects.postgresql import insert, ARRAY
@@ -65,11 +66,11 @@ def _transaction_abort_error(exc: BaseException) -> BaseException | None:
     # InFailedSqlTransaction 25P02). Prefer returning the SA OperationalError
     # so http_conflict_tween can turn it into a 409; fall back to the raw
     # psycopg2 error otherwise.
-    from sqlalchemy.exc import OperationalError
     seen: set[int] = set()
     queue: list[BaseException | None] = [exc]
     sa_error: BaseException | None = None
     raw_error: BaseException | None = None
+
     while queue:
         current = queue.pop()
         if current is None or id(current) in seen:
@@ -91,6 +92,7 @@ def _transaction_abort_error(exc: BaseException) -> BaseException | None:
             raw_error = orig
         queue.append(current.__cause__)
         queue.append(current.__context__)
+
     return sa_error or raw_error
 
 
@@ -338,6 +340,9 @@ class Indexer:
             )
             abort_error = _transaction_abort_error(e)
             if abort_error is not None:
+                if abort_error is e:
+                    raise
+                # abort outer tx; SA OperationalError → 409
                 raise abort_error from e
             return False
 
@@ -417,6 +422,9 @@ class Indexer:
             )
             abort_error = _transaction_abort_error(e)
             if abort_error is not None:
+                if abort_error is e:
+                    raise
+                # abort outer tx; SA OperationalError → 409
                 raise abort_error from e
             return False
 

--- a/src/onegov/search/indexer.py
+++ b/src/onegov/search/indexer.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import psycopg2.errors
 import re
 
 from itertools import groupby
@@ -9,6 +10,7 @@ from onegov.search.datamanager import IndexerDataManager
 from onegov.search.search_index import SearchIndex
 from onegov.search.utils import language_from_locale
 from operator import itemgetter
+from psycopg2.extensions import TransactionRollbackError
 from sqlalchemy import and_, bindparam, delete, func, text, String
 from sqlalchemy.orm import object_session
 from sqlalchemy.orm.exc import ObjectDeletedError
@@ -55,6 +57,41 @@ if TYPE_CHECKING:
         | InstrumentedAttribute[int | None]
         | InstrumentedAttribute[str | None]
     )
+
+
+def _transaction_abort_error(exc: BaseException) -> BaseException | None:
+    # Walk __cause__/__context__ chains for evidence the outer PG transaction
+    # was aborted (serialization failure 40xxx, deadlock,
+    # InFailedSqlTransaction 25P02). Prefer returning the SA OperationalError
+    # so http_conflict_tween can turn it into a 409; fall back to the raw
+    # psycopg2 error otherwise.
+    from sqlalchemy.exc import OperationalError
+    seen: set[int] = set()
+    queue: list[BaseException | None] = [exc]
+    sa_error: BaseException | None = None
+    raw_error: BaseException | None = None
+    while queue:
+        current = queue.pop()
+        if current is None or id(current) in seen:
+            continue
+        seen.add(id(current))
+        orig = getattr(current, 'orig', None)
+        if sa_error is None and isinstance(current, OperationalError):
+            if isinstance(orig, TransactionRollbackError):
+                sa_error = current
+        if raw_error is None and isinstance(current, (
+            TransactionRollbackError,
+            psycopg2.errors.InFailedSqlTransaction,
+        )):
+            raw_error = current
+        if raw_error is None and isinstance(orig, (
+            TransactionRollbackError,
+            psycopg2.errors.InFailedSqlTransaction,
+        )):
+            raw_error = orig
+        queue.append(current.__cause__)
+        queue.append(current.__context__)
+    return sa_error or raw_error
 
 
 class Indexer:
@@ -291,13 +328,17 @@ class Indexer:
                 # will not be able to infer the matching constraint
                 index_where=owner_id_column.is_not(None)
             )
+
             with session.begin_nested():
                 session.execute(stmt, list(params_dict.values()))
-        except Exception:
+        except Exception as e:
             index_log.exception(
                 f'Error creating index schema {schema} of '
                 f'table {tablename}, tasks: {[t["id"] for t in tasks]}',
             )
+            abort_error = _transaction_abort_error(e)
+            if abort_error is not None:
+                raise abort_error from e
             return False
 
         return True
@@ -370,10 +411,13 @@ class Indexer:
             )
             with session.begin_nested():
                 session.execute(stmt)
-        except Exception:
+        except Exception as e:
             index_log.exception(
                 f'Error deleting index schema {schema} tasks {tasks}:'
             )
+            abort_error = _transaction_abort_error(e)
+            if abort_error is not None:
+                raise abort_error from e
             return False
 
         return True

--- a/tests/onegov/search/test_indexer.py
+++ b/tests/onegov/search/test_indexer.py
@@ -15,7 +15,11 @@ from onegov.search.indexer import (
     TypeMappingRegistry
 )
 from onegov.search.search_index import SearchIndex
+from typing import TYPE_CHECKING
 from unittest.mock import patch, Mock, MagicMock
+
+if TYPE_CHECKING:
+    from onegov.search.indexer import DeleteTask, IndexTask
 
 
 from typing import Any, TYPE_CHECKING
@@ -436,7 +440,8 @@ def test_indexer_reraises_on_transaction_abort(
     caplog: pytest.LogCaptureFixture
 ) -> None:
     """index()/delete() must log and re-raise on transaction abort so
-    tpc_abort() suppresses queued emails and http_conflict_tween returns 409.
+    tpc_abort() suppresses queued emails. When abort_error is an SA
+    OperationalError, http_conflict_tween additionally returns 409.
     """
     from sqlalchemy.exc import OperationalError as SAOperationalError
 
@@ -446,7 +451,7 @@ def test_indexer_reraises_on_transaction_abort(
     }, 'title')
     indexer = Indexer(mappings)
 
-    index_task: dict = {
+    index_task: IndexTask = {
         'action': 'index',
         'schema': 'test',
         'tablename': 'my-pages',
@@ -464,7 +469,7 @@ def test_indexer_reraises_on_transaction_abort(
         'title': 'Test',
         'properties': {'title': 'Test'},
     }
-    delete_task: dict = {
+    delete_task: DeleteTask = {
         'action': 'delete',
         'schema': 'test',
         'tablename': 'my-pages',
@@ -521,10 +526,15 @@ def test_indexer_reraises_on_transaction_abort(
         session = make_session(execute_error, abort_savepoint=True)
         with caplog.at_level(logging.ERROR, logger='onegov.search.index'):
             caplog.clear()
-            with pytest.raises(SAOperationalError):
-                method(task, session)
+            with pytest.raises(SAOperationalError) as exc_info:
+                method(task, session)  # type: ignore[arg-type]
             assert caplog.records, (
                 f'{method.__name__} did not log the serialization failure'
+            )
+            # abort_error is not e → raise abort_error from e;
+            assert isinstance(
+                exc_info.value.__cause__,
+                psycopg2.errors.InFailedSqlTransaction,
             )
 
     # Scenario 2: execute() raises bare InFailedSqlTransaction — matches the
@@ -541,11 +551,15 @@ def test_indexer_reraises_on_transaction_abort(
         session = make_session(in_failed, abort_savepoint=False)
         with caplog.at_level(logging.ERROR, logger='onegov.search.index'):
             caplog.clear()
-            with pytest.raises(psycopg2.errors.InFailedSqlTransaction):
-                method(task, session)
+            with pytest.raises(
+                psycopg2.errors.InFailedSqlTransaction
+            ) as exc_info2:
+                method(task, session)  # type: ignore[arg-type]
             assert caplog.records, (
                 f'{method.__name__} did not log the InFailedSqlTransaction'
             )
+            # abort_error is e → bare raise
+            assert exc_info2.value.__cause__ is None
 
     # Non-abort errors must be swallowed → return False.
     for method, task in (
@@ -555,4 +569,4 @@ def test_indexer_reraises_on_transaction_abort(
         session = make_session(
             RuntimeError('unexpected'), abort_savepoint=False
         )
-        assert method(task, session) is False
+        assert method(task, session) is False  # type: ignore[arg-type]

--- a/tests/onegov/search/test_indexer.py
+++ b/tests/onegov/search/test_indexer.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import psycopg2.errors
 import pytest
 import transaction
 
@@ -14,7 +15,7 @@ from onegov.search.indexer import (
     TypeMappingRegistry
 )
 from onegov.search.search_index import SearchIndex
-from unittest.mock import patch, Mock
+from unittest.mock import patch, Mock, MagicMock
 
 
 from typing import Any, TYPE_CHECKING
@@ -429,3 +430,129 @@ def test_tags(
     assert indexer.process([task], session)
 
     # TODO search indexed entry using search index via tags
+
+
+def test_indexer_reraises_on_transaction_abort(
+    caplog: pytest.LogCaptureFixture
+) -> None:
+    """index()/delete() must log and re-raise on transaction abort so
+    tpc_abort() suppresses queued emails and http_conflict_tween returns 409.
+    """
+    from sqlalchemy.exc import OperationalError as SAOperationalError
+
+    mappings = TypeMappingRegistry()
+    mappings.register_type('Page', {
+        'title': {'type': 'localized', 'weight': 'A'},
+    }, 'title')
+    indexer = Indexer(mappings)
+
+    index_task: dict = {
+        'action': 'index',
+        'schema': 'test',
+        'tablename': 'my-pages',
+        'id': 1,
+        'id_key': 'id',
+        'owner_type': 'Page',
+        'access': 'public',
+        'public': True,
+        'last_change': None,
+        'publication_start': None,
+        'publication_end': None,
+        'suggestion': [],
+        'tags': [],
+        'language': 'en',
+        'title': 'Test',
+        'properties': {'title': 'Test'},
+    }
+    delete_task: dict = {
+        'action': 'delete',
+        'schema': 'test',
+        'tablename': 'my-pages',
+        'owner_type': 'Page',
+        'id': 1,
+    }
+
+    def make_session(
+        execute_error: BaseException,
+        abort_savepoint: bool
+    ) -> Mock:
+        # abort_savepoint=True: __exit__ raises InFailedSqlTransaction,
+        # mirroring the failed ROLLBACK TO SAVEPOINT after a serialization
+        # failure aborts the outer PG transaction.
+        session = Mock()
+
+        ctx = MagicMock()
+        ctx.__enter__ = Mock(return_value=ctx)
+
+        if abort_savepoint:
+            def exit_raises_in_failed(
+                exc_type: object,
+                exc_val: object,
+                exc_tb: object
+            ) -> bool:
+                if exc_val is not None:
+                    raise psycopg2.errors.InFailedSqlTransaction(
+                        'current transaction is aborted, commands ignored '
+                        'until end of transaction block'
+                    )
+                return False
+            ctx.__exit__ = Mock(side_effect=exit_raises_in_failed)
+        else:
+            ctx.__exit__ = Mock(return_value=False)
+
+        session.begin_nested.return_value = ctx
+        session.execute.side_effect = execute_error
+        return session
+
+    # Scenario 1: execute() raises OperationalError(SerializationFailure),
+    # __exit__ raises InFailedSqlTransaction — matches the 'attendees' entry
+    # in the production logs. Must re-raise SAOperationalError for 409.
+    for method, task in (
+        (indexer.index, [index_task]),
+        (indexer.delete, [delete_task]),
+    ):
+        execute_error = SAOperationalError(
+            statement='INSERT INTO search_index ...',
+            params={},
+            orig=psycopg2.errors.SerializationFailure(
+                'could not serialize access due to read/write dependencies'
+            ),
+        )
+        session = make_session(execute_error, abort_savepoint=True)
+        with caplog.at_level(logging.ERROR, logger='onegov.search.index'):
+            caplog.clear()
+            with pytest.raises(SAOperationalError):
+                method(task, session)
+            assert caplog.records, (
+                f'{method.__name__} did not log the serialization failure'
+            )
+
+    # Scenario 2: execute() raises bare InFailedSqlTransaction — matches the
+    # 'users' entry in the production logs (second call on already-dead tx).
+    # Must still re-raise even without a SerializationFailure in the chain.
+    for method, task in (
+        (indexer.index, [index_task]),
+        (indexer.delete, [delete_task]),
+    ):
+        in_failed = psycopg2.errors.InFailedSqlTransaction(
+            'current transaction is aborted, commands ignored '
+            'until end of transaction block'
+        )
+        session = make_session(in_failed, abort_savepoint=False)
+        with caplog.at_level(logging.ERROR, logger='onegov.search.index'):
+            caplog.clear()
+            with pytest.raises(psycopg2.errors.InFailedSqlTransaction):
+                method(task, session)
+            assert caplog.records, (
+                f'{method.__name__} did not log the InFailedSqlTransaction'
+            )
+
+    # Non-abort errors must be swallowed → return False.
+    for method, task in (
+        (indexer.index, [index_task]),
+        (indexer.delete, [delete_task]),
+    ):
+        session = make_session(
+            RuntimeError('unexpected'), abort_savepoint=False
+        )
+        assert method(task, session) is False


### PR DESCRIPTION
Search: Propagate psql error while updating search index

Under high load (e.g. Feriennet opening days) concurrent bookings can trigger PostgreSQL serialization failures inside the search indexer's savepoint. Previously these were silently swallowed, leaving the outer transaction dead (booking lost) while the confirmation email was still dispatched.

TYPE: Bugfix
LINK: pro-1545

