### PR TITLE
Include coordinate property in directory populate loop

### DIFF
--- a/src/onegov/directory/models/directory.py
+++ b/src/onegov/directory/models/directory.py
@@ -568,7 +568,11 @@ class Directory(Base, ContentMixin, TimestampMixin,
                     lambda v: isinstance(v, (InstrumentedAttribute, property))
                 )}
 
-                include = ('publication_start', 'publication_end', 'coordinates')
+                include = (
+                    'publication_start',
+                    'publication_end',
+                    'coordinates',
+                )
                 exclude = {k for k in exclude if k not in include}
 
                 super().populate_obj(obj, exclude=exclude)

--- a/src/onegov/directory/models/directory.py
+++ b/src/onegov/directory/models/directory.py
@@ -568,7 +568,7 @@ class Directory(Base, ContentMixin, TimestampMixin,
                     lambda v: isinstance(v, (InstrumentedAttribute, property))
                 )}
 
-                include = ('publication_start', 'publication_end')
+                include = ('publication_start', 'publication_end', 'coordinates')
                 exclude = {k for k in exclude if k not in include}
 
                 super().populate_obj(obj, exclude=exclude)

--- a/tests/shared/browser.py
+++ b/tests/shared/browser.py
@@ -259,7 +259,7 @@ class ExtendedBrowser:
         self,
         browser: Browser,
         baseurl: str | None = None,
-        wait_time: float = 8.0,
+        wait_time: float = 5.0,
     ) -> None:
         self.baseurl = baseurl
 


### PR DESCRIPTION
Directory: Explicitly include `coordinates` property in wtforms setattr loop

TYPE: Bugfix
LINK: ogc-3195