### PR TITLE
Core: Turns the browser session into a `transaction` data manager

### DIFF
--- a/src/onegov/core/browser_session.py
+++ b/src/onegov/core/browser_session.py
@@ -72,7 +72,7 @@ class BrowserSession:
     This class also acts as a data manager for ``transaction``, so changes
     are not committed to Redis, until the transaction is commited.
 
-    The ``on_dirty`` callback gets invoked when the firs change to the
+    The ``on_dirty`` callback gets invoked when the first change to the
     session happens, even if it ends up getting rolled back, so use with
     care!
 

--- a/src/onegov/core/browser_session.py
+++ b/src/onegov/core/browser_session.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import transaction
+
 from contextlib import suppress
 from dogpile.cache.api import NO_VALUE
 from hashlib import blake2b
@@ -9,6 +11,7 @@ from typing import overload, Any
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from collections.abc import Callable
+    from transaction.interfaces import ITransaction
 
     from .cache import RedisCacheRegion
 
@@ -35,13 +38,6 @@ class Prefixed:
 
     def delete(self, key: str) -> None:
         self.cache.delete(self.mangle(key))
-
-    def count(self) -> int:
-        # note, this cannot be used in a Redis cluster - if we use that
-        # we have to keep track of all keys separately
-        return self.cache.backend.reader_client.eval("""
-            return #redis.pcall('keys', ARGV[1])
-        """, 0, f'{self.cache.namespace}:{self.prefix}:*')
 
     def flush(self) -> int:
         # note, this cannot be used in a Redis cluster - if we use that
@@ -73,6 +69,13 @@ class BrowserSession:
     This class can act like an object, through attribute access, or like a
     dict, through square brackets. Whatever you prefer.
 
+    This class also acts as a data manager for ``transaction``, so changes
+    are not committed to Redis, until the transaction is commited.
+
+    The ``on_dirty`` callback gets invoked just before the changes are
+    committed to Redis, so additional changes can be performed in this
+    callback.
+
     """
 
     def __init__(
@@ -87,18 +90,57 @@ class BrowserSession:
         self._cache = Prefixed(prefix=prefix, cache=cache)
         self._token = token
 
+        # NOTE: Since these take priority over the Redis cache, it's possible
+        #       for conflicting changes that happen during our transaction on
+        #       a different transaction to be lost, which may result in a mix
+        #       of fresh attributes and stale attributes, if we're actually
+        #       worried about this, we could check the timestamp of the cached
+        #       values against the timestamps when we recorded our overrides
+        #       and emit a retryable error, if we detect another transactions'
+        #       changes interleaving with ours. Even our best attempt could
+        #       still have data races though, unless we depend on Redis
+        #       pipelines, which would probably mean having to write a new
+        #       `dogpile.cache` backend. It's probably not worth changing,
+        #       especially since we've had the same problems before we changed
+        #       this into a data manager.
+        self._pending_overrides: dict[str, Any] = {}
+        self._pending_deletes: set[str] = set()
+        self._pending_flush = False
+
         self._is_dirty = False
         self._on_dirty = on_dirty
 
-    def has(self, name: str) -> bool:
-        return self._cache.get(name) is not NO_VALUE
+    def _get(self, name: str) -> Any:
+        value = self._pending_overrides.get(name, NO_VALUE)
+        if (
+            # value has been overridden
+            value is not NO_VALUE
+            # ... or deleted
+            or self._pending_flush
+            or name in self._pending_deletes
+        ):
+            # ... so we can completely ignore what's inside _cache
+            return value
+        return self._cache.get(name)
 
-    def flush(self) -> None:
-        self._cache.flush()
+    def set(self, name: str, value: Any) -> None:
+        self._pending_overrides[name] = value
+        self._pending_deletes.discard(name)
         self.mark_as_dirty()
 
-    def count(self) -> int:
-        return self._cache.count()
+    def delete(self, name: str) -> None:
+        self._pending_deletes.add(name)
+        self._pending_overrides.pop(name, None)
+        self.mark_as_dirty()
+
+    def has(self, name: str) -> bool:
+        return self._get(name) is not NO_VALUE
+
+    def flush(self) -> None:
+        self._pending_flush = True
+        self._pending_overrides.clear()
+        self._pending_deletes.clear()
+        self.mark_as_dirty()
 
     def pop(self, name: str, default: Any = None) -> Any:
         """ Returns the value for the given name, removing the value in
@@ -120,7 +162,9 @@ class BrowserSession:
 
     def mark_as_dirty(self) -> None:
         if not self._is_dirty:
-            self._on_dirty(self, self._token)
+            # NOTE: We only need to join the transaction once we actually
+            #       intend to write anything.
+            transaction.get().join(self)
             self._is_dirty = True
 
     @overload
@@ -130,7 +174,7 @@ class BrowserSession:
     def get[T](self, name: str, default: T) -> Any | T: ...
 
     def get(self, name: str, default: Any = None) -> Any:
-        result = self._cache.get(name)
+        result = self._get(name)
 
         if result is NO_VALUE:
             return default
@@ -138,18 +182,18 @@ class BrowserSession:
         return result
 
     def __getitem__(self, name: str) -> Any:
-        result = self._cache.get(name)
+        result = self._get(name)
 
         if result is NO_VALUE:
-            raise KeyError
+            raise KeyError(name)
 
         return result
 
     def __getattr__(self, name: str) -> Any:
-        result = self._cache.get(name)
+        result = self._get(name)
 
         if result is NO_VALUE:
-            raise AttributeError
+            raise AttributeError(name)
 
         return result
 
@@ -157,17 +201,80 @@ class BrowserSession:
         if name.startswith('_'):
             return super().__setattr__(name, value)
 
-        self._cache.set(name, value)
-        self.mark_as_dirty()
+        self.set(name, value)
 
     def __delattr__(self, name: str) -> None:
         if name.startswith('_'):
             return super().__delattr__(name)
 
-        self._cache.delete(name)
-        self.mark_as_dirty()
+        self.delete(name)
 
     __setitem__ = __setattr__
     __delitem__ = __delattr__
     __delattr__ = __delattr__
     __contains__ = has
+
+    # DataManager interface
+    def sortKey(self) -> str:
+        return 'browser_session'
+
+    def commit(self, transaction: ITransaction) -> None:
+        pass
+
+    def abort(self, transaction: ITransaction) -> None:
+        if self._is_dirty:
+            self._finish()
+
+    def _finish(self) -> None:
+        self._pending_overrides = {}
+        self._pending_flush = False
+        self._pending_deletes = set()
+        self._pending_transaction = False
+        self._is_dirty = False
+
+    def tpc_begin(self, transaction: ITransaction) -> None:
+        pass
+
+    def tpc_vote(self, transaction: ITransaction) -> None:
+        pass
+
+    def tpc_abort(self, transaction: ITransaction) -> None:
+        if self._is_dirty:
+            self._finish()
+
+    def tpc_finish(self, transaction: ITransaction) -> None:
+        if not self._is_dirty:
+            return
+
+        self._on_dirty(self, self._token)
+
+        if self._pending_flush:
+            self._cache.flush()
+        elif self._pending_deletes:
+            for key in self._pending_deletes:
+                self._cache.delete(key)
+        for name, value in self._pending_overrides.items():
+            self._cache.set(name, value)
+        self._finish()
+
+    def savepoint(self) -> BrowserSessionSavepoint:
+        return BrowserSessionSavepoint(self)
+
+
+class BrowserSessionSavepoint:
+    def __init__(self, browser_session: BrowserSession) -> None:
+        self.browser_session = browser_session
+        self.original_state = (
+            browser_session._pending_overrides.copy(),
+            browser_session._pending_deletes.copy(),
+            browser_session._pending_flush,
+            browser_session._is_dirty
+        )
+
+    def rollback(self) -> None:
+        (
+            self.browser_session._pending_overrides,
+            self.browser_session._pending_deletes,
+            self.browser_session._pending_flush,
+            self.browser_session._is_dirty
+        ) = self.original_state

--- a/src/onegov/core/browser_session.py
+++ b/src/onegov/core/browser_session.py
@@ -72,9 +72,9 @@ class BrowserSession:
     This class also acts as a data manager for ``transaction``, so changes
     are not committed to Redis, until the transaction is commited.
 
-    The ``on_dirty`` callback gets invoked just before the changes are
-    committed to Redis, so additional changes can be performed in this
-    callback.
+    The ``on_dirty`` callback gets invoked when the firs change to the
+    session happens, even if it ends up getting rolled back, so use with
+    care!
 
     """
 
@@ -166,6 +166,12 @@ class BrowserSession:
             #       intend to write anything.
             transaction.get().join(self)
             self._is_dirty = True
+            # FIXME: We would like to defer calling this until the transaction
+            #        has been committed, but since we use this to add headers
+            #        to the response via `request.after`, we cannot do that
+            #        since those callbacks are invoked on the inner-most layer
+            #        so the transaction commit happens after the callbacks run
+            self._on_dirty(self, self._token)
 
     @overload
     def get(self, name: str) -> Any | None: ...
@@ -245,8 +251,6 @@ class BrowserSession:
     def tpc_finish(self, transaction: ITransaction) -> None:
         if not self._is_dirty:
             return
-
-        self._on_dirty(self, self._token)
 
         if self._pending_flush:
             self._cache.flush()

--- a/src/onegov/core/cache/redis.py
+++ b/src/onegov/core/cache/redis.py
@@ -25,7 +25,7 @@ class RedisCacheRegion(CacheRegion):
     on a given namespace as well as a couple of additional convenience
     methods specific to Redis.
 
-    It will use dill to serialize/deserialize values.
+    It will use msgpack to serialize/deserialize values.
     """
     def __init__(
         self,

--- a/src/onegov/core/security/identity_policy.py
+++ b/src/onegov/core/security/identity_policy.py
@@ -70,7 +70,8 @@ def forget(app: Framework, session_id: str) -> None:
     """
 
     session = BrowserSession(app.session_cache, session_id)
-    session.flush()
+    # NOTE: We bypass the transaction machinery for this part
+    session._cache.flush()
 
 
 def remembered(app: Framework, session_id: str) -> bool:
@@ -78,6 +79,14 @@ def remembered(app: Framework, session_id: str) -> bool:
     browser session.
 
     """
+
+    # FIXME: This check is a little flaky for a session_id that was created
+    #        in the current transaction, since the changes will not have
+    #        been committed to redis yet, so they will not show up here.
+    #        We may be able to get around this by weakref caching the
+    #        created BrowserSession instances for a given application_id
+    #        and session_id, so we get the same instance as the one
+    #        created by the request here.
     session = BrowserSession(app.session_cache, session_id)
     for key in IdentityPolicy.required_keys:
         if session.has(key):

--- a/src/onegov/org/views/directory.py
+++ b/src/onegov/org/views/directory.py
@@ -177,10 +177,12 @@ def handle_new_directory(
         try:
             directory = self.add_by_form(form, properties=('configuration', ))
         except DuplicateEntryError as e:
+            transaction.abort()
+            # NOTE: The alert needs to be emitted after, so it doesn't get
+            #       rolled back as well.
             request.alert(_('The entry ${name} exists twice', mapping={
                 'name': e.name
             }))
-            transaction.abort()
             return request.redirect(request.link(self))
 
         request.success(_('Added a new directory'))
@@ -674,10 +676,12 @@ def handle_new_directory_entry(
                 type='extended'
             )
         except DuplicateEntryError as e:
+            transaction.abort()
+            # NOTE: The alert needs to be emitted after, so it doesn't get
+            #       rolled back as well.
             request.alert(_('The entry ${name} exists twice', mapping={
                 'name': e.name
             }))
-            transaction.abort()
             return request.redirect(request.link(self))
 
         if self.directory.enable_update_notifications and entry.access in (
@@ -1061,29 +1065,30 @@ def view_import(
     layout.editbar_links = None  # type:ignore[assignment]
 
     if form.submitted(request):
+        message: str | None = None
         try:
             imported = form.run_import(target=self.directory)
         except MissingColumnError as e:
             field = self.directory.field_by_id(e.column)
             assert field is not None
-            request.alert(_('The column ${name} is missing', mapping={
+            message = _('The column ${name} is missing', mapping={
                 'name': field.human_id
-            }))
+            })
         except MissingFileError as e:
-            request.alert(_('The file ${name} is missing', mapping={
+            message = _('The file ${name} is missing', mapping={
                 'name': e.name
-            }))
+            })
         except DuplicateEntryError as e:
-            request.alert(_('The entry ${name} exists twice', mapping={
+            message = _('The entry ${name} exists twice', mapping={
                 'name': e.name
-            }))
+            })
         except ValidationError as e:
             error = e
         except NotImplementedError:
-            request.alert(_(
+            message = _(
                 'The given file is invalid, does it include a metadata.json '
                 'with a data.xlsx, data.csv, or data.json?'
-            ))
+            )
         else:
             notify = request.success if imported else request.warning
             notify(_('Imported ${count} entries', mapping={
@@ -1094,6 +1099,10 @@ def view_import(
 
         # no success if we land here
         transaction.abort()
+        # NOTE: The alert needs to be emitted after, so it doesn't get
+        #       rolled back as well.
+        if message is not None:
+            request.alert(message)
 
     return {
         'layout': layout,

--- a/src/onegov/user/models/user.py
+++ b/src/onegov/user/models/user.py
@@ -330,14 +330,17 @@ class User(Base, TimestampMixin, ORMSearchable):
     def save_current_session(self, request: CoreRequest) -> None:
         """ Stores the current browser session. """
 
+        # NOTE: We cleanup before we add the current session
+        #       since the current session may not yet have been
+        #       persisted, so `remembered` may yield `False`.
+        self.cleanup_sessions(request.app)
+
         self.sessions = self.sessions or {}
         self.sessions[request.browser_session._token] = {
             'address': request.client_addr,
             'timestamp': utcnow().replace(tzinfo=None).isoformat(),
             'agent': request.user_agent
         }
-
-        self.cleanup_sessions(request.app)
 
     def remove_current_session(self, request: CoreRequest) -> None:
         """ Removes the current browser session. """

--- a/tests/onegov/core/test_browser_session.py
+++ b/tests/onegov/core/test_browser_session.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 import pytest
+import transaction
 
 from dogpile.cache import make_region
 from dogpile.cache.api import NO_VALUE
-from onegov.core.browser_session import BrowserSession
 from onegov.core import cache
+from onegov.core.browser_session import BrowserSession
 
 
 def test_browser_session_mangle() -> None:
@@ -41,7 +42,6 @@ def test_browser_session_cache() -> None:
     assert 'name' in session
     assert session.name == 'test'
     assert session['name'] == 'test'
-    assert cache.get(key) == 'test'
 
     del session.name
     assert not session.has('name')
@@ -53,14 +53,14 @@ def test_browser_session_cache() -> None:
     with pytest.raises(KeyError):
         session['name']
 
-    assert cache.get(key) is NO_VALUE
-
 
 def test_browser_session_cache_prefix() -> None:
     cache = make_region().configure('dogpile.cache.memory')
 
     session = BrowserSession(cache, 'foo')  # type: ignore[arg-type]
+    transaction.begin()
     session.name = 'test'
+    transaction.commit()
     assert session.name == 'test'
 
     session = BrowserSession(cache, 'foo')  # type: ignore[arg-type]
@@ -75,25 +75,132 @@ def test_browser_session_cache_prefix() -> None:
         session.name
 
 
-def test_browser_session_count(redis_url: str) -> None:
-    session = BrowserSession(cache.get('sessions', 60, redis_url), 'token')
+def test_browser_session_data_manager(redis_url: str) -> None:
+    session = BrowserSession(cache.get('sessions', 60, redis_url), 'foo')
 
-    assert session.count() == 0
+    transaction.begin()
     session['foo'] = 'bar'
+    session['bar'] = 'baz'
+    assert session['foo'] == 'bar'
+    assert session['bar'] == 'baz'
+    assert session._pending_overrides == {'foo': 'bar', 'bar': 'baz'}
+    # before the commit nothing is written to the actual cache
+    assert session._cache.get('foo') is NO_VALUE
+    assert session._cache.get('bar') is NO_VALUE
 
-    assert session.count() == 1
-    session['foo'] = 'baz'
+    # after the commit, the cache the changes have been mirrored
+    transaction.commit()
+    assert session['foo'] == 'bar'
+    assert session['bar'] == 'baz'
+    assert not session._pending_overrides
+    assert session._cache.get('foo') == 'bar'
+    assert session._cache.get('bar') == 'baz'
 
-    assert session.count() == 1
-    del session['foo']
+    # and we can start a new transaction
+    transaction.begin()
+    del session['bar']
+    session['baz'] = 'foo'
+    assert session['foo'] == 'bar'
+    assert 'bar' not in session
+    assert session['baz'] == 'foo'
+    assert session._pending_overrides == {'baz': 'foo'}
+    assert session._pending_deletes == {'bar'}
+    assert session._cache.get('foo') == 'bar'
+    assert session._cache.get('bar') == 'baz'
+    assert session._cache.get('baz') is NO_VALUE
 
-    assert session.count() == 0
+    # after an abort the session is back to how it was before
+    transaction.abort()
+    assert session['foo'] == 'bar'
+    assert session['bar'] == 'baz'
+    assert 'baz' not in session
+    assert not session._pending_overrides
+    assert not session._pending_deletes
+    assert session._cache.get('foo') == 'bar'
+    assert session._cache.get('bar') == 'baz'
+    assert session._cache.get('baz') is NO_VALUE
 
-    session['asdf'] = 'qwerty'
-    assert session.count() == 1
-
+    # flushes get deferred as well
+    transaction.begin()
     session.flush()
-    assert session.count() == 0
+    session['baz'] = 'foo'
+    assert 'foo' not in session
+    assert 'bar' not in session
+    assert session['baz'] == 'foo'
+    assert session._pending_overrides == {'baz': 'foo'}
+    assert session._pending_flush
+    assert session._cache.get('foo') == 'bar'
+    assert session._cache.get('bar') == 'baz'
+    assert session._cache.get('baz') is NO_VALUE
 
-    session.flush()
-    assert session.count() == 0
+    # the commit correctly orders the operations
+    transaction.commit()
+    session = session  # undo mypy narrowing
+    assert 'foo' not in session
+    assert 'bar' not in session
+    assert session['baz'] == 'foo'
+    assert not session._pending_overrides
+    assert not session._pending_flush
+    assert session._cache.get('foo') is NO_VALUE
+    assert session._cache.get('bar') is NO_VALUE
+    assert session._cache.get('baz') == 'foo'
+
+    # savepoints work too!
+    transaction.begin()
+    session['foo'] = 'bar'
+    savepoint = transaction.savepoint()
+    session['bar'] = 'baz'
+    assert session['foo'] == 'bar'
+    assert session['bar'] == 'baz'
+    assert session['baz'] == 'foo'
+    assert session._pending_overrides == {'foo': 'bar', 'bar': 'baz'}
+    assert session._cache.get('foo') is NO_VALUE
+    assert session._cache.get('bar') is NO_VALUE
+    assert session._cache.get('baz') == 'foo'
+
+    # rolling back the savepoint only rolls back those changes
+    savepoint.rollback()
+    assert session._pending_overrides == {'foo': 'bar'}
+    transaction.commit()
+    assert session['foo'] == 'bar'
+    assert 'bar' not in session
+    assert session['baz'] == 'foo'
+    assert not session._pending_overrides
+    assert session._cache.get('foo') == 'bar'
+    assert session._cache.get('bar') is NO_VALUE
+    assert session._cache.get('baz') == 'foo'
+
+
+def test_browser_session_data_manager_callback(redis_url: str) -> None:
+    session = BrowserSession(
+        cache.get('sessions', 60, redis_url),
+        'foo',
+        # modifying the session within the callback is allowed
+        on_dirty=lambda session, token: session.set('extra', 'foo')
+    )
+
+    transaction.begin()
+    session['foo'] = 'bar'
+    transaction.commit()
+    assert session._cache.get('foo') == 'bar'
+    assert session._cache.get('extra') == 'foo'
+
+
+    on_dirty_called = False
+    # aborting changes, avoids the callback being invoked
+    def on_dirty(session: BrowserSession, token: str) -> None:
+        nonlocal on_dirty_called
+        on_dirty_called = True
+        session.set('extra', 'bar')
+
+    session = BrowserSession(
+        cache.get('sessions', 60, redis_url),
+        'foo',
+        on_dirty=on_dirty
+    )
+    transaction.begin()
+    session['bar'] = 'baz'
+    transaction.abort()
+    assert not on_dirty_called
+    assert session._cache.get('foo') == 'bar'
+    assert session._cache.get('extra') == 'foo'

--- a/tests/onegov/core/test_browser_session.py
+++ b/tests/onegov/core/test_browser_session.py
@@ -187,7 +187,7 @@ def test_browser_session_data_manager_callback(redis_url: str) -> None:
 
 
     on_dirty_called = False
-    # aborting changes, avoids the callback being invoked
+    # aborting changes, does not avoid the callback being invoked
     def on_dirty(session: BrowserSession, token: str) -> None:
         nonlocal on_dirty_called
         on_dirty_called = True
@@ -201,6 +201,6 @@ def test_browser_session_data_manager_callback(redis_url: str) -> None:
     transaction.begin()
     session['bar'] = 'baz'
     transaction.abort()
-    assert not on_dirty_called
+    assert on_dirty_called
     assert session._cache.get('foo') == 'bar'
     assert session._cache.get('extra') == 'foo'

--- a/tests/onegov/user/test_models.py
+++ b/tests/onegov/user/test_models.py
@@ -180,51 +180,53 @@ def test_user_cleanup_sessions() -> None:
     user = User()
     assert not user.sessions
 
-    with patch('onegov.user.models.user.remembered') as remembered:
-        with patch('onegov.user.models.user.forget'):
-            # ... implicit
-            remembered.return_value = True
-            user.save_current_session(DummyRequest('xxx'))  # type: ignore[arg-type]
-            assert user.sessions is not None
-            assert 'xxx' in user.sessions
+    with (
+        patch('onegov.user.models.user.remembered') as remembered,
+        patch('onegov.user.models.user.forget')
+    ):
+        # ... implicit
+        remembered.return_value = True
+        user.save_current_session(DummyRequest('xxx'))  # type: ignore[arg-type]
+        assert user.sessions is not None
+        assert 'xxx' in user.sessions
 
-            remembered.return_value = False
-            user.cleanup_sessions(DummyRequest('zzz').app)  # type: ignore[arg-type]
-            assert 'xxx' not in user.sessions
+        remembered.return_value = False
+        user.cleanup_sessions(DummyRequest('zzz').app)  # type: ignore[arg-type]
+        assert 'xxx' not in user.sessions
 
-            # ... while adding
-            remembered.return_value = True
-            user.save_current_session(DummyRequest('xxx'))  # type: ignore[arg-type]
-            assert 'xxx' in user.sessions
+        # ... while adding
+        remembered.return_value = True
+        user.save_current_session(DummyRequest('xxx'))  # type: ignore[arg-type]
+        assert 'xxx' in user.sessions
 
-            remembered.return_value = False
-            user.save_current_session(DummyRequest('yyy'))  # type: ignore[arg-type]
-            assert 'xxx' not in user.sessions
-            assert 'yyy' not in user.sessions
+        remembered.return_value = False
+        user.save_current_session(DummyRequest('yyy'))  # type: ignore[arg-type]
+        assert 'xxx' not in user.sessions
+        assert 'yyy' in user.sessions
 
-            # ... while removing
-            remembered.return_value = True
-            user.save_current_session(DummyRequest('xxx'))  # type: ignore[arg-type]
-            user.save_current_session(DummyRequest('yyy'))  # type: ignore[arg-type]
-            assert 'xxx' in user.sessions
-            assert 'yyy' in user.sessions
+        # ... while removing
+        remembered.return_value = True
+        user.save_current_session(DummyRequest('xxx'))  # type: ignore[arg-type]
+        user.save_current_session(DummyRequest('yyy'))  # type: ignore[arg-type]
+        assert 'xxx' in user.sessions
+        assert 'yyy' in user.sessions
 
-            remembered.return_value = False
-            user.remove_current_session(DummyRequest('xxx'))  # type: ignore[arg-type]
-            assert 'xxx' not in user.sessions
-            assert 'yyy' not in user.sessions
+        remembered.return_value = False
+        user.remove_current_session(DummyRequest('xxx'))  # type: ignore[arg-type]
+        assert 'xxx' not in user.sessions
+        assert 'yyy' not in user.sessions
 
-            # ... while logging out
-            remembered.return_value = True
-            user.save_current_session(DummyRequest('xxx'))  # type: ignore[arg-type]
-            user.save_current_session(DummyRequest('yyy'))  # type: ignore[arg-type]
-            assert 'xxx' in user.sessions
-            assert 'yyy' in user.sessions
+        # ... while logging out
+        remembered.return_value = True
+        user.save_current_session(DummyRequest('xxx'))  # type: ignore[arg-type]
+        user.save_current_session(DummyRequest('yyy'))  # type: ignore[arg-type]
+        assert 'xxx' in user.sessions
+        assert 'yyy' in user.sessions
 
-            remembered.return_value = False
-            user.logout_all_sessions(DummyRequest('zzz').app)  # type: ignore[arg-type]
-            assert 'xxx' not in user.sessions
-            assert 'yyy' not in user.sessions
+        remembered.return_value = False
+        user.logout_all_sessions(DummyRequest('zzz').app)  # type: ignore[arg-type]
+        assert 'xxx' not in user.sessions
+        assert 'yyy' not in user.sessions
 
 
 def test_role_mapping(session: Session) -> None:


### PR DESCRIPTION
## Commit message

Core: Turns the browser session into a `transaction` data manager

This avoids aborted/retried transactions from emitting changes to the
browser session, which could result in success messages being displayed
after a failed transaction or similar weird edge-cases.

TYPE: Bugfix
LINK: OGC-3182

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes/features