### PR TITLE
Form: Update image size information in submission after potential resizing

### DIFF
--- a/src/onegov/agency/forms/agency.py
+++ b/src/onegov/agency/forms/agency.py
@@ -16,7 +16,7 @@ from onegov.form import Form
 from onegov.form.fields import ChosenSelectField, HtmlField
 from onegov.form.fields import MultiCheckboxField
 from onegov.form.fields import UploadField
-from onegov.form.validators import FileSizeLimit, MIME_TYPES_IMAGE
+from onegov.form.validators import ImageFileSizeLimit, MIME_TYPES_IMAGE
 from onegov.gis import CoordinatesField
 from sqlalchemy import func
 from wtforms.fields import StringField
@@ -72,7 +72,7 @@ class ExtendedAgencyForm(Form):
     organigram = UploadField(
         label=_('Organigram'),
         validators=[
-            FileSizeLimit(1 * 1024 * 1024)
+            ImageFileSizeLimit()
         ],
         allowed_mimetypes=MIME_TYPES_IMAGE,
     )

--- a/src/onegov/agency/forms/agency.py
+++ b/src/onegov/agency/forms/agency.py
@@ -12,11 +12,15 @@ from onegov.agency.models import ExtendedAgency
 from onegov.agency.utils import handle_empty_p_tags
 from onegov.core.security import Private
 from onegov.core.utils import linkify, ensure_scheme
+from onegov.file.attachments import IMAGE_MAX_SIZE
 from onegov.form import Form
 from onegov.form.fields import ChosenSelectField, HtmlField
 from onegov.form.fields import MultiCheckboxField
 from onegov.form.fields import UploadField
-from onegov.form.validators import ImageFileSizeLimit, MIME_TYPES_IMAGE
+from onegov.form.validators import (
+    ImageSizeLimit,
+    MIME_TYPES_IMAGE,
+)
 from onegov.gis import CoordinatesField
 from sqlalchemy import func
 from wtforms.fields import StringField
@@ -72,7 +76,8 @@ class ExtendedAgencyForm(Form):
     organigram = UploadField(
         label=_('Organigram'),
         validators=[
-            ImageFileSizeLimit()
+            ImageSizeLimit(
+                max_bytes=1 * 1024 * 1024, max_dimensions=IMAGE_MAX_SIZE)
         ],
         allowed_mimetypes=MIME_TYPES_IMAGE,
     )

--- a/src/onegov/file/attachments.py
+++ b/src/onegov/file/attachments.py
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
         exif: NotRequired[Image.Exif]
 
 
-IMAGE_MAX_SIZE = 2048
+IMAGE_MAX_SIZE = 4096
 IMAGE_QUALITY = 85
 CHECKSUM_FUNCTION = 'md5'
 

--- a/src/onegov/file/attachments.py
+++ b/src/onegov/file/attachments.py
@@ -41,7 +41,7 @@ def get_svg_size_or_default(content: IO[bytes]) -> tuple[str, str]:
     return width, height
 
 
-def strip_exif_and_limit_and_store_image_size(
+def strip_exif_and_store_image_size(
     file: ProcessedUploadedFile,
     content: IO[bytes],
     content_type: str | None
@@ -69,23 +69,16 @@ def strip_exif_and_limit_and_store_image_size(
         # treat any other internal error as an UnidentifiedImageError
         raise UnidentifiedImageError from None
 
-    needs_resample = max(image.size) > IMAGE_MAX_SIZE
     has_exif = bool(hasattr(image, 'getexif') and image.getexif())
 
-    if needs_resample or has_exif:
+    if has_exif:
         params: _ImageSaveOptionalParams = {}
 
-        if has_exif:
-            # bake EXIF orientation into the image
-            ImageOps.exif_transpose(image, in_place=True)
+        # bake EXIF orientation into the image
+        ImageOps.exif_transpose(image, in_place=True)
 
-            # replace EXIF section with an empty one
-            params['exif'] = Image.Exif()
-
-        if needs_resample:
-            image.thumbnail(
-                (IMAGE_MAX_SIZE, IMAGE_MAX_SIZE), Image.Resampling.LANCZOS
-            )
+        # replace EXIF section with an empty one
+        params['exif'] = Image.Exif()
 
         content = SpooledTemporaryFile(INMEMORY_FILESIZE)  # noqa: SIM115
         try:
@@ -98,6 +91,48 @@ def strip_exif_and_limit_and_store_image_size(
     file.size = get_image_size(image)
 
     return content
+
+
+def resize_image(
+    content: IO[bytes],
+    max_size: int = IMAGE_MAX_SIZE
+) -> IO[bytes]:
+    """Resize an image so that neither dimension exceeds *max_size*.
+
+    When a resize is performed the EXIF orientation is baked in and the EXIF
+    block is stripped in the same pass, so the depot processor's EXIF-stripping
+    step becomes a no-op and the image is only encoded once.
+
+    Non-image streams and images that are already within the limit are returned
+    unchanged (seeked to 0).  Large images are resampled into a new
+    SpooledTemporaryFile.
+    """
+    content.seek(0)
+    try:
+        image = Image.open(content)
+        image.load()
+    except Exception:
+        content.seek(0)
+        return content
+
+    if max(image.size) <= max_size:
+        content.seek(0)
+        return content
+
+    params: _ImageSaveOptionalParams = {}
+    if hasattr(image, 'getexif') and image.getexif():
+        ImageOps.exif_transpose(image, in_place=True)
+        params['exif'] = Image.Exif()
+
+    image.thumbnail((max_size, max_size), Image.Resampling.LANCZOS)
+
+    out = SpooledTemporaryFile(INMEMORY_FILESIZE)  # noqa: SIM115
+    try:
+        image.save(out, image.format, quality=IMAGE_QUALITY, **params)
+    except ValueError:
+        image.save(out, image.format, **params)
+    out.seek(0)
+    return out
 
 
 def store_checksum(
@@ -141,7 +176,7 @@ class ProcessedUploadedFile(UploadedFile):
 
     processors = (
         store_checksum,
-        strip_exif_and_limit_and_store_image_size,
+        strip_exif_and_store_image_size,
         sanitize_svg_images,
         store_extract_and_pages,
     )

--- a/src/onegov/file/attachments.py
+++ b/src/onegov/file/attachments.py
@@ -46,6 +46,9 @@ def strip_exif_and_store_image_size(
     content: IO[bytes],
     content_type: str | None
 ) -> IO[bytes] | None:
+    # Resizing is NOT done here — it is the caller's responsibility
+    # (BaseImageFileCollection.add or ImageSizeLimit validator).  Plain File
+    # objects created outside those paths are stored at their original size.
 
     if content_type == 'image/svg+xml':
         file.size = get_svg_size_or_default(content)

--- a/src/onegov/form/collection.py
+++ b/src/onegov/form/collection.py
@@ -475,9 +475,13 @@ class FormSubmissionCollection:
             )
 
             submission.files.append(f)
+            self.session.flush()
 
-            # replace the data in the submission with a reference
+            # replace the data in the submission with a reference and
+            # update the size to reflect the actual stored size after
+            # any resizing/compression applied by the depot
             submission.data[field_id]['data'] = '@{}'.format(f.id)
+            submission.data[field_id]['size'] = f.reference.file.content_length
 
             # we need to mark these changes as only top-level json changes
             # are automatically propagated
@@ -516,9 +520,12 @@ class FormSubmissionCollection:
                     )
 
                     submission.files.append(f)
+                    self.session.flush()
 
-                    # replace the data in the submission with a reference
+                    # replace the data in the submission with a reference and
+                    # update the size to reflect the actual stored size
                     data['data'] = '@{}'.format(f.id)
+                    data['size'] = f.reference.file.content_length
 
                 datalist.append(data)
                 new_idx += 1

--- a/src/onegov/form/locale/de_ch/LC_MESSAGES/onegov.form.po
+++ b/src/onegov/form/locale/de_ch/LC_MESSAGES/onegov.form.po
@@ -159,6 +159,10 @@ msgstr "Ungültige Eingabe."
 msgid "The file is too large, please provide a file smaller than {}."
 msgstr "Die Datei ist zu gross, bitte senden Sie eine Datei kleiner als {}."
 
+#, python-format
+msgid "The image is too large, please provide an image smaller than {}."
+msgstr "Das Bild ist zu gross, bitte senden Sie ein Bild kleiner als {}."
+
 msgid ""
 "The password you wanted to use was found on list of commonly used passwords, "
 "please use a more secure password."

--- a/src/onegov/form/locale/fr_CH/LC_MESSAGES/onegov.form.po
+++ b/src/onegov/form/locale/fr_CH/LC_MESSAGES/onegov.form.po
@@ -159,6 +159,11 @@ msgid "The file is too large, please provide a file smaller than {}."
 msgstr ""
 "Le fichier est trop volumineux, veuillez fournir un fichier de moins de {}."
 
+#, python-format
+msgid "The image is too large, please provide an image smaller than {}."
+msgstr ""
+"L'image est trop volumineuse, veuillez fournir une image de moins de {}."
+
 msgid ""
 "The password you wanted to use was found on list of commonly used passwords, "
 "please use a more secure password."

--- a/src/onegov/form/locale/it_CH/LC_MESSAGES/onegov.form.po
+++ b/src/onegov/form/locale/it_CH/LC_MESSAGES/onegov.form.po
@@ -157,6 +157,11 @@ msgid "The file is too large, please provide a file smaller than {}."
 msgstr ""
 "Il file è troppo grande, si prega di fornire un file più piccolo di {}."
 
+#, python-format
+msgid "The image is too large, please provide an image smaller than {}."
+msgstr ""
+"L'immagine è troppo grande, si prega di fornire un'immagine più piccola di {}."
+
 msgid ""
 "The password you wanted to use was found on list of commonly used passwords, "
 "please use a more secure password."

--- a/src/onegov/form/locale/rm_CH/LC_MESSAGES/onegov.form.po
+++ b/src/onegov/form/locale/rm_CH/LC_MESSAGES/onegov.form.po
@@ -154,6 +154,10 @@ msgstr ""
 msgid "The file is too large, please provide a file smaller than {}."
 msgstr ""
 
+#, python-format
+msgid "The image is too large, please provide an image smaller than {}."
+msgstr ""
+
 msgid ""
 "The password you wanted to use was found on list of commonly used passwords, "
 "please use a more secure password."

--- a/src/onegov/form/validators.py
+++ b/src/onegov/form/validators.py
@@ -11,8 +11,10 @@ from datetime import date
 from datetime import datetime
 from decimal import Decimal
 from dateutil.relativedelta import relativedelta
+from io import BytesIO
 from mimetypes import types_map
-
+from onegov.core.utils import binary_to_dictionary, dictionary_to_binary
+from onegov.file.attachments import resize_image
 from onegov.file.utils import get_supported_image_mime_types
 from onegov.form import _
 from onegov.form.errors import (
@@ -134,9 +136,14 @@ class FileSizeLimit:
             raise ValidationError(message)
 
 
-class ImageFileSizeLimit(FileSizeLimit):
-    """ Like :class:`FileSizeLimit` but with a default suited for image uploads
-    and image-specific error messaging.
+class ImageSizeLimit(FileSizeLimit):
+    """ Like :class:`FileSizeLimit` but with a default suited for image
+    uploads, image-specific error messaging, and optional automatic resampling.
+
+    When *max_dimensions* is given, images whose longest side exceeds that
+    value are resampled (LANCZOS) before the byte-size check runs, so
+    over-sized images silently shrink rather than trigger a validation error —
+    unless the resampled image still exceeds *max_bytes*.
 
     Expects an :class:`onegov.form.fields.UploadField` instance.
 
@@ -148,8 +155,35 @@ class ImageFileSizeLimit(FileSizeLimit):
         'The image is too large, please provide an image smaller than {}.'
     )
 
-    def __init__(self, max_bytes: int = DEFAULT_MAX_BYTES):
+    def __init__(
+        self,
+        max_bytes: int = DEFAULT_MAX_BYTES,
+        max_dimensions: int | None = None,
+    ):
         super().__init__(max_bytes)
+        self.max_dimensions = max_dimensions
+
+    def __call__(self, form: Form, field: Field) -> None:
+        if (field.data
+                and self.max_dimensions is not None
+                and isinstance(field.data, dict)
+                and field.data.get('mimetype', '').startswith('image/')
+                and 'data' in field.data):
+            self._maybe_resize(field)
+        super().__call__(form, field)
+
+    def _maybe_resize(self, field: Field) -> None:
+        assert self.max_dimensions is not None
+        try:
+            binary = dictionary_to_binary(field.data)
+        except Exception:
+            return
+        buf = BytesIO(binary)
+        resized = resize_image(buf, self.max_dimensions)
+        if resized is buf:
+            return
+        filename = field.data.get('filename')
+        field.data = binary_to_dictionary(resized.read(), filename)
 
 
 MIME_TYPES_PDF = {

--- a/src/onegov/form/validators.py
+++ b/src/onegov/form/validators.py
@@ -134,6 +134,24 @@ class FileSizeLimit:
             raise ValidationError(message)
 
 
+class ImageFileSizeLimit(FileSizeLimit):
+    """ Like :class:`FileSizeLimit` but with a default suited for image uploads
+    and image-specific error messaging.
+
+    Expects an :class:`onegov.form.fields.UploadField` instance.
+
+    """
+
+    DEFAULT_MAX_BYTES = 20_000_000  # 20 MB
+
+    message = _(
+        'The image is too large, please provide an image smaller than {}.'
+    )
+
+    def __init__(self, max_bytes: int = DEFAULT_MAX_BYTES):
+        super().__init__(max_bytes)
+
+
 MIME_TYPES_PDF = {
     'application/pdf',
 }

--- a/src/onegov/org/cli.py
+++ b/src/onegov/org/cli.py
@@ -916,9 +916,15 @@ def fix_directory_files(
 def fix_submission_file_sizes(
     group_context: GroupContext
 ) -> Callable[[OrgRequest, OrgApp], None]:
-    """ Updates the file size stored in form submission data to reflect the
+    """
+    Updates the file size stored in form submission data to reflect the
     actual stored size (after resizing/compression) rather than the original
-    upload size. """
+    upload size.
+
+        `onegov-org --select /onegov_org/* fix-submission-file-sizes`
+        `onegov-org --select /onegov_town6/* fix-submission-file-sizes`
+
+    """
 
     def file_dicts(data: dict[str, object]) -> list[dict[str, object]]:
         """ Yields all single-file and multi-file dicts from submission
@@ -944,7 +950,10 @@ def fix_submission_file_sizes(
                 ).first()
                 if file is None:
                     continue
-                actual_size = file.reference.file.content_length
+                try:
+                    actual_size = file.reference.file.content_length
+                except OSError:
+                    continue
                 if file_dict.get('size') == actual_size:
                     continue
                 file_dict['size'] = actual_size

--- a/src/onegov/org/cli.py
+++ b/src/onegov/org/cli.py
@@ -911,6 +911,57 @@ def fix_directory_files(
     return execute
 
 
+@cli.command('fix-submission-file-sizes')
+@pass_group_context
+def fix_submission_file_sizes(
+    group_context: GroupContext
+) -> Callable[[OrgRequest, OrgApp], None]:
+    """ Updates the file size stored in form submission data to reflect the
+    actual stored size (after resizing/compression) rather than the original
+    upload size. """
+
+    def file_dicts(data: dict[str, object]) -> list[dict[str, object]]:
+        """ Yields all single-file and multi-file dicts from submission
+        data."""
+        result = []
+        for value in data.values():
+            if isinstance(value, dict):
+                result.append(value)
+            elif isinstance(value, list):
+                result.extend(item for item in value if isinstance(item, dict))
+        return result
+
+    def execute(request: OrgRequest, app: OrgApp) -> None:
+        count = 0
+        for submission in request.session.query(FormSubmission).all():
+            changed = False
+            for file_dict in file_dicts(submission.data):
+                ref = file_dict.get('data', '')
+                if not isinstance(ref, str) or not ref.startswith('@'):
+                    continue
+                file = request.session.query(File).filter_by(
+                    id=ref[1:]
+                ).first()
+                if file is None:
+                    continue
+                actual_size = file.reference.file.content_length
+                if file_dict.get('size') == actual_size:
+                    continue
+                file_dict['size'] = actual_size
+                changed = True
+                count += 1
+
+            if changed:
+                submission.data.changed()  # type:ignore[attr-defined]
+
+        click.secho(
+            f'{app.schema} - updated sizes for {count} file field(s)',
+            fg='green'
+        )
+
+    return execute
+
+
 @cli.command('migrate-town', context_settings={'singular': True})
 @pass_group_context
 def migrate_town(

--- a/src/onegov/org/forms/event.py
+++ b/src/onegov/org/forms/event.py
@@ -20,9 +20,10 @@ from onegov.form.fields import TimeField
 from onegov.form.fields import UploadField
 from onegov.form.fields import UploadFileWithORMSupport
 from onegov.form.utils import get_fields_from_class
+from onegov.file.attachments import IMAGE_MAX_SIZE
 from onegov.form.validators import (
     FileSizeLimit,
-    ImageFileSizeLimit,
+    ImageSizeLimit,
     ValidPhoneNumber,
     ValidFilterFormDefinition,
     MIME_TYPES_EXCEL,
@@ -129,7 +130,8 @@ class EventForm(Form):
         file_class=EventFile,
         validators=[
             Optional(),
-            ImageFileSizeLimit()
+            ImageSizeLimit(
+                max_bytes=5 * 1024 * 1024, max_dimensions=IMAGE_MAX_SIZE)
         ],
         allowed_mimetypes=(
             'image/gif',

--- a/src/onegov/org/forms/event.py
+++ b/src/onegov/org/forms/event.py
@@ -22,6 +22,7 @@ from onegov.form.fields import UploadFileWithORMSupport
 from onegov.form.utils import get_fields_from_class
 from onegov.form.validators import (
     FileSizeLimit,
+    ImageFileSizeLimit,
     ValidPhoneNumber,
     ValidFilterFormDefinition,
     MIME_TYPES_EXCEL,
@@ -128,7 +129,7 @@ class EventForm(Form):
         file_class=EventFile,
         validators=[
             Optional(),
-            FileSizeLimit(5 * 1024 * 1024)
+            ImageFileSizeLimit()
         ],
         allowed_mimetypes=(
             'image/gif',

--- a/src/onegov/org/forms/parliamentarian.py
+++ b/src/onegov/org/forms/parliamentarian.py
@@ -7,6 +7,7 @@ from onegov.form.fields import TranslatedSelectField
 from onegov.form.fields import UploadField
 from onegov.form.forms import NamedFileForm
 from onegov.form.validators import (
+    ImageFileSizeLimit,
     MIME_TYPES_IMAGE,
     ValidPhoneNumber
 )
@@ -52,7 +53,7 @@ class ParliamentarianForm(NamedFileForm):
     picture = UploadField(
         label=_('Picture'),
         fieldset=_('Basic properties'),
-        validators=[],
+        validators=[ImageFileSizeLimit()],
         allowed_mimetypes=MIME_TYPES_IMAGE,
     )
 

--- a/src/onegov/org/forms/parliamentarian.py
+++ b/src/onegov/org/forms/parliamentarian.py
@@ -6,8 +6,9 @@ from onegov.form.fields import PhoneNumberField
 from onegov.form.fields import TranslatedSelectField
 from onegov.form.fields import UploadField
 from onegov.form.forms import NamedFileForm
+from onegov.file.attachments import IMAGE_MAX_SIZE
 from onegov.form.validators import (
-    ImageFileSizeLimit,
+    ImageSizeLimit,
     MIME_TYPES_IMAGE,
     ValidPhoneNumber
 )
@@ -53,7 +54,7 @@ class ParliamentarianForm(NamedFileForm):
     picture = UploadField(
         label=_('Picture'),
         fieldset=_('Basic properties'),
-        validators=[ImageFileSizeLimit()],
+        validators=[ImageSizeLimit(max_dimensions=IMAGE_MAX_SIZE)],
         allowed_mimetypes=MIME_TYPES_IMAGE,
     )
 

--- a/src/onegov/org/models/file.py
+++ b/src/onegov/org/models/file.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import sedate
 
 from datetime import datetime
+from io import BytesIO
 from dateutil.relativedelta import relativedelta
 from functools import cached_property
 from itertools import chain, groupby
@@ -431,9 +432,12 @@ class BaseImageFileCollection[FileT: File](
         publish_date: datetime | None = None,
         publish_end_date: datetime | None = None
     ) -> FileT:
+        buf: IO[bytes] = (
+            BytesIO(content) if isinstance(content, bytes) else content
+        )
         return super().add(
             filename,
-            resize_image(content, IMAGE_MAX_SIZE),  # type: ignore[arg-type]
+            resize_image(buf, IMAGE_MAX_SIZE),
             note=note,
             published=published,
             publish_date=publish_date,

--- a/src/onegov/org/models/file.py
+++ b/src/onegov/org/models/file.py
@@ -11,6 +11,7 @@ from onegov.core.orm import as_selectable
 from onegov.core.orm.mixins import dict_property, meta_property
 from onegov.file import File, FileSet, FileCollection, FileSetCollection
 from onegov.file import SearchableFile
+from onegov.file.attachments import IMAGE_MAX_SIZE, resize_image
 from onegov.file.utils import IMAGE_MIME_TYPES_AND_SVG
 from onegov.form.validators import WhitelistedMimeType
 from onegov.org import _
@@ -24,10 +25,10 @@ from sqlalchemy import asc, desc, select, nullslast
 from typing import overload, Any, Literal, NamedTuple, TYPE_CHECKING
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable, Iterator
+    from typing import IO, Self
     from sqlalchemy.engine import Result
     from sqlalchemy.orm import Query, Session
     from sqlalchemy.sql import Select
-    from typing import Self
 
     class IdRow(NamedTuple):
         id: str
@@ -420,6 +421,24 @@ class BaseImageFileCollection[FileT: File](
 ):
 
     supported_content_types = IMAGE_MIME_TYPES_AND_SVG
+
+    def add(
+        self,
+        filename: str,
+        content: bytes | IO[bytes],
+        note: str | None = None,
+        published: bool = True,
+        publish_date: datetime | None = None,
+        publish_end_date: datetime | None = None
+    ) -> FileT:
+        return super().add(
+            filename,
+            resize_image(content, IMAGE_MAX_SIZE),  # type: ignore[arg-type]
+            note=note,
+            published=published,
+            publish_date=publish_date,
+            publish_end_date=publish_end_date,
+        )
 
 
 class ImageFileCollection(BaseImageFileCollection[ImageFile]):

--- a/src/onegov/pas/forms/parliamentarian.py
+++ b/src/onegov/pas/forms/parliamentarian.py
@@ -4,8 +4,9 @@ from onegov.form.fields import PhoneNumberField
 from onegov.form.fields import TranslatedSelectField
 from onegov.form.fields import UploadField
 from onegov.form.forms import NamedFileForm
+from onegov.file.attachments import IMAGE_MAX_SIZE
 from onegov.form.validators import (
-    ImageFileSizeLimit,
+    ImageSizeLimit,
     ValidPhoneNumber,
     MIME_TYPES_IMAGE
 )
@@ -75,7 +76,7 @@ class PASParliamentarianForm(NamedFileForm):
     picture = UploadField(
         label=_('Picture'),
         fieldset=_('Basic properties'),
-        validators=[ImageFileSizeLimit()],
+        validators=[ImageSizeLimit(max_dimensions=IMAGE_MAX_SIZE)],
         allowed_mimetypes=MIME_TYPES_IMAGE,
     )
 

--- a/src/onegov/pas/forms/parliamentarian.py
+++ b/src/onegov/pas/forms/parliamentarian.py
@@ -5,6 +5,7 @@ from onegov.form.fields import TranslatedSelectField
 from onegov.form.fields import UploadField
 from onegov.form.forms import NamedFileForm
 from onegov.form.validators import (
+    ImageFileSizeLimit,
     ValidPhoneNumber,
     MIME_TYPES_IMAGE
 )
@@ -74,6 +75,7 @@ class PASParliamentarianForm(NamedFileForm):
     picture = UploadField(
         label=_('Picture'),
         fieldset=_('Basic properties'),
+        validators=[ImageFileSizeLimit()],
         allowed_mimetypes=MIME_TYPES_IMAGE,
     )
 

--- a/tests/onegov/file/test_models.py
+++ b/tests/onegov/file/test_models.py
@@ -11,7 +11,6 @@ from onegov.core.orm import Base
 from onegov.core.orm.abstract import associated
 from onegov.core.utils import module_path
 from onegov.file import File, FileSet, AssociatedFiles, NamedFile
-from onegov.file.attachments import IMAGE_MAX_SIZE
 from onegov.file.filters import WithPDFThumbnailFilter
 from onegov.file.models.fileset import file_to_set_associations
 from tests.shared.utils import create_image
@@ -267,39 +266,19 @@ def test_pdf_preview_creation_with_erroneous_pdf(
 
 def test_max_image_size(session: Session) -> None:
     session.add(
-        File(
-            name='unchanged.png',
-            reference=create_image(IMAGE_MAX_SIZE, IMAGE_MAX_SIZE),
-        )
-    )
+        File(name='unchanged.png', reference=create_image(2048, 2048)))
     session.add(
-        File(
-            name='limited.png',
-            reference=create_image(IMAGE_MAX_SIZE + 1, IMAGE_MAX_SIZE),
-        )
-    )
+        File(name='limited.png', reference=create_image(2049, 2048)))
 
     transaction.commit()
 
     limited, unchanged = session.query(File).order_by(File.name).all()
 
-    assert Image.open(limited.reference.file).size == (
-        IMAGE_MAX_SIZE,
-        IMAGE_MAX_SIZE - 1,
-    )
-    assert Image.open(unchanged.reference.file).size == (
-        IMAGE_MAX_SIZE,
-        IMAGE_MAX_SIZE,
-    )
+    assert Image.open(limited.reference.file).size == (2048, 2047)
+    assert Image.open(unchanged.reference.file).size == (2048, 2048)
 
-    assert unchanged.reference.size == [
-        f'{IMAGE_MAX_SIZE}px',
-        f'{IMAGE_MAX_SIZE}px',
-    ]
-    assert limited.reference.size == [
-        f'{IMAGE_MAX_SIZE}px',
-        f'{IMAGE_MAX_SIZE - 1}px',
-    ]
+    assert unchanged.reference.size == ['2048px', '2048px']
+    assert limited.reference.size == ['2048px', '2047px']
 
     assert unchanged.reference.thumbnail_small['size'] == ['512px', '512px']
     assert limited.reference.thumbnail_small['size'][0] in ['512px', '511px']
@@ -358,10 +337,7 @@ def test_determine_unknown_svg_size(
 
     # use the default max size as the size if we can't determine one
     logo = session.query(File).order_by(File.name).one()
-    assert logo.reference.size == [
-        f'{IMAGE_MAX_SIZE}px',
-        f'{IMAGE_MAX_SIZE}px',
-    ]
+    assert logo.reference.size == ['2048px', '2048px']
 
 
 def test_associated_files(session: Session) -> None:

--- a/tests/onegov/file/test_models.py
+++ b/tests/onegov/file/test_models.py
@@ -11,6 +11,7 @@ from onegov.core.orm import Base
 from onegov.core.orm.abstract import associated
 from onegov.core.utils import module_path
 from onegov.file import File, FileSet, AssociatedFiles, NamedFile
+from onegov.file.attachments import IMAGE_MAX_SIZE
 from onegov.file.filters import WithPDFThumbnailFilter
 from onegov.file.models.fileset import file_to_set_associations
 from tests.shared.utils import create_image
@@ -265,18 +266,40 @@ def test_pdf_preview_creation_with_erroneous_pdf(
 
 
 def test_max_image_size(session: Session) -> None:
-    session.add(File(name='unchanged.png', reference=create_image(4096, 4096)))
-    session.add(File(name='limited.png', reference=create_image(4097, 4096)))
+    session.add(
+        File(
+            name='unchanged.png',
+            reference=create_image(IMAGE_MAX_SIZE, IMAGE_MAX_SIZE),
+        )
+    )
+    session.add(
+        File(
+            name='limited.png',
+            reference=create_image(IMAGE_MAX_SIZE + 1, IMAGE_MAX_SIZE),
+        )
+    )
 
     transaction.commit()
 
     limited, unchanged = session.query(File).order_by(File.name).all()
 
-    assert Image.open(limited.reference.file).size == (4096, 4095)
-    assert Image.open(unchanged.reference.file).size == (4096, 4096)
+    assert Image.open(limited.reference.file).size == (
+        IMAGE_MAX_SIZE,
+        IMAGE_MAX_SIZE - 1,
+    )
+    assert Image.open(unchanged.reference.file).size == (
+        IMAGE_MAX_SIZE,
+        IMAGE_MAX_SIZE,
+    )
 
-    assert unchanged.reference.size == ['4096px', '4096px']
-    assert limited.reference.size == ['4096px', '4095px']
+    assert unchanged.reference.size == [
+        f'{IMAGE_MAX_SIZE}px',
+        f'{IMAGE_MAX_SIZE}px',
+    ]
+    assert limited.reference.size == [
+        f'{IMAGE_MAX_SIZE}px',
+        f'{IMAGE_MAX_SIZE - 1}px',
+    ]
 
     assert unchanged.reference.thumbnail_small['size'] == ['512px', '512px']
     assert limited.reference.thumbnail_small['size'][0] in ['512px', '511px']
@@ -335,7 +358,10 @@ def test_determine_unknown_svg_size(
 
     # use the default max size as the size if we can't determine one
     logo = session.query(File).order_by(File.name).one()
-    assert logo.reference.size == ['4096px', '4096px']
+    assert logo.reference.size == [
+        f'{IMAGE_MAX_SIZE}px',
+        f'{IMAGE_MAX_SIZE}px',
+    ]
 
 
 def test_associated_files(session: Session) -> None:

--- a/tests/onegov/file/test_models.py
+++ b/tests/onegov/file/test_models.py
@@ -265,18 +265,18 @@ def test_pdf_preview_creation_with_erroneous_pdf(
 
 
 def test_max_image_size(session: Session) -> None:
-    session.add(File(name='unchanged.png', reference=create_image(2048, 2048)))
-    session.add(File(name='limited.png', reference=create_image(2049, 2048)))
+    session.add(File(name='unchanged.png', reference=create_image(4096, 4096)))
+    session.add(File(name='limited.png', reference=create_image(4097, 4096)))
 
     transaction.commit()
 
     limited, unchanged = session.query(File).order_by(File.name).all()
 
-    assert Image.open(limited.reference.file).size == (2048, 2047)
-    assert Image.open(unchanged.reference.file).size == (2048, 2048)
+    assert Image.open(limited.reference.file).size == (4096, 4095)
+    assert Image.open(unchanged.reference.file).size == (4096, 4096)
 
-    assert unchanged.reference.size == ['2048px', '2048px']
-    assert limited.reference.size == ['2048px', '2047px']
+    assert unchanged.reference.size == ['4096px', '4096px']
+    assert limited.reference.size == ['4096px', '4095px']
 
     assert unchanged.reference.thumbnail_small['size'] == ['512px', '512px']
     assert limited.reference.thumbnail_small['size'][0] in ['512px', '511px']
@@ -335,7 +335,7 @@ def test_determine_unknown_svg_size(
 
     # use the default max size as the size if we can't determine one
     logo = session.query(File).order_by(File.name).one()
-    assert logo.reference.size == ['2048px', '2048px']
+    assert logo.reference.size == ['4096px', '4096px']
 
 
 def test_associated_files(session: Session) -> None:

--- a/tests/onegov/file/test_models.py
+++ b/tests/onegov/file/test_models.py
@@ -264,25 +264,27 @@ def test_pdf_preview_creation_with_erroneous_pdf(
     assert thumb.read() == thumbnail_medium_pdf_preview_fallback.read()
 
 
-def test_max_image_size(session: Session) -> None:
+def test_image_size_stored_for_base_file(session: Session) -> None:
+    # Plain File objects no longer resize — resizing lives in
+    # BaseImageFileCollection.add(). The processor only strips EXIF and
+    # records dimensions.
     session.add(
-        File(name='unchanged.png', reference=create_image(2048, 2048)))
+        File(name='large.png', reference=create_image(2049, 2048)))
     session.add(
-        File(name='limited.png', reference=create_image(2049, 2048)))
+        File(name='small.png', reference=create_image(2048, 2048)))
 
     transaction.commit()
 
-    limited, unchanged = session.query(File).order_by(File.name).all()
+    large, small = session.query(File).order_by(File.name).all()
 
-    assert Image.open(limited.reference.file).size == (2048, 2047)
-    assert Image.open(unchanged.reference.file).size == (2048, 2048)
+    assert Image.open(large.reference.file).size == (2049, 2048)
+    assert Image.open(small.reference.file).size == (2048, 2048)
 
-    assert unchanged.reference.size == ['2048px', '2048px']
-    assert limited.reference.size == ['2048px', '2047px']
+    assert large.reference.size == ['2049px', '2048px']
+    assert small.reference.size == ['2048px', '2048px']
 
-    assert unchanged.reference.thumbnail_small['size'] == ['512px', '512px']
-    assert limited.reference.thumbnail_small['size'][0] in ['512px', '511px']
-    assert limited.reference.thumbnail_small['size'][1] in ['512px', '511px']
+    assert large.reference.thumbnail_small['size'][0] in ['512px', '511px']
+    assert small.reference.thumbnail_small['size'] == ['512px', '512px']
 
 
 def test_checksum(session: Session) -> None:
@@ -337,7 +339,7 @@ def test_determine_unknown_svg_size(
 
     # use the default max size as the size if we can't determine one
     logo = session.query(File).order_by(File.name).one()
-    assert logo.reference.size == ['2048px', '2048px']
+    assert logo.reference.size == ['4096px', '4096px']
 
 
 def test_associated_files(session: Session) -> None:

--- a/tests/onegov/form/test_collection.py
+++ b/tests/onegov/form/test_collection.py
@@ -5,7 +5,7 @@ import pytest
 from datetime import timedelta
 from io import BytesIO
 from onegov.file import File
-from onegov.file.attachments import IMAGE_MAX_SIZE, IMAGE_QUALITY
+from onegov.file.attachments import IMAGE_QUALITY
 from onegov.form import CompleteFormSubmission
 from onegov.form import FormCollection
 from onegov.form import parse_form
@@ -500,23 +500,20 @@ def test_add_externally_defined_submission(session: Session) -> None:
 
 def test_upload_image_size_stored_as_actual_size(session: Session) -> None:
     """ The size stored in the submission data must reflect the actual stored
-    file size (after resizing/compression), not the original upload size. """
+    file size, not the original upload size. """
     collection = FormCollection(session)
 
     definition = collection.definitions.add(
         'Photo', definition="Photo = *.jpg|*.png"
     )
 
-    # create an image larger than IMAGE_MAX_SIZE so it will be resized
-    original_size = IMAGE_MAX_SIZE + 1000
-    img = Image.new('RGB', (original_size, original_size), color=(255, 0, 0))
+    img = Image.new('RGB', (200, 200), color=(255, 0, 0))
     buf = BytesIO()
     img.save(buf, format='JPEG', quality=IMAGE_QUALITY)
-    original_bytes = buf.getvalue()
     buf.seek(0)
 
     data: Any = FileMultiDict()
-    data.add_file('photo', buf, filename='big.jpg')
+    data.add_file('photo', buf, filename='photo.jpg')
 
     submission = collection.submissions.add(
         'photo', definition.form_class(data), state='pending'
@@ -528,8 +525,5 @@ def test_upload_image_size_stored_as_actual_size(session: Session) -> None:
     stored_file = submission.files[0]
     actual_size = stored_file.reference.file.content_length
 
-    # the stored file must be smaller than the original (was resized)
-    assert actual_size < len(original_bytes)
-
-    # the size in the submission data must match the actual stored size
+    # the size in the submission data must match the actual stored file size
     assert submission.data['photo']['size'] == actual_size

--- a/tests/onegov/form/test_collection.py
+++ b/tests/onegov/form/test_collection.py
@@ -5,12 +5,14 @@ import pytest
 from datetime import timedelta
 from io import BytesIO
 from onegov.file import File
+from onegov.file.attachments import IMAGE_MAX_SIZE, IMAGE_QUALITY
 from onegov.form import CompleteFormSubmission
 from onegov.form import FormCollection
 from onegov.form import parse_form
 from onegov.form import PendingFormSubmission
 from onegov.form.errors import UnableToComplete
 from onegov.form.utils import hash_definition
+from PIL import Image
 from sedate import utcnow
 from sqlalchemy.exc import IntegrityError
 from textwrap import dedent
@@ -494,3 +496,40 @@ def test_add_externally_defined_submission(session: Session) -> None:
     collection.submissions.remove_old_pending_submissions(
         older_than=date, include_external=True)
     assert collection.submissions.query().count() == 0
+
+
+def test_upload_image_size_stored_as_actual_size(session: Session) -> None:
+    """ The size stored in the submission data must reflect the actual stored
+    file size (after resizing/compression), not the original upload size. """
+    collection = FormCollection(session)
+
+    definition = collection.definitions.add(
+        'Photo', definition="Photo = *.jpg|*.png"
+    )
+
+    # create an image larger than IMAGE_MAX_SIZE so it will be resized
+    original_size = IMAGE_MAX_SIZE + 1000
+    img = Image.new('RGB', (original_size, original_size), color=(255, 0, 0))
+    buf = BytesIO()
+    img.save(buf, format='JPEG', quality=IMAGE_QUALITY)
+    original_bytes = buf.getvalue()
+    buf.seek(0)
+
+    data: Any = FileMultiDict()
+    data.add_file('photo', buf, filename='big.jpg')
+
+    submission = collection.submissions.add(
+        'photo', definition.form_class(data), state='pending'
+    )
+    session.flush()
+    session.refresh(submission)
+
+    assert len(submission.files) == 1
+    stored_file = submission.files[0]
+    actual_size = stored_file.reference.file.content_length
+
+    # the stored file must be smaller than the original (was resized)
+    assert actual_size < len(original_bytes)
+
+    # the size in the submission data must match the actual stored size
+    assert submission.data['photo']['size'] == actual_size

--- a/tests/onegov/form/test_validators.py
+++ b/tests/onegov/form/test_validators.py
@@ -7,7 +7,7 @@ from onegov.form import Form
 from onegov.form import parse_form
 from onegov.form.fields import UploadField
 from onegov.form.validators import ExpectedExtensions
-from onegov.form.validators import ImageFileSizeLimit
+from onegov.form.validators import ImageSizeLimit
 from onegov.form.validators import InputRequiredIf
 from onegov.form.validators import ValidSwissSocialSecurityNumber
 from onegov.form.validators import UniqueColumnValue
@@ -223,32 +223,32 @@ def test_image_file_size_limit() -> None:
         def gettext(self, text: str) -> str:
             return text
 
-    validator = ImageFileSizeLimit()
-    assert validator.max_bytes == ImageFileSizeLimit.DEFAULT_MAX_BYTES
+    validator = ImageSizeLimit()
+    assert validator.max_bytes == ImageSizeLimit.DEFAULT_MAX_BYTES
 
     # no data — pass
     validator(None, Field(None))  # type: ignore[arg-type]
 
     # within limit — pass
-    validator(None, Field(ImageFileSizeLimit.DEFAULT_MAX_BYTES))  # type: ignore[arg-type]
+    validator(None, Field(ImageSizeLimit.DEFAULT_MAX_BYTES))  # type: ignore[arg-type]
 
     # exceeds limit — fail
     with raises(ValidationError):
-        validator(None, Field(ImageFileSizeLimit.DEFAULT_MAX_BYTES + 1))  # type: ignore[arg-type]
+        validator(None, Field(ImageSizeLimit.DEFAULT_MAX_BYTES + 1))  # type: ignore[arg-type]
 
     # custom limit
     with raises(ValidationError):
-        ImageFileSizeLimit(max_bytes=1024)(None, Field(1025))  # type: ignore[arg-type]
+        ImageSizeLimit(max_bytes=1024)(None, Field(1025))  # type: ignore[arg-type]
 
     with raises(ValidationError, match='The image is too large,'):
-        validator(None, Field(ImageFileSizeLimit.DEFAULT_MAX_BYTES + 1))  # type: ignore[arg-type]
+        validator(None, Field(ImageSizeLimit.DEFAULT_MAX_BYTES + 1))  # type: ignore[arg-type]
 
 
 def test_image_file_size_limit_on_upload_field() -> None:
     limit = 2_000  # 2 KB
 
     class PhotoForm(Form):
-        photo = UploadField(validators=[ImageFileSizeLimit(max_bytes=limit)])
+        photo = UploadField(validators=[ImageSizeLimit(max_bytes=limit)])
 
     def make_form(img: Image.Image, fmt: str) -> PhotoForm:
         buf = BytesIO()
@@ -278,7 +278,7 @@ def test_image_file_size_limit_rejects_on_form_submission() -> None:
         def on_request(self) -> None:
             self.photo.validators = [
                 *self.photo.validators,
-                ImageFileSizeLimit(max_bytes=limit),
+                ImageSizeLimit(max_bytes=limit),
             ]
 
     small = Image.new('RGB', (10, 10), color=(0, 128, 0))
@@ -306,3 +306,184 @@ def test_image_file_size_limit_rejects_on_form_submission() -> None:
     form_large.on_request()
     assert not form_large.validate()
     assert 'The image is too large,' in form_large.photo.errors[0]
+
+
+def test_image_size_limit_resizes_large_image() -> None:
+    """max_dimensions triggers automatic resampling before the byte check."""
+
+    max_dim = 100
+
+    class PhotoForm(Form):
+        photo = UploadField(
+            validators=[ImageSizeLimit(max_dimensions=max_dim)]
+        )
+
+    def make_form(img: Image.Image, fmt: str) -> PhotoForm:
+        buf = BytesIO()
+        img.save(buf, format=fmt)
+        buf.seek(0)
+        data: Any = FileMultiDict()
+        data.add_file('photo', buf, filename=f'test.{fmt.lower()}')
+        return PhotoForm(data)
+
+    # Image larger than max_dim — should be resized and pass validation
+    large = make_form(Image.new('RGB', (500, 500), color=(0, 128, 0)), 'JPEG')
+    assert large.validate(), large.photo.errors
+    # field.data reflects the resized image
+    assert large.photo.data is not None
+    assert large.photo.data.get('size', 0) > 0
+
+    # Image already within limit — should pass untouched
+    small = make_form(Image.new('RGB', (50, 50), color=(0, 0, 255)), 'JPEG')
+    assert small.validate(), small.photo.errors
+
+    # Image too large even after resizing (byte limit very tight)
+    class TightForm(Form):
+        photo = UploadField(
+            validators=[ImageSizeLimit(max_bytes=1, max_dimensions=max_dim)]
+        )
+
+    def make_tight(img: Image.Image, fmt: str) -> TightForm:
+        buf = BytesIO()
+        img.save(buf, format=fmt)
+        buf.seek(0)
+        data: Any = FileMultiDict()
+        data.add_file('photo', buf, filename=f'test.{fmt.lower()}')
+        return TightForm(data)
+
+    tight = make_tight(Image.new('RGB', (500, 500), color=(255, 0, 0)), 'JPEG')
+    assert not tight.validate()
+    assert tight.photo.errors
+    assert 'The image is too large,' in tight.photo.errors[0]
+
+
+def test_image_size_limit_output_dimensions() -> None:
+    """Resized image dimensions are within max_dimensions; aspect
+    ratio kept."""
+    from onegov.core.utils import dictionary_to_binary
+
+    max_dim = 100
+
+    class PhotoForm(Form):
+        photo = UploadField(
+            validators=[ImageSizeLimit(max_dimensions=max_dim)])
+
+    def submit(img: Image.Image, fmt: str) -> PhotoForm:
+        buf = BytesIO()
+        img.save(buf, format=fmt)
+        buf.seek(0)
+        data: Any = FileMultiDict()
+        data.add_file('photo', buf, filename=f'test.{fmt.lower()}')
+        form = PhotoForm(data)
+        assert form.validate(), form.photo.errors
+        return form
+
+    def decoded_size(form: PhotoForm) -> tuple[int, int]:
+        assert form.photo.data is not None
+        return Image.open(BytesIO(dictionary_to_binary(form.photo.data))).size  # type: ignore[arg-type]
+
+    # Square: both sides land exactly on max_dim
+    w, h = decoded_size(submit(Image.new('RGB', (500, 500)), 'JPEG'))
+    assert w == max_dim and h == max_dim
+
+    # Landscape: width is the long side → clamped to max_dim, height scales
+    w, h = decoded_size(submit(Image.new('RGB', (600, 300)), 'JPEG'))
+    assert w == max_dim
+    assert h == 50  # 300 × (100/600)
+
+    # Portrait: height is the long side → height clamped, width scales
+    w, h = decoded_size(submit(Image.new('RGB', (300, 600)), 'JPEG'))
+    assert w == 50  # 300 × (100/600)
+    assert h == max_dim
+
+    # PNG format — quality param is unsupported, must not raise
+    w, h = decoded_size(submit(Image.new('RGB', (500, 500)), 'PNG'))
+    assert w == max_dim and h == max_dim
+
+
+def test_image_size_limit_size_field_updated_after_resize() -> None:
+    """field.data['size'] reflects the resized byte count, not the original."""
+    max_dim = 50
+
+    class PhotoForm(Form):
+        photo = UploadField(
+            validators=[ImageSizeLimit(max_dimensions=max_dim)])
+
+    original = Image.new('RGB', (800, 800), color=(128, 64, 32))
+    buf = BytesIO()
+    original.save(buf, format='JPEG')
+    original_size = buf.tell()
+    buf.seek(0)
+
+    data: Any = FileMultiDict()
+    data.add_file('photo', buf, filename='test.jpg')
+    form = PhotoForm(data)
+    assert form.validate(), form.photo.errors
+
+    assert form.photo.data is not None
+    stored_size = form.photo.data['size']
+    assert stored_size < original_size
+
+
+def test_image_size_limit_no_resize_when_within_limit() -> None:
+    """Images already within max_dimensions are stored unchanged."""
+    max_dim = 200
+
+    class PhotoForm(Form):
+        photo = UploadField(
+            validators=[ImageSizeLimit(max_dimensions=max_dim)])
+
+    img = Image.new('RGB', (100, 80), color=(0, 200, 100))
+    buf = BytesIO()
+    img.save(buf, format='JPEG')
+    original_size = buf.tell()
+    buf.seek(0)
+
+    data: Any = FileMultiDict()
+    data.add_file('photo', buf, filename='small.jpg')
+    form = PhotoForm(data)
+    assert form.validate(), form.photo.errors
+
+    # byte count must not increase (no re-encoding happened)
+    assert form.photo.data is not None
+    assert form.photo.data['size'] == original_size
+
+
+def test_image_size_limit_exif_orientation_baked_in() -> None:
+    """When resize happens, EXIF rotation is baked into the pixel data."""
+    from onegov.core.utils import dictionary_to_binary
+
+    # Build a minimal JPEG with EXIF orientation=6 (90° CW → swap W/H)
+    # We construct only the EXIF IFD bytes we need; Pillow reads them on open.
+    def jpeg_with_exif_orientation(
+        width: int, height: int, orientation: int
+    ) -> bytes:
+        img = Image.new('RGB', (width, height), color=(200, 100, 50))
+        exif = img.getexif()
+        exif[0x0112] = orientation  # 0x0112 = Orientation tag
+        buf = BytesIO()
+        img.save(buf, format='JPEG', exif=exif.tobytes())
+        buf.seek(0)
+        return buf.read()
+
+    max_dim = 100
+    # 300 wide × 600 tall, orientation=6 means "rotate 90° CW" →
+    # effective 600×300
+    raw = jpeg_with_exif_orientation(300, 600, orientation=6)
+
+    class PhotoForm(Form):
+        photo = UploadField(
+            validators=[ImageSizeLimit(max_dimensions=max_dim)])
+
+    data: Any = FileMultiDict()
+    data.add_file('photo', BytesIO(raw), filename='rotated.jpg')
+    form = PhotoForm(data)
+    assert form.validate(), form.photo.errors
+
+    assert form.photo.data is not None
+    result = Image.open(BytesIO(dictionary_to_binary(form.photo.data)))  # type: ignore[arg-type]
+    # After baking orientation=6 the image is 600×300 (landscape).
+    # Resized to max_dim=100: width=100, height=50.
+    assert result.size == (max_dim, 50)
+    # EXIF block should be cleared (no Orientation tag left)
+    assert result.getexif().get(0x0112) is None

--- a/tests/onegov/form/test_validators.py
+++ b/tests/onegov/form/test_validators.py
@@ -1,18 +1,26 @@
 from __future__ import annotations
 
+from io import BytesIO
 from onegov.core.orm import SessionManager
+from onegov.file.attachments import IMAGE_QUALITY
+from onegov.form import Form
+from onegov.form import parse_form
+from onegov.form.fields import UploadField
 from onegov.form.validators import ExpectedExtensions
+from onegov.form.validators import ImageFileSizeLimit
 from onegov.form.validators import InputRequiredIf
 from onegov.form.validators import ValidSwissSocialSecurityNumber
 from onegov.form.validators import UniqueColumnValue
 from onegov.form.validators import ValidPhoneNumber
+from PIL import Image
 from pytest import raises
 from sqlalchemy.orm import mapped_column, registry, DeclarativeBase, Mapped
+from werkzeug.datastructures import FileMultiDict
 from wtforms.validators import StopValidation
 from wtforms.validators import ValidationError
 
 
-from typing import Any, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from onegov.core.orm import Base  # noqa: F401
     from onegov.core.request import CoreRequest
@@ -205,3 +213,96 @@ def test_swiss_ssn_validator() -> None:
 def test_mp3_extension_nonempty_whitelist() -> None:
     validator = ExpectedExtensions(['.mp3'])
     assert validator.whitelist
+
+
+def test_image_file_size_limit() -> None:
+    class Field:
+        def __init__(self, size: int | None) -> None:
+            self.data = {'size': size} if size is not None else None
+
+        def gettext(self, text: str) -> str:
+            return text
+
+    validator = ImageFileSizeLimit()
+    assert validator.max_bytes == ImageFileSizeLimit.DEFAULT_MAX_BYTES
+
+    # no data — pass
+    validator(None, Field(None))  # type: ignore[arg-type]
+
+    # within limit — pass
+    validator(None, Field(ImageFileSizeLimit.DEFAULT_MAX_BYTES))  # type: ignore[arg-type]
+
+    # exceeds limit — fail
+    with raises(ValidationError):
+        validator(None, Field(ImageFileSizeLimit.DEFAULT_MAX_BYTES + 1))  # type: ignore[arg-type]
+
+    # custom limit
+    with raises(ValidationError):
+        ImageFileSizeLimit(max_bytes=1024)(None, Field(1025))  # type: ignore[arg-type]
+
+    with raises(ValidationError, match='The image is too large,'):
+        validator(None, Field(ImageFileSizeLimit.DEFAULT_MAX_BYTES + 1))  # type: ignore[arg-type]
+
+
+def test_image_file_size_limit_on_upload_field() -> None:
+    limit = 2_000  # 2 KB
+
+    class PhotoForm(Form):
+        photo = UploadField(validators=[ImageFileSizeLimit(max_bytes=limit)])
+
+    def make_form(img: Image.Image, fmt: str) -> PhotoForm:
+        buf = BytesIO()
+        img.save(buf, format=fmt)
+        buf.seek(0)
+        data: Any = FileMultiDict()
+        data.add_file('photo', buf, filename=f'test.{fmt.lower()}')
+        return PhotoForm(data)
+
+    # small solid-color JPEG — well under 2 KB
+    small = make_form(Image.new('RGB', (10, 10), color=(0, 128, 0)), 'JPEG')
+    assert small.validate(), small.photo.errors
+
+    # large PNG (1000×1000) — will exceed 2 KB
+    large = make_form(Image.new('RGB', (1000, 1000), color=(255, 0, 0)), 'PNG')
+    assert not large.validate()
+    assert large.photo.errors
+    assert 'The image is too large,' in large.photo.errors[0]
+
+
+def test_image_file_size_limit_rejects_on_form_submission() -> None:
+    limit = 1_000  # 1 KB — small enough that a 1000×1000 PNG always exceeds it
+
+    BaseForm = parse_form("Photo = *.jpg|*.png")
+
+    class PhotoForm(BaseForm):  # type: ignore[valid-type,misc]
+        def on_request(self) -> None:
+            self.photo.validators = [
+                *self.photo.validators,
+                ImageFileSizeLimit(max_bytes=limit),
+            ]
+
+    small = Image.new('RGB', (10, 10), color=(0, 128, 0))
+    buf_small = BytesIO()
+    small.save(buf_small, format='JPEG', quality=IMAGE_QUALITY)
+    buf_small.seek(0)
+    assert len(buf_small.getvalue()) < limit
+
+    data_small: Any = FileMultiDict()
+    data_small.add_file('photo', buf_small, filename='small.jpg')
+    form_small = PhotoForm(data_small)
+    form_small.on_request()
+    assert form_small.validate()
+    assert not form_small.photo.errors
+
+    large = Image.new('RGB', (1000, 1000), color=(255, 0, 0))
+    buf_large = BytesIO()
+    large.save(buf_large, format='PNG')
+    buf_large.seek(0)
+    assert len(buf_large.getvalue()) > limit
+
+    data_large: Any = FileMultiDict()
+    data_large.add_file('photo', buf_large, filename='large.png')
+    form_large = PhotoForm(data_large)
+    form_large.on_request()
+    assert not form_large.validate()
+    assert 'The image is too large,' in form_large.photo.errors[0]

--- a/tests/onegov/org/test_models.py
+++ b/tests/onegov/org/test_models.py
@@ -8,7 +8,9 @@ from datetime import datetime, date
 from freezegun import freeze_time
 from onegov.core.utils import module_path
 from onegov.core.utils import Bunch
+from onegov.file.attachments import IMAGE_MAX_SIZE
 from onegov.org.models import Clipboard, ImageFileCollection, PushNotification
+from PIL import Image
 from onegov.org.models import News, NewsCollection
 from onegov.org.models import Organisation
 from onegov.org.models import SiteCollection
@@ -465,3 +467,27 @@ def test_duplicate_prevention_push_notifications(session: Session) -> None:
         PushNotification.record_sent_notification(
             session, news_id, "topic1", {"status": "sent"}
         )
+
+
+def test_image_file_collection_resizes_large_images(session: Session) -> None:
+    """ImageFileCollection must resize images that exceed IMAGE_MAX_SIZE."""
+    collection = ImageFileCollection(session)
+
+    large = IMAGE_MAX_SIZE + 500
+    image = collection.add('big.png', create_image(large, large))
+    session.flush()
+
+    stored_size = Image.open(image.reference.file).size
+    assert stored_size[0] <= IMAGE_MAX_SIZE
+    assert stored_size[1] <= IMAGE_MAX_SIZE
+
+    # an image already within the limit must not be altered
+    small = collection.add(
+        'small.png', create_image(IMAGE_MAX_SIZE, IMAGE_MAX_SIZE)
+    )
+    session.flush()
+
+    assert Image.open(small.reference.file).size == (
+        IMAGE_MAX_SIZE,
+        IMAGE_MAX_SIZE,
+    )


### PR DESCRIPTION
Form: Update image size information in submission after potential resizing

TYPE: Feature
LINK: ogc-3199
HINT: `onegov-org --select /onegov_org/* fix-submission-file-sizes`
HINT: `onegov-org --select /onegov_town6/* fix-submission-file-sizes`