### PR TITLE
Onboarding: Fixes town assistant.

### DIFF
--- a/src/onegov/onboarding/models/town_assistant.py
+++ b/src/onegov/onboarding/models/town_assistant.py
@@ -177,44 +177,46 @@ class TownAssistant(Assistant):
             schema = self.get_schema(name)
             custom_config = self.config['configuration']
 
-            self.app.session_manager.set_current_schema(schema)
-            session = self.app.session_manager.session()
+            with self.app.session_manager.disable_change_signals():
+                self.app.session_manager.set_current_schema(schema)
+                session = self.app.session_manager.session()
 
-            if session.query(Organisation).first():
-                raise AlreadyExistsError
+                if session.query(Organisation).first():
+                    raise AlreadyExistsError
 
-            with self.app.temporary_depot(schema, **custom_config):
-                create_new_organisation(self.app, name=name, reply_to=user)
+                with self.app.temporary_depot(schema, **custom_config):
+                    create_new_organisation(self.app, name=name, reply_to=user)
 
-            org = session.query(Organisation).first()
-            assert org is not None and org.theme_options is not None
-            org.theme_options['primary-color-ui'] = color
+                org = session.query(Organisation).first()
+                assert org is not None and org.theme_options is not None
+                org.theme_options['primary-color-ui'] = color
 
-            users = UserCollection(self.app.session_manager.session())
-            assert not users.query().first()
+                users = UserCollection(self.app.session_manager.session())
+                assert not users.query().first()
 
-            users.add(user, password, 'admin')
+                users.add(user, password, 'admin')
 
-            title = request.translate(_('Welcome to OneGov Cloud'))
-            welcome_mail = render_template(
-                'mail_welcome.pt',
-                request,
-                {
-                    'url': 'https://{}'.format(self.get_domain(name)),
-                    'mail': user,
-                    'layout': MailLayout(self, request),
-                    'title': title,
-                    'org': name,
-                },
-            )
+                title = request.translate(_('Welcome to OneGov Cloud'))
+                welcome_mail = render_template(
+                    'mail_welcome.pt',
+                    request,
+                    {
+                        'url': 'https://{}'.format(self.get_domain(name)),
+                        'mail': user,
+                        'layout': MailLayout(self, request),
+                        'title': title,
+                        'org': name,
+                    },
+                )
 
-            self.app.send_transactional_email(
-                subject=title,
-                receivers=(user,),
-                content=welcome_mail,
-                reply_to='onegov@seantis.ch',
-            )
-            session.flush()
+                self.app.perform_reindex_in_transaction()
+                self.app.send_transactional_email(
+                    subject=title,
+                    receivers=(user,),
+                    content=welcome_mail,
+                    reply_to='onegov@seantis.ch',
+                )
+                session.flush()
 
         finally:
             self.app.session_manager.set_current_schema(current_schema)

--- a/src/onegov/onboarding/models/town_assistant.py
+++ b/src/onegov/onboarding/models/town_assistant.py
@@ -209,7 +209,7 @@ class TownAssistant(Assistant):
                     },
                 )
 
-                self.app.perform_reindex_in_transaction()
+                self.app.perform_reindex(dispose_session=False)
                 self.app.send_transactional_email(
                     subject=title,
                     receivers=(user,),

--- a/src/onegov/onboarding/models/town_assistant.py
+++ b/src/onegov/onboarding/models/town_assistant.py
@@ -177,42 +177,44 @@ class TownAssistant(Assistant):
             schema = self.get_schema(name)
             custom_config = self.config['configuration']
 
-            with self.app.session_manager.disable_change_signals():
-                self.app.session_manager.set_current_schema(schema)
-                session = self.app.session_manager.session()
+            self.app.session_manager.set_current_schema(schema)
+            session = self.app.session_manager.session()
 
-                if session.query(Organisation).first():
-                    raise AlreadyExistsError
+            if session.query(Organisation).first():
+                raise AlreadyExistsError
 
-                with self.app.temporary_depot(schema, **custom_config):
-                    create_new_organisation(self.app, name=name, reply_to=user)
+            with self.app.temporary_depot(schema, **custom_config):
+                create_new_organisation(self.app, name=name, reply_to=user)
 
-                org = session.query(Organisation).first()
-                assert org is not None and org.theme_options is not None
-                org.theme_options['primary-color-ui'] = color
+            org = session.query(Organisation).first()
+            assert org is not None and org.theme_options is not None
+            org.theme_options['primary-color-ui'] = color
 
-                users = UserCollection(self.app.session_manager.session())
-                assert not users.query().first()
+            users = UserCollection(self.app.session_manager.session())
+            assert not users.query().first()
 
-                users.add(user, password, 'admin')
+            users.add(user, password, 'admin')
 
-                title = request.translate(_('Welcome to OneGov Cloud'))
-                welcome_mail = render_template('mail_welcome.pt', request, {
+            title = request.translate(_('Welcome to OneGov Cloud'))
+            welcome_mail = render_template(
+                'mail_welcome.pt',
+                request,
+                {
                     'url': 'https://{}'.format(self.get_domain(name)),
                     'mail': user,
                     'layout': MailLayout(self, request),
                     'title': title,
-                    'org': name
-                })
+                    'org': name,
+                },
+            )
 
-                self.app.perform_reindex()
-                self.app.send_transactional_email(
-                    subject=title,
-                    receivers=(user, ),
-                    content=welcome_mail,
-                    reply_to='onegov@seantis.ch'
-                )
-                session.flush()
+            self.app.send_transactional_email(
+                subject=title,
+                receivers=(user,),
+                content=welcome_mail,
+                reply_to='onegov@seantis.ch',
+            )
+            session.flush()
 
         finally:
             self.app.session_manager.set_current_schema(current_schema)

--- a/src/onegov/search/integration.py
+++ b/src/onegov/search/integration.py
@@ -271,3 +271,35 @@ class SearchApp(morepath.App):
         session.invalidate()
         if session.bind and hasattr(session.bind, 'dispose'):
             session.bind.dispose()
+
+    def perform_reindex_in_transaction(self) -> None:
+        """Re-indexes all content of the current schema using the active
+        session's transaction.
+
+        Unlike :meth:`perform_reindex`, this does not commit, invalidate or
+        dispose of the session, making it safe to call within an active
+        request transaction (e.g. when bootstrapping a freshly created
+        schema during onboarding).
+
+        """
+        if not self.fts_search_enabled:
+            return
+
+        schema = self.schema
+        session = self.session()
+        for model in self.indexable_base_models():
+            query = session.query(model).options(undefer('*'))
+            query = apply_searchable_polymorphic_filter(
+                query, model, order_by_polymorphic_identity=True
+            )
+            self.fts_indexer.process(
+                (
+                    task
+                    for obj in query
+                    if (
+                        task := self.fts_orm_events.index_task(schema, obj)  # type: ignore[arg-type]
+                    )
+                    is not None
+                ),
+                session,
+            )

--- a/src/onegov/search/integration.py
+++ b/src/onegov/search/integration.py
@@ -218,8 +218,8 @@ class SearchApp(morepath.App):
             for model in self.searchable_models()
         }
 
-    def perform_reindex(self) -> None:
-        """ Re-indexes all content.
+    def perform_reindex(self, dispose_session: bool = True) -> None:
+        """Re-indexes all content.
 
         This is a heavy operation and should be run with consideration.
 
@@ -268,38 +268,7 @@ class SearchApp(morepath.App):
         with ThreadPoolExecutor() as executor:
             executor.map(reindex_model, self.indexable_base_models())
 
-        session.invalidate()
-        if session.bind and hasattr(session.bind, 'dispose'):
-            session.bind.dispose()
-
-    def perform_reindex_in_transaction(self) -> None:
-        """Re-indexes all content of the current schema using the active
-        session's transaction.
-
-        Unlike :meth:`perform_reindex`, this does not commit, invalidate or
-        dispose of the session, making it safe to call within an active
-        request transaction (e.g. when bootstrapping a freshly created
-        schema during onboarding).
-
-        """
-        if not self.fts_search_enabled:
-            return
-
-        schema = self.schema
-        session = self.session()
-        for model in self.indexable_base_models():
-            query = session.query(model).options(undefer('*'))
-            query = apply_searchable_polymorphic_filter(
-                query, model, order_by_polymorphic_identity=True
-            )
-            self.fts_indexer.process(
-                (
-                    task
-                    for obj in query
-                    if (
-                        task := self.fts_orm_events.index_task(schema, obj)  # type: ignore[arg-type]
-                    )
-                    is not None
-                ),
-                session,
-            )
+        if dispose_session:
+            session.invalidate()
+            if session.bind and hasattr(session.bind, 'dispose'):
+                session.bind.dispose()

--- a/src/onegov/server/core.py
+++ b/src/onegov/server/core.py
@@ -143,6 +143,10 @@ class Server:
             patch_morepath()
             morepath.autoscan()
 
+            # Commit all registered morepath applications
+            for app in self.applications.morepath_applications():
+                morepath.commit(app.application_class)  # type: ignore[arg-type]
+
     def handle_request(
         self,
         environ: WSGIEnvironment,


### PR DESCRIPTION
Note: The url to test locally is http://127.0.0.1:8080/onegov_onboarding



## Commit message

Onboarding: Fixes town assistant.

Submitting the town onboarding assistant failed at request commit. Three
seperate issues had to be resolved.

1. Morepath apps weren't committed at server startup, so
app.translations was empty → `assert translator is not None` in
`create_new_organisation`. (Fix: Commit all registered morepath applications)
Note: I am unsure at this point how this ever worked in the first place.

2. `perform_reindex()` bypasses the transaction machinery (raw `COMMIT`)
 for speed. That is fine for the CLI, but when called mid-request
  it tears down the request-managed transaction, so the request fails with
`ResourceClosedError: This transaction is closed.`

3. Added `perform_reindex_in_transaction()` which is only necessary because
of an otherwise `AssertionError` (`src/onegov/core/orm/cache.py:170`, inside `handle_orm_change receiver`)

TYPE: Bugfix
LINK: OGC-2727

## Checklist

- [x] I have performed a self-review of my code

