### PR TITLE
Core: Avoids `BrowserSession.pop` causing changes for non-existent keys

### DIFF
--- a/src/onegov/core/browser_session.py
+++ b/src/onegov/core/browser_session.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import transaction
 
-from contextlib import suppress
 from dogpile.cache.api import NO_VALUE
 from hashlib import blake2b
 
@@ -147,16 +146,15 @@ class BrowserSession:
         the process.
 
         """
-        value = self.get(name, default=default)
+        value = self._get(name)
+        if value is NO_VALUE:
+            return default
 
-        # we can run into a race condition here when two requests come in
-        # simultaneously - one request will get the value and delete it, the
-        # other will get the value and fail with an error when trying to
-        # delete it
-        #
-        # we can be pragmatic - if it's gone, it doesn't need to be deleted
-        with suppress(AttributeError):
-            delattr(self, name)
+        # NOTE: dogpile.cache deletes are idempotent and so are deletes
+        #       on our data manager layer, so we don't have to worry
+        #       about races, if the key no longer exists, this just does
+        #       not do anything, rather than throw an exception.
+        self.delete(name)
 
         return value
 
@@ -215,9 +213,8 @@ class BrowserSession:
 
         self.delete(name)
 
-    __setitem__ = __setattr__
-    __delitem__ = __delattr__
-    __delattr__ = __delattr__
+    __setitem__ = set
+    __delitem__ = delete
     __contains__ = has
 
     # DataManager interface

--- a/src/onegov/landsgemeinde/assets/js/ticker.js
+++ b/src/onegov/landsgemeinde/assets/js/ticker.js
@@ -25,7 +25,7 @@ document.addEventListener("DOMContentLoaded", function() {
     function onWebsocketNotification(message, _websocket) {
         if (document.body.id.search(message.assembly) !== -1) {
             if (message.event === 'refresh') {
-                window.location.reload();
+                window.location.href = window.location.href;
             }
             if (message.event === 'update') {
                 const agendaItem = document.querySelector('#' + message.node);
@@ -73,7 +73,7 @@ document.addEventListener("DOMContentLoaded", function() {
             .then((response) => {
                 const modified = response.headers.get("Last-Modified");
                 if (lastModified && modified !== lastModified) {
-                    window.location.reload();
+                    window.location.href = window.location.href;
                 }
                 lastModified = modified;
             })

--- a/src/onegov/landsgemeinde/views/assembly.py
+++ b/src/onegov/landsgemeinde/views/assembly.py
@@ -136,6 +136,12 @@ def view_assembly_ticker(
         .preloaded_by_assembly(self).all()
     )
 
+    # FIXME: For some reason we need there to be a session cookie
+    #        in order for the ticker to work correctly, which does
+    #        not really make much sense, since we don't need the
+    #        browser session for the ticker...
+    request.browser_session.mark_as_dirty()
+
     return {
         'layout': layout,
         'assembly': self,

--- a/tests/onegov/election_day/views/test_views.py
+++ b/tests/onegov/election_day/views/test_views.py
@@ -130,7 +130,6 @@ def test_cache_control(election_day_app_zg: TestApp) -> None:
 
     response = client.get('/')
     assert 'cache-control' not in response.headers
-    assert 'no_cache' not in response.headers['Set-Cookie']
     assert 'no_cache' not in client.cookies
 
     login(client)
@@ -217,12 +216,8 @@ def test_pages_cache(election_day_app_zg: TestApp) -> None:
     assert 'Set-Cookie' in response.headers  # no_cache
     assert len(election_day_app_zg.pages_cache.keys()) == 0
 
-    anonymous = Client(election_day_app_zg)
-    response = anonymous.get('/vote/0xdeadbeef/entities')
-    assert 'Set-Cookie' in response.headers  # session_id
-    assert len(election_day_app_zg.pages_cache.keys()) == 0
-
     # make sure HEAD requests are cached without qs
+    anonymous = Client(election_day_app_zg)
     anonymous.head('/vote/0xdeadbeef/')
     assert len(election_day_app_zg.pages_cache.keys()) == 1
 


### PR DESCRIPTION
## Commit message

Core: Avoids `BrowserSession.pop` causing changes for non-existent keys

This also cleans up some old sharp corners in the API

TYPE: Bugfix
## Checklist

- [x] I have performed a self-review of my code
