### PR TITLE
Org: Fixes event search index corrupted after fetch.

### DIFF
--- a/src/onegov/agency/cli.py
+++ b/src/onegov/agency/cli.py
@@ -247,7 +247,7 @@ def import_lu_data_files(
                 """)
             )
             session.flush()
-            if app.fts_search_enabled:
+            if getattr(app, 'fts_search_enabled', False):
                 # remove the relevant entries from the search index
                 session.execute(text("""
                     DELETE

--- a/src/onegov/gever/gever_client.py
+++ b/src/onegov/gever/gever_client.py
@@ -71,7 +71,7 @@ class GeverClientCAS:
         )
         # Get CSRF token that was returned by server in a cookie
         # FIXME: See https://github.com/jawah/niquests/issues/401
-        csrf_token = self.portal_session.cookies['csrftoken']  # type: ignore[index]
+        csrf_token = self.portal_session.cookies['csrftoken']
 
         # Send the CSRF token as a request header in subsequent requests
         self.portal_session.headers.update({'X-CSRFToken': csrf_token})
@@ -144,7 +144,7 @@ class GeverClientCAS:
 
         # The server will return a temporary upload URL 'location' in header
         # FIXME: See https://github.com/jawah/niquests/issues/401#issuecomment-4498876553
-        location: str = resp.headers['Location']  # type: ignore[assignment]
+        location: str = resp.headers['Location']
         headers = {
             'Accept': 'application/json',
             'Content-Type': 'application/offset+octet-stream',

--- a/src/onegov/org/cli.py
+++ b/src/onegov/org/cli.py
@@ -762,33 +762,42 @@ def fetch(
                     return TicketCollection(local_session).by_handler_id(
                         event_id.hex)
 
-                added, updated, purged = local_events.from_import(
-                    remote_events(),
-                    to_purge=[f'fetch-{key}'],
-                    publish_immediately=False,
-                    valid_state_transfers=valid_state_transfers,
-                    published_only=published_only
-                )
+                with app.session_manager.disable_change_signals():
+                    added, updated, purged = local_events.from_import(
+                        remote_events(),
+                        to_purge=[f'fetch-{key}'],
+                        publish_immediately=False,
+                        valid_state_transfers=valid_state_transfers,
+                        published_only=published_only,
+                    )
 
-                for event_ in added:
-                    event_.submit()
-                    if not create_tickets:
-                        event_.publish()
-                        continue
+                    for event_ in added:
+                        event_.submit()
+                        if not create_tickets:
+                            event_.publish()
+                            continue
 
-                    assert local_admin is not None
-                    with local_session.no_autoflush:
-                        tickets = TicketCollection(local_session)
-                        new_ticket = tickets.open_ticket(
-                            handler_code='EVN', handler_id=event_.id.hex,
-                            source=event_.meta['source'],
-                            user=local_admin.username
-                        )
-                        new_ticket.muted = True
-                        TicketNote.create(new_ticket, request, (
-                            f'Importiert von Instanz {key}'
+                        assert local_admin is not None
+                        with local_session.no_autoflush:
+                            tickets = TicketCollection(local_session)
+                            new_ticket = tickets.open_ticket(
+                                handler_code='EVN',
+                                handler_id=event_.id.hex,
+                                source=event_.meta['source'],
+                                user=local_admin.username,
+                            )
+                            new_ticket.muted = True
+                            TicketNote.create(
+                                new_ticket,
+                                request,
+                                (f'Importiert von Instanz {key}'),
+                                owner=local_admin.username,
+                            )
 
-                        ), owner=local_admin.username)
+                if hasattr(app, 'fts_orm_events'):
+                    for event_ in (*added, *updated):
+                        if not event_.fts_skip:
+                            app.fts_orm_events.index(local_schema, event_)
 
                 helper_request: OrgRequest = Bunch(  # type:ignore
                     current_username=local_admin and local_admin.username,

--- a/src/onegov/org/cli.py
+++ b/src/onegov/org/cli.py
@@ -795,7 +795,7 @@ def fetch(
                                 owner=local_admin.username,
                             )
 
-                if app.fts_search_enabled:
+                if getattr(app, 'fts_search_enabled', False):
                     if added or updated:
                         app.fts_indexer.process(
                             (

--- a/src/onegov/org/cli.py
+++ b/src/onegov/org/cli.py
@@ -804,7 +804,7 @@ def fetch(
                                 if (
                                     task := app.fts_orm_events.index_task(
                                         local_schema,
-                                        event_,  # type:ignore
+                                        event_,
                                     )
                                 )
                                 is not None

--- a/src/onegov/org/cli.py
+++ b/src/onegov/org/cli.py
@@ -17,6 +17,7 @@ import transaction
 import yaml
 
 from collections import defaultdict
+from itertools import chain
 from datetime import date, datetime, timedelta
 from io import BytesIO
 from libres.modules.errors import (InvalidEmailAddress, AlreadyReservedError,
@@ -794,10 +795,37 @@ def fetch(
                                 owner=local_admin.username,
                             )
 
-                if hasattr(app, 'fts_orm_events'):
-                    for event_ in (*added, *updated):
-                        if not event_.fts_skip:
-                            app.fts_orm_events.index(local_schema, event_)
+                if app.fts_search_enabled:
+                    if added or updated:
+                        app.fts_indexer.process(
+                            (
+                                task
+                                for event_ in chain(added, updated)
+                                if (
+                                    task := app.fts_orm_events.index_task(
+                                        local_schema,
+                                        event_,  # type:ignore
+                                    )
+                                )
+                                is not None
+                            ),
+                            local_session,
+                        )
+                    if purged:
+                        app.fts_indexer.process(
+                            (
+                                {
+                                    'action': 'delete',
+                                    'schema': local_schema,
+                                    'tablename': 'events',
+                                    'owner_type': 'Event',
+                                    'id': eid,
+                                }
+                                for eid in purged
+                            ),
+                            local_session,
+                        )
+                    local_session.flush()
 
                 helper_request: OrgRequest = Bunch(  # type:ignore
                     current_username=local_admin and local_admin.username,


### PR DESCRIPTION
We have hourly cronjobs that fetch events. They look like this: `sudo /usr/sbin/container-exec onegov-cloud onegov-org --select /onegov_town6_without_yubikey/zug fetch --source huenenberg --source risch --source steinhausen --published-only --create-tickets`

We have empirically determined that this exact  command above results in:
<img width="1276" height="235" alt="image" src="https://github.com/user-attachments/assets/a881f71b-992a-46e8-9c6c-5b2bc9c3abda" />

**I have tested this fix (hotfix and run the cli manually) and with the fix this problem doesn't appear.**

## Commit message

Org: Fixes event search index corrupted after fetch.

The fetch CLI switches schemas multiple times in a loop (remote → local
per source key), violating the session_manager's own design contract:
"we only set the schema once per request". Any ORM flush during the
schema-switch window would send indexing signals tagged with the wrong
schema.

Wrap from_import() and the submit/publish/ticket block in
disable_change_signals(), then explicitly index each added/updated
published event after signals are restored.


TYPE: Bugfix
LINK: OGC-3101


## Checklist

- [x] I have performed a self-review of my code
- [x] I considered adding a reviewer
- [x] I have tested my code thoroughly by hand
