### PR TITLE
Reproduce issue

### DIFF
--- a/src/onegov/org/views/reservation.py
+++ b/src/onegov/org/views/reservation.py
@@ -334,6 +334,9 @@ def handle_reservation_form(
     reservations on a resource.
 
     """
+    # remove all expired session before loading
+    self.remove_expired_reservation_sessions()  # type: ignore[attr-defined]
+
     reservations_query = self.bound_reservations(request, with_data=True)  # type: ignore[attr-defined]
     reservations: tuple[Reservation, ...] = tuple(reservations_query)
 
@@ -380,10 +383,6 @@ def handle_reservation_form(
                 data['ticket_tag'] = form.ticket_tag.data
                 if filtered_meta:
                     data['ticket_tag_meta'] = filtered_meta
-
-        # while we re at it, remove all expired sessions
-        # FIXME: Should this be part of the base class?
-        self.remove_expired_reservation_sessions()  # type: ignore[attr-defined]
 
         # add the submission if it doesn't yet exist
         if self.definition and not submission:

--- a/src/onegov/org/views/reservation.py
+++ b/src/onegov/org/views/reservation.py
@@ -336,7 +336,9 @@ def handle_reservation_form(
     """
     # remove all expired session before loading on POST
     if request.POST:
-        self.remove_expired_reservation_sessions()  # type: ignore[attr-defined]
+        self.remove_expired_reservation_sessions(  # type: ignore[attr-defined]
+            expiration_date=sedate.utcnow() - timedelta(hours=2)
+        )
 
     reservations_query = self.bound_reservations(request, with_data=True)  # type: ignore[attr-defined]
     reservations: tuple[Reservation, ...] = tuple(reservations_query)

--- a/src/onegov/org/views/reservation.py
+++ b/src/onegov/org/views/reservation.py
@@ -334,8 +334,9 @@ def handle_reservation_form(
     reservations on a resource.
 
     """
-    # remove all expired session before loading
-    self.remove_expired_reservation_sessions()  # type: ignore[attr-defined]
+    # remove all expired session before loading on POST
+    if request.POST:
+        self.remove_expired_reservation_sessions()  # type: ignore[attr-defined]
 
     reservations_query = self.bound_reservations(request, with_data=True)  # type: ignore[attr-defined]
     reservations: tuple[Reservation, ...] = tuple(reservations_query)

--- a/tests/onegov/org/test_views_resources.py
+++ b/tests/onegov/org/test_views_resources.py
@@ -4663,11 +4663,20 @@ def test_my_reservations_view(client: Client) -> None:
     client2.get('/resources/my-reservations-pdf', status=403)
 
 
-def test_reserve_form_expired_session_returns_403(client: Client) -> None:
-    # Regression: cleanup was placed after bound_reservations inside
-    # `if request.POST:`, so submitting the form after session expiry could
-    # crash when the template accessed info.price on a detached object.
-    with freeze_time("2026-05-29 10:00:00"):
+@pytest.mark.parametrize('frozen_at,expected_status', [
+    ('2026-05-29 11:59:59', 200),   # just before 2-hour expiry: proceeds
+    ('2026-05-29 12:00:01', 403),   # just after 2-hour expiry → session
+    # cleaned up
+])
+def test_reserve_form_session_expiry(
+    client: Client,
+    frozen_at: str,
+    expected_status: int,
+) -> None:
+    # Regression: expired-session cleanup must run before bound_reservations.
+    # Old placement (after bound_reservations) detached the reservation; the
+    # template then crashed accessing info.price on the detached object.
+    with freeze_time('2026-05-29 10:00:00'):
         resources = ResourceCollection(client.app.libres_context)
         resource = resources.by_name('tageskarte')
         assert resource is not None
@@ -4686,5 +4695,5 @@ def test_reserve_form_expired_session_returns_403(client: Client) -> None:
         formular = client.get('/resource/tageskarte/form')
         formular.form['email'] = 'info@example.org'
 
-    with freeze_time("2026-05-29 10:15:01"):  # past 15-min expiry threshold
-        formular.form.submit(expect_errors=True, status=403)
+    with freeze_time(frozen_at):
+        formular.form.submit(status=expected_status)

--- a/tests/onegov/org/test_views_resources.py
+++ b/tests/onegov/org/test_views_resources.py
@@ -4661,3 +4661,27 @@ def test_my_reservations_view(client: Client) -> None:
     # but not the other views
     client2.get('/resources/my-reservations-json', status=403)
     client2.get('/resources/my-reservations-pdf', status=403)
+
+
+def test_reserve_form_expired_session_returns_403(client: Client) -> None:
+    # Regression: cleanup was only called inside `if request.POST:`, so an
+    # expired session could still render the form (or crash on info.price
+    # for a detached object on re-render). Cleanup must run first.
+    with freeze_time("2015-08-28 10:00:00"):
+        resources = ResourceCollection(client.app.libres_context)
+        resource = resources.by_name('tageskarte')
+        assert resource is not None
+        scheduler = resource.get_scheduler(client.app.libres_context)
+
+        allocations = scheduler.allocate(
+            dates=(datetime(2015, 8, 28), datetime(2015, 8, 28)),
+            whole_day=True,
+        )
+
+        reserve = client.bound_reserve(allocations[0])
+        transaction.commit()
+
+        assert reserve(whole_day=True).json == {'success': True}
+
+    with freeze_time("2015-08-28 10:15:01"):  # past 15-min expiry threshold
+        client.get('/resource/tageskarte/form', status=403)

--- a/tests/onegov/org/test_views_resources.py
+++ b/tests/onegov/org/test_views_resources.py
@@ -4664,17 +4664,17 @@ def test_my_reservations_view(client: Client) -> None:
 
 
 def test_reserve_form_expired_session_returns_403(client: Client) -> None:
-    # Regression: cleanup was only called inside `if request.POST:`, so an
-    # expired session could still render the form (or crash on info.price
-    # for a detached object on re-render). Cleanup must run first.
-    with freeze_time("2015-08-28 10:00:00"):
+    # Regression: cleanup was placed after bound_reservations inside
+    # `if request.POST:`, so submitting the form after session expiry could
+    # crash when the template accessed info.price on a detached object.
+    with freeze_time("2026-05-29 10:00:00"):
         resources = ResourceCollection(client.app.libres_context)
         resource = resources.by_name('tageskarte')
         assert resource is not None
         scheduler = resource.get_scheduler(client.app.libres_context)
 
         allocations = scheduler.allocate(
-            dates=(datetime(2015, 8, 28), datetime(2015, 8, 28)),
+            dates=(datetime(2026, 5, 29), datetime(2026, 5, 29)),
             whole_day=True,
         )
 
@@ -4683,5 +4683,8 @@ def test_reserve_form_expired_session_returns_403(client: Client) -> None:
 
         assert reserve(whole_day=True).json == {'success': True}
 
-    with freeze_time("2015-08-28 10:15:01"):  # past 15-min expiry threshold
-        client.get('/resource/tageskarte/form', status=403)
+        formular = client.get('/resource/tageskarte/form')
+        formular.form['email'] = 'info@example.org'
+
+    with freeze_time("2026-05-29 10:15:01"):  # past 15-min expiry threshold
+        formular.form.submit(expect_errors=True, status=403)


### PR DESCRIPTION
Org: Fix reservation form crashing on expired session
  
Move remove_expired_reservation_sessions to run before bound_reservations so an expired session yields a clean 403 instead of potentially crashing when the template accesses attributes of a detached SQLAlchemy object.

TYPE: Bugfix
LINK: https://seantis-gmbh.sentry.io/issues/7432727459/activity/
