### PR TITLE
Pas: Restore abschluss guard for attendance creation.

### DIFF
--- a/src/onegov/pas/views/attendence.py
+++ b/src/onegov/pas/views/attendence.py
@@ -12,9 +12,11 @@ from onegov.pas import _
 from onegov.pas import PasApp
 from onegov.pas.collections import (
     AttendenceCollection,
+    PASParliamentarianCollection,
     SettlementRunCollection,
 )
 from onegov.pas.custom import (
+    has_user_set_abschluss_for_settlement_run,
     validate_attendance_date,
     notify_admins_finalized,
 )
@@ -256,6 +258,29 @@ def add_attendence(
                     'form_width': 'large',
                 }
 
+        if not request.is_admin:
+            if (
+                form.parliamentarian_id.data
+                and form.date.data
+                and has_user_set_abschluss_for_settlement_run(
+                    request.session,
+                    form.parliamentarian_id.data,
+                    form.date.data,
+                )
+            ):
+                request.alert(
+                    _(
+                        'Cannot book attendance - abschluss '
+                        'already set for this settlement run'
+                    )
+                )
+                return {
+                    'layout': AttendenceCollectionLayout(self, request),
+                    'title': _('New attendence'),
+                    'form': form,
+                    'form_width': 'large',
+                }
+
         attendence = self.add(**form.get_useful_data())
         Change.add(request, 'add', attendence)
         request.success(_('Added a new attendence'))
@@ -309,6 +334,34 @@ def add_bulk_attendence(
 
         data = form.get_useful_data()
         if raw_parl_ids := request.POST.getall('parliamentarian_id'):
+            if not request.is_admin and form.date.data:
+                blocked_parls: list[str] = []
+                for parl_id in raw_parl_ids:
+                    pid = str(parl_id)
+                    if has_user_set_abschluss_for_settlement_run(
+                        request.session, pid, form.date.data
+                    ):
+                        parl = PASParliamentarianCollection(request.app).by_id(
+                            pid
+                        )
+                        if parl:
+                            blocked_parls.append(parl.title)
+                if blocked_parls:
+                    request.alert(
+                        _(
+                            'Cannot book attendance - '
+                            'abschluss already set '
+                            'for: ${names}',
+                            mapping={'names': ', '.join(blocked_parls)},
+                        )
+                    )
+                    return {
+                        'layout': AttendenceCollectionLayout(self, request),
+                        'title': title,
+                        'form': form,
+                        'form_width': 'large',
+                    }
+
             data.pop('parliamentarian_id', None)
             bulk_edit_id = uuid.uuid4()
             notify_attendence = None

--- a/tests/onegov/pas/test_views.py
+++ b/tests/onegov/pas/test_views.py
@@ -1017,6 +1017,109 @@ def test_commission_president_bulk_add(
     assert page.status_code == 200
 
 
+def test_abschluss_blocks_second_bulk_add(
+    client: Client[TestPasApp],
+) -> None:
+    from onegov.pas.models import Attendence
+
+    session = client.app.session()
+    session.add(
+        SettlementRun(
+            name='Q1 2024',
+            start=datetime.date(2024, 1, 1),
+            end=datetime.date(2024, 12, 31),
+            active=True,
+            closed=False,
+        )
+    )
+
+    parliamentarians = PASParliamentarianCollection(client.app)
+    bob = parliamentarians.add(
+        first_name='Bob',
+        last_name='Member',
+        email_primary='bob.member@example.org',
+        zg_username='zgbob',
+    )
+    alice = parliamentarians.add(
+        first_name='Alice',
+        last_name='President',
+        email_primary='alice.president@example.org',
+        zg_username='zgalice',
+    )
+
+    for p in (bob, alice):
+        session.add(
+            PASParliamentarianRole(
+                parliamentarian_id=p.id,
+                role='member',
+                meta={'org_type': 'Kantonsrat'},
+            )
+        )
+
+    commissions = PASCommissionCollection(session)
+    commission = commissions.add(name='Finanzkommission')
+
+    session.add(
+        PASCommissionMembership(
+            parliamentarian_id=bob.id,
+            commission_id=commission.id,
+            role='member',
+        )
+    )
+    session.add(
+        PASCommissionMembership(
+            parliamentarian_id=alice.id,
+            commission_id=commission.id,
+            role='president',
+        )
+    )
+
+    commission_id = str(commission.id)
+    bob_id = str(bob.id)
+    alice_id = str(alice.id)
+
+    users = UserCollection(session)
+    president_user = users.by_username('zgalice')
+    assert president_user is not None
+    president_user.role = 'commission_president'
+    president_user.password = 'test'
+    president_user.active = True
+    transaction.commit()
+
+    client.login('zgalice', 'test')
+
+    page = client.get('/attendences/new-commission-bulk')
+    assert page.status_code == 200
+    page.form['date'] = '2024-06-01'
+    page.form['type'] = 'commission'
+    page.form['duration'] = '2'
+    page.form['commission_id'] = commission_id
+    page.form['abschluss'] = True
+    page.form['parliamentarian_id'] = [bob_id, alice_id]
+    page = page.form.submit().maybe_follow()
+    assert page.status_code == 200
+
+    session = client.app.session()
+    count_after_first = session.query(Attendence).count()
+    assert count_after_first == 2
+
+    page = client.get('/attendences/new-commission-bulk')
+    assert page.status_code == 200
+    page.form['date'] = '2024-07-15'
+    page.form['type'] = 'commission'
+    page.form['duration'] = '3'
+    page.form['commission_id'] = commission_id
+    page.form['abschluss'] = False
+    page.form['parliamentarian_id'] = [bob_id, alice_id]
+    page = page.form.submit()
+
+    assert 'abschluss' in page.text.lower()
+
+    session = client.app.session()
+    count_after_second = session.query(Attendence).count()
+    assert count_after_second == 2
+
+
 def test_presidential_allowance_view(client: Client[TestPasApp]) -> None:
     client.login_admin()
 


### PR DESCRIPTION
Commit da2a45a99 accidentally removed the check that prevents adding attendances after abschluss was set for a settlement run.

TYPE: Bugfix
LINK: OGC-3188
