### PR TITLE
Pin back redis timeout to 30 seconds as it got halfed by pytest-redis…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.pytest.ini_options]
 log_level = "INFO"
+redis_timeout = 30
 testpaths = ["tests"]
 python_classes = []
 python_files = ["test_*.py"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.pytest.ini_options]
 log_level = "INFO"
-redis_timeout = 30
+redis_timeout = 60
 testpaths = ["tests"]
 python_classes = []
 python_files = ["test_*.py"]


### PR DESCRIPTION
Core: Increase redis timeout to 60 seconds as tests are failing [skip-ci]