### PR TITLE
Feature/ogc 3142 people strip first name last name and function

### DIFF
--- a/src/onegov/activity/models/volunteer.py
+++ b/src/onegov/activity/models/volunteer.py
@@ -2,7 +2,11 @@ from __future__ import annotations
 
 from datetime import date
 from onegov.core.orm import Base
-from onegov.core.orm.mixins import ContentMixin, TimestampMixin
+from onegov.core.orm.mixins import (
+    ContentMixin,
+    StripWhitespaceMixin,
+    TimestampMixin,
+)
 from sqlalchemy import Enum, ForeignKey
 from sqlalchemy.orm import mapped_column, relationship, Mapped
 from uuid import uuid4, UUID
@@ -19,7 +23,7 @@ type VolunteerState = Literal[
 ]
 
 
-class Volunteer(Base, ContentMixin, TimestampMixin):
+class Volunteer(Base, StripWhitespaceMixin, ContentMixin, TimestampMixin):
     """ Describes a volunteer that has signed up to fulfill an
     occasion need.
 

--- a/src/onegov/core/orm/mixins/__init__.py
+++ b/src/onegov/core/orm/mixins/__init__.py
@@ -6,6 +6,7 @@ from onegov.core.orm.mixins.content import data_property
 from onegov.core.orm.mixins.content import dict_markup_property
 from onegov.core.orm.mixins.content import dict_property
 from onegov.core.orm.mixins.content import meta_property
+from onegov.core.orm.mixins.names import StripWhitespaceMixin
 from onegov.core.orm.mixins.publication import UTCPublicationMixin
 from onegov.core.orm.mixins.timestamp import TimestampMixin
 
@@ -17,6 +18,7 @@ __all__ = [
     'dict_property',
     'dict_markup_property',
     'meta_property',
+    'StripWhitespaceMixin',
     'TimestampMixin',
     'UTCPublicationMixin',
 ]

--- a/src/onegov/core/orm/mixins/names.py
+++ b/src/onegov/core/orm/mixins/names.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from sqlalchemy.orm import validates
+
+
+class StripWhitespaceMixin:
+    """ Mixin that strips leading/trailing whitespace from first_name and
+    last_name on assignment. Subclasses may override strip_names with a
+    broader @validates to cover additional fields (e.g. function). """
+
+    @validates('first_name', 'last_name')
+    def strip_names(self, key: str, value: str | None) -> str | None:
+        return value.strip() if value is not None else value

--- a/src/onegov/feriennet/cli.py
+++ b/src/onegov/feriennet/cli.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 import click
+import transaction
 
 from onegov.activity import Activity
-from onegov.core.cli import command_group
 from onegov.activity.models import BookingPeriod
 from onegov.activity.models import Occasion
+from onegov.core.cli import command_group
+from onegov.core.orm import mark_changed
 from sqlalchemy import text
 
 
@@ -202,3 +204,50 @@ def delete_activity(
         request.session.delete(activity)
 
     return delete_activity
+
+
+@cli.command('strip-whitespace-from-names')
+@click.option('--dry-run/--no-dry-run', default=False)
+def strip_whitespace_from_names(
+    dry_run: bool
+) -> Callable[[FeriennetRequest, FeriennetApp], None]:
+    """ Strips leading/trailing whitespace from first_name and last_name
+    of all volunteers.
+
+    Example:
+
+        `onegov-feriennet --select /onegov_feriennet/*
+        strip-whitespace-from-names`
+
+    """
+
+    def _strip(
+        request: FeriennetRequest,
+        app: FeriennetApp
+    ) -> None:
+        session = app.session()
+
+        # Raw SQL skips ORM/FTS events; mark_changed tells zope.sqlalchemy
+        # to commit.
+        result = session.execute(text("""
+            UPDATE volunteers
+               SET first_name = TRIM(first_name),
+                   last_name   = TRIM(last_name)
+             WHERE first_name  != TRIM(first_name)
+                OR last_name   != TRIM(last_name)
+        """))
+        count = result.rowcount  # type: ignore[attr-defined]
+        mark_changed(session)
+
+        if dry_run:
+            transaction.abort()
+            click.secho('Aborting transaction', fg='yellow')
+        else:
+            transaction.commit()
+
+        click.secho(
+            f'{app.schema}: Stripped whitespace from {count} volunteer(s)',
+            fg='green'
+        )
+
+    return _strip

--- a/src/onegov/feriennet/cli.py
+++ b/src/onegov/feriennet/cli.py
@@ -6,8 +6,8 @@ import transaction
 from onegov.activity import Activity
 from onegov.activity.models import BookingPeriod
 from onegov.activity.models import Occasion
+from onegov.activity.models import Volunteer
 from onegov.core.cli import command_group
-from onegov.core.orm import mark_changed
 from sqlalchemy import text
 
 
@@ -226,24 +226,21 @@ def strip_whitespace_from_names(
         app: FeriennetApp
     ) -> None:
         session = app.session()
-
-        # Raw SQL skips ORM/FTS events; mark_changed tells zope.sqlalchemy
-        # to commit.
-        result = session.execute(text("""
-            UPDATE volunteers
-               SET first_name = TRIM(first_name),
-                   last_name   = TRIM(last_name)
-             WHERE first_name  != TRIM(first_name)
-                OR last_name   != TRIM(last_name)
-        """))
-        count = result.rowcount  # type: ignore[attr-defined]
-        mark_changed(session)
+        count = 0
+        for volunteer in session.query(Volunteer):
+            first_name = volunteer.first_name.strip()
+            last_name = volunteer.last_name.strip()
+            if (first_name, last_name) != (
+                volunteer.first_name,
+                volunteer.last_name,
+            ):
+                volunteer.first_name = first_name
+                volunteer.last_name = last_name
+                count += 1
 
         if dry_run:
             transaction.abort()
             click.secho('Aborting transaction', fg='yellow')
-        else:
-            transaction.commit()
 
         click.secho(
             f'{app.schema}: Stripped whitespace from {count} volunteer(s)',

--- a/src/onegov/fsi/cli.py
+++ b/src/onegov/fsi/cli.py
@@ -7,10 +7,9 @@ import transaction
 from datetime import date, datetime, UTC
 from sedate import replace_timezone
 from sqlalchemy import or_, and_
-from sqlalchemy import cast, Date, text
+from sqlalchemy import cast, Date
 
 from onegov.core.cli import command_group
-from onegov.core.orm import mark_changed
 from onegov.fsi import log
 from onegov.fsi.ims_import import (
     parse_ims_data, import_ims_data, import_teacher_data, with_open,
@@ -448,24 +447,29 @@ def strip_whitespace_from_names(
 
     def _strip(request: FsiRequest, app: FsiApp) -> None:
         session = app.session()
-
-        # Raw SQL skips ORM/FTS events; mark_changed tells zope.sqlalchemy
-        # to commit.
-        result = session.execute(text("""
-            UPDATE fsi_attendees
-               SET first_name = TRIM(first_name),
-                   last_name   = TRIM(last_name)
-             WHERE (first_name IS NOT NULL AND first_name != TRIM(first_name))
-                OR (last_name  IS NOT NULL AND last_name  != TRIM(last_name))
-        """))
-        count = result.rowcount  # type: ignore[attr-defined]
-        mark_changed(session)
+        count = 0
+        for attendee in session.query(CourseAttendee):
+            first_name = (
+                attendee.first_name.strip()
+                if attendee.first_name
+                else attendee.first_name
+            )
+            last_name = (
+                attendee.last_name.strip()
+                if attendee.last_name
+                else attendee.last_name
+            )
+            if (first_name, last_name) != (
+                attendee.first_name,
+                attendee.last_name,
+            ):
+                attendee.first_name = first_name
+                attendee.last_name = last_name
+                count += 1
 
         if dry_run:
             transaction.abort()
             click.secho('Aborting transaction', fg='yellow')
-        else:
-            transaction.commit()
 
         click.secho(
             f'{app.schema}: Stripped whitespace from {count} attendee(s)',

--- a/src/onegov/fsi/cli.py
+++ b/src/onegov/fsi/cli.py
@@ -7,9 +7,10 @@ import transaction
 from datetime import date, datetime, UTC
 from sedate import replace_timezone
 from sqlalchemy import or_, and_
-from sqlalchemy import cast, Date
+from sqlalchemy import cast, Date, text
 
 from onegov.core.cli import command_group
+from onegov.core.orm import mark_changed
 from onegov.fsi import log
 from onegov.fsi.ims_import import (
     parse_ims_data, import_ims_data, import_teacher_data, with_open,
@@ -429,3 +430,46 @@ def fetch_users(
 
     if dry_run:
         transaction.abort()
+
+
+@cli.command('strip-whitespace-from-names')
+@click.option('--dry-run/--no-dry-run', default=False)
+def strip_whitespace_from_names(
+    dry_run: bool
+) -> Callable[[FsiRequest, FsiApp], None]:
+    """ Strips leading/trailing whitespace from first_name and last_name
+    of all course attendees.
+
+    Example:
+
+        `onegov-fsi --select /fsi/* strip-whitespace-from-names`
+
+    """
+
+    def _strip(request: FsiRequest, app: FsiApp) -> None:
+        session = app.session()
+
+        # Raw SQL skips ORM/FTS events; mark_changed tells zope.sqlalchemy
+        # to commit.
+        result = session.execute(text("""
+            UPDATE fsi_attendees
+               SET first_name = TRIM(first_name),
+                   last_name   = TRIM(last_name)
+             WHERE (first_name IS NOT NULL AND first_name != TRIM(first_name))
+                OR (last_name  IS NOT NULL AND last_name  != TRIM(last_name))
+        """))
+        count = result.rowcount  # type: ignore[attr-defined]
+        mark_changed(session)
+
+        if dry_run:
+            transaction.abort()
+            click.secho('Aborting transaction', fg='yellow')
+        else:
+            transaction.commit()
+
+        click.secho(
+            f'{app.schema}: Stripped whitespace from {count} attendee(s)',
+            fg='green'
+        )
+
+    return _strip

--- a/src/onegov/fsi/models/course_attendee.py
+++ b/src/onegov/fsi/models/course_attendee.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import datetime
 import pytz
 from onegov.core.orm import Base
+from onegov.core.orm.mixins import StripWhitespaceMixin
 from onegov.fsi.i18n import _
 from onegov.search import ORMSearchable
 from sedate import utcnow
@@ -23,7 +24,7 @@ if TYPE_CHECKING:
 external_attendee_org = 'Externe Kursteilnehmer'
 
 
-class CourseAttendee(Base, ORMSearchable):
+class CourseAttendee(Base, StripWhitespaceMixin, ORMSearchable):
     """
     Comprises the user base mirrored by one-to-one relationship with
     onegov.user.User which is linked to the LDAP System including

--- a/src/onegov/people/cli.py
+++ b/src/onegov/people/cli.py
@@ -9,11 +9,9 @@ from collections import OrderedDict
 
 from onegov.core.cli import command_group
 from onegov.core.cli import abort
-from onegov.core.orm import mark_changed
 from onegov.people.models import Person
 from openpyxl import load_workbook
 from openpyxl import Workbook
-from sqlalchemy import text
 
 
 from typing import IO
@@ -104,26 +102,23 @@ def strip_whitespace_from_names(
 
     def _strip(request: CoreRequest, app: Framework) -> None:
         session = app.session()
-
-        # Raw SQL skips ORM/FTS events; mark_changed tells zope.sqlalchemy
-        # to commit.
-        result = session.execute(text("""
-            UPDATE people
-               SET first_name = TRIM(first_name),
-                   last_name = TRIM(last_name),
-                   function = TRIM(function)
-             WHERE first_name != TRIM(first_name)
-                OR last_name != TRIM(last_name)
-                OR (function IS NOT NULL AND function != TRIM(function))
-        """))
-        count = result.rowcount  # type: ignore[attr-defined]
-        mark_changed(session)
+        count = 0
+        for person in session.query(Person):
+            first_name = person.first_name.strip()
+            last_name = person.last_name.strip()
+            function = (
+                person.function.strip() if person.function else person.function
+            )
+            if (first_name, last_name, function) != (
+                    person.first_name, person.last_name, person.function):
+                person.first_name = first_name
+                person.last_name = last_name
+                person.function = function
+                count += 1
 
         if dry_run:
             transaction.abort()
             click.secho('Aborting transaction', fg='yellow')
-        else:
-            transaction.commit()
 
         click.secho(
             f'{app.schema}: Stripped whitespace from {count} person(s)',

--- a/src/onegov/people/cli.py
+++ b/src/onegov/people/cli.py
@@ -9,9 +9,11 @@ from collections import OrderedDict
 
 from onegov.core.cli import command_group
 from onegov.core.cli import abort
+from onegov.core.orm import mark_changed
 from onegov.people.models import Person
 from openpyxl import load_workbook
 from openpyxl import Workbook
+from sqlalchemy import text
 
 
 from typing import IO
@@ -83,6 +85,52 @@ EXPORT_FIELDS = OrderedDict((
     ('Link zum Bild', 'picture_url'),
     ('Notizen', 'notes'),
 ))
+
+
+@cli.command('strip-whitespace-from-names')
+@click.option('--dry-run/--no-dry-run', default=False)
+def strip_whitespace_from_names(
+    dry_run: bool
+) -> Callable[[CoreRequest, Framework], None]:
+    """ Strips leading/trailing whitespace from first_name, last_name,
+    and function of all people.
+
+    Example:
+
+        `onegov-people --select /onegov_org/* strip-whitespace-from-names`
+        `onegov-people --select /onegov_town6/* strip-whitespace-from-names`
+
+    """
+
+    def _strip(request: CoreRequest, app: Framework) -> None:
+        session = app.session()
+
+        # Raw SQL skips ORM/FTS events; mark_changed tells zope.sqlalchemy
+        # to commit.
+        result = session.execute(text("""
+            UPDATE people
+               SET first_name = TRIM(first_name),
+                   last_name = TRIM(last_name),
+                   function = TRIM(function)
+             WHERE first_name != TRIM(first_name)
+                OR last_name != TRIM(last_name)
+                OR (function IS NOT NULL AND function != TRIM(function))
+        """))
+        count = result.rowcount  # type: ignore[attr-defined]
+        mark_changed(session)
+
+        if dry_run:
+            transaction.abort()
+            click.secho('Aborting transaction', fg='yellow')
+        else:
+            transaction.commit()
+
+        click.secho(
+            f'{app.schema}: Stripped whitespace from {count} person(s)',
+            fg='green'
+        )
+
+    return _strip
 
 
 @cli.command('export')

--- a/src/onegov/people/models/person.py
+++ b/src/onegov/people/models/person.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from onegov.core.orm import Base
 from onegov.core.orm.mixins import ContentMixin
+from onegov.core.orm.mixins import StripWhitespaceMixin
 from onegov.core.orm.mixins import TimestampMixin
 from onegov.core.orm.mixins import UTCPublicationMixin
 from onegov.core.orm.mixins import content_property
@@ -12,6 +13,7 @@ from onegov.search import ORMSearchable
 from sqlalchemy.orm import mapped_column
 from sqlalchemy.orm import joinedload
 from sqlalchemy.orm import relationship
+from sqlalchemy.orm import validates
 from sqlalchemy.orm import DynamicMapped
 from sqlalchemy.orm import Mapped
 from translationstring import TranslationString
@@ -27,9 +29,15 @@ if TYPE_CHECKING:
     from vobject.base import Component
 
 
-class Person(Base, ContentMixin, TimestampMixin, ORMSearchable,
-             UTCPublicationMixin):
-    """ A person. """
+class Person(
+    Base,
+    StripWhitespaceMixin,
+    ContentMixin,
+    TimestampMixin,
+    ORMSearchable,
+    UTCPublicationMixin,
+):
+    """A person."""
 
     __tablename__ = 'people'
 
@@ -67,6 +75,10 @@ class Person(Base, ContentMixin, TimestampMixin, ORMSearchable,
     def fts_last_change(self) -> None:
         return None
 
+    @validates('first_name', 'last_name', 'function')
+    def strip_names(self, key: str, value: str | None) -> str | None:
+        return super().strip_names(key, value)
+
     @property
     def phone_fts(self) -> list[str]:
         numbers = (self.phone, self.phone_direct)
@@ -74,12 +86,12 @@ class Person(Base, ContentMixin, TimestampMixin, ORMSearchable,
 
     @property
     def title(self) -> str:
-        """ Returns the Eastern-ordered name. """
+        """Returns the Eastern-ordered name."""
         return f'{self.last_name} {self.first_name}'
 
     @property
     def spoken_title(self) -> str:
-        """ Returns the Western-ordered name. Includes the academic title if
+        """Returns the Western-ordered name. Includes the academic title if
         available.
 
         """
@@ -92,10 +104,7 @@ class Person(Base, ContentMixin, TimestampMixin, ORMSearchable,
         return ' '.join(parts)
 
     #: the unique id, part of the url
-    id: Mapped[UUID] = mapped_column(
-        primary_key=True,
-        default=uuid4
-    )
+    id: Mapped[UUID] = mapped_column(primary_key=True, default=uuid4)
 
     #: the salutation used for the person
     salutation: Mapped[str | None]
@@ -122,7 +131,8 @@ class Person(Base, ContentMixin, TimestampMixin, ORMSearchable,
     organisation: Mapped[str | None]
 
     #: multiple organisations the person belongs to
-    organisations_multiple: dict_property[list[str] | None] = content_property(
+    organisations_multiple: dict_property[list[str] | None] = (
+        content_property()
     )
 
     # a sub organisation the person belongs to
@@ -181,9 +191,9 @@ class Person(Base, ContentMixin, TimestampMixin, ORMSearchable,
     def vcard_object(
         self,
         exclude: Collection[str] | None = None,
-        include_memberships: bool = True
+        include_memberships: bool = True,
     ) -> Component:
-        """ Returns the person as vCard (3.0) object.
+        """Returns the person as vCard (3.0) object.
 
         Allows to specify the included attributes, provides a reasonable
         default if none are specified. Always includes the first and last
@@ -263,23 +273,29 @@ class Person(Base, ContentMixin, TimestampMixin, ORMSearchable,
             line.value = self.website
 
         if (
-            'postal_address' not in exclude and self.postal_address
-            and 'postal_code_city' not in exclude and self.postal_code_city
+            'postal_address' not in exclude
+            and self.postal_address
+            and 'postal_code_city' not in exclude
+            and self.postal_code_city
         ):
             line = result.add('adr')
             code, city = split_code_from_city(self.postal_code_city)
-            line.value = Address(street=self.postal_address,
-                                 code=code, city=city)
+            line.value = Address(
+                street=self.postal_address, code=code, city=city
+            )
             line.charset_param = 'utf-8'
 
         if (
-            'location_address' not in exclude and self.location_address
-            and 'location_code_city' not in exclude and self.location_code_city
+            'location_address' not in exclude
+            and self.location_address
+            and 'location_code_city' not in exclude
+            and self.location_code_city
         ):
             line = result.add('adr')
             code, city = split_code_from_city(self.location_code_city)
-            line.value = Address(street=self.location_address,
-                                 code=code, city=city)
+            line.value = Address(
+                street=self.location_address, code=code, city=city
+            )
             line.charset_param = 'utf-8'
 
         if 'notes' not in exclude and self.notes:
@@ -287,12 +303,15 @@ class Person(Base, ContentMixin, TimestampMixin, ORMSearchable,
             line.value = self.notes
             line.charset_param = 'utf-8'
 
-        if include_memberships and (memberships := [
-            f'{m.agency.title}, {m.title}' for m in self.memberships.options(
-                # eagerly load the agency along with the membership
-                joinedload(AgencyMembership.agency)
-            )
-        ]):
+        if include_memberships and (
+            memberships := [
+                f'{m.agency.title}, {m.title}'
+                for m in self.memberships.options(
+                    # eagerly load the agency along with the membership
+                    joinedload(AgencyMembership.agency)
+                )
+            ]
+        ):
             line = result.add('org')
             line.value = ['; '.join(memberships)]
             line.charset_param = 'utf-8'
@@ -300,7 +319,7 @@ class Person(Base, ContentMixin, TimestampMixin, ORMSearchable,
         return result
 
     def vcard(self, exclude: Collection[str] | None = None) -> str:
-        """ Returns the person as vCard (3.0).
+        """Returns the person as vCard (3.0).
 
         Allows to specify the included attributes, provides a reasonable
         default if none are specified. Always includes the first and last
@@ -312,7 +331,7 @@ class Person(Base, ContentMixin, TimestampMixin, ORMSearchable,
 
     @property
     def memberships_by_agency(self) -> list[AgencyMembership]:
-        """ Returns the memberships sorted alphabetically by the agency. """
+        """Returns the memberships sorted alphabetically by the agency."""
 
         def sortkey(membership: AgencyMembership) -> int:
             return membership.order_within_person

--- a/src/onegov/translator_directory/cli.py
+++ b/src/onegov/translator_directory/cli.py
@@ -5,7 +5,6 @@ import transaction
 
 from openpyxl import load_workbook
 from onegov.core.cli import command_group
-from onegov.core.orm import mark_changed
 from onegov.translator_directory.collections.translator import (
     TranslatorCollection)
 from onegov.translator_directory import log
@@ -17,7 +16,7 @@ from onegov.user import User
 from onegov.user.auth.clients import LDAPClient
 from onegov.user.auth.provider import ensure_user
 from onegov.user.sync import ZugUserSource
-from sqlalchemy import or_, and_, text
+from sqlalchemy import or_, and_
 
 
 from typing import Any, TYPE_CHECKING
@@ -1039,24 +1038,21 @@ def strip_whitespace_from_names(
         app: TranslatorDirectoryApp
     ) -> None:
         session = app.session()
-
-        # Raw SQL skips ORM/FTS events; mark_changed tells zope.sqlalchemy
-        # to commit.
-        result = session.execute(text("""
-            UPDATE translators
-               SET first_name = TRIM(first_name),
-                   last_name   = TRIM(last_name)
-             WHERE first_name  != TRIM(first_name)
-                OR last_name   != TRIM(last_name)
-        """))
-        count = result.rowcount  # type: ignore[attr-defined]
-        mark_changed(session)
+        count = 0
+        for translator in session.query(Translator):
+            first_name = translator.first_name.strip()
+            last_name = translator.last_name.strip()
+            if (first_name, last_name) != (
+                translator.first_name,
+                translator.last_name,
+            ):
+                translator.first_name = first_name
+                translator.last_name = last_name
+                count += 1
 
         if dry_run:
             transaction.abort()
             click.secho('Aborting transaction', fg='yellow')
-        else:
-            transaction.commit()
 
         click.secho(
             f'{app.schema}: Stripped whitespace from {count} translator(s)',

--- a/src/onegov/translator_directory/cli.py
+++ b/src/onegov/translator_directory/cli.py
@@ -5,6 +5,7 @@ import transaction
 
 from openpyxl import load_workbook
 from onegov.core.cli import command_group
+from onegov.core.orm import mark_changed
 from onegov.translator_directory.collections.translator import (
     TranslatorCollection)
 from onegov.translator_directory import log
@@ -16,7 +17,7 @@ from onegov.user import User
 from onegov.user.auth.clients import LDAPClient
 from onegov.user.auth.provider import ensure_user
 from onegov.user.sync import ZugUserSource
-from sqlalchemy import or_, and_
+from sqlalchemy import or_, and_, text
 
 
 from typing import Any, TYPE_CHECKING
@@ -1016,3 +1017,50 @@ def change_finanzstelle_cli(
             click.secho('Changes committed', fg='green')
 
     return do_change
+
+
+@cli.command('strip-whitespace-from-names')
+@click.option('--dry-run/--no-dry-run', default=False)
+def strip_whitespace_from_names(
+    dry_run: bool
+) -> Callable[[TranslatorAppRequest, TranslatorDirectoryApp], None]:
+    """Strips leading/trailing whitespace from first_name and last_name
+    of all translators.
+
+    Example:
+
+        `onegov-translator --select /translator_directory/*
+        strip-whitespace-from-names`
+
+    """
+
+    def _strip(
+        request: TranslatorAppRequest,
+        app: TranslatorDirectoryApp
+    ) -> None:
+        session = app.session()
+
+        # Raw SQL skips ORM/FTS events; mark_changed tells zope.sqlalchemy
+        # to commit.
+        result = session.execute(text("""
+            UPDATE translators
+               SET first_name = TRIM(first_name),
+                   last_name   = TRIM(last_name)
+             WHERE first_name  != TRIM(first_name)
+                OR last_name   != TRIM(last_name)
+        """))
+        count = result.rowcount  # type: ignore[attr-defined]
+        mark_changed(session)
+
+        if dry_run:
+            transaction.abort()
+            click.secho('Aborting transaction', fg='yellow')
+        else:
+            transaction.commit()
+
+        click.secho(
+            f'{app.schema}: Stripped whitespace from {count} translator(s)',
+            fg='green'
+        )
+
+    return _strip

--- a/src/onegov/translator_directory/models/translator.py
+++ b/src/onegov/translator_directory/models/translator.py
@@ -9,7 +9,8 @@ from sqlalchemy.orm import backref, mapped_column, relationship, Mapped
 
 from onegov.core.orm import Base
 from onegov.core.orm.mixins import (ContentMixin, dict_property,
-                                    meta_property, content_property)
+                                    meta_property, content_property,
+                                    StripWhitespaceMixin)
 from onegov.file import AssociatedFiles
 from onegov.gis import CoordinatesMixin
 from onegov.search import ORMSearchable
@@ -45,8 +46,15 @@ type InterpretingType = Literal[
 ]
 
 
-class Translator(Base, TimestampMixin, AssociatedFiles, ContentMixin,
-                 CoordinatesMixin, ORMSearchable):
+class Translator(
+    Base,
+    StripWhitespaceMixin,
+    TimestampMixin,
+    AssociatedFiles,
+    ContentMixin,
+    CoordinatesMixin,
+    ORMSearchable,
+):
 
     __tablename__ = 'translators'
 

--- a/tests/onegov/core/test_orm.py
+++ b/tests/onegov/core/test_orm.py
@@ -24,6 +24,7 @@ from onegov.core.orm.mixins import content_property
 from onegov.core.orm.mixins import dict_property
 from onegov.core.orm.mixins import dict_markup_property
 from onegov.core.orm.mixins import ContentMixin
+from onegov.core.orm.mixins import StripWhitespaceMixin
 from onegov.core.orm.mixins import TimestampMixin
 from onegov.core.orm import orm_cached, request_cached
 from onegov.core.orm.types import HSTORE, JSON, UTCDateTime
@@ -38,7 +39,7 @@ from sqlalchemy import (
 )
 from sqlalchemy.exc import OperationalError
 from sqlalchemy.ext.mutable import MutableDict
-from sqlalchemy.orm import mapped_column, registry, relationship
+from sqlalchemy.orm import mapped_column, registry, relationship, validates
 from sqlalchemy.orm import DeclarativeBase, Mapped
 from sqlalchemy_utils import aggregated
 from threading import Thread
@@ -2459,3 +2460,39 @@ def test_postgres_timezone(postgres_dsn: str) -> None:
         ALTER DATABASE onegov SET timezone TO 'UTC';
     to change the default timezone, then restart postgres service.
     """
+
+
+def test_strip_whitespace_mixin(postgres_dsn: str) -> None:
+
+    class Base(DeclarativeBase, ModelBase):
+        registry = registry()
+
+    class Record(Base, StripWhitespaceMixin):
+        __tablename__ = 'records'
+        id: Mapped[int] = mapped_column(primary_key=True)
+        first_name: Mapped[str]
+        last_name: Mapped[str]
+        city: Mapped[str | None]
+
+        @validates('first_name', 'last_name', 'city')
+        def strip_names(self, key: str, value: str | None) -> str | None:
+            return super().strip_names(key, value)
+
+    mgr = SessionManager(postgres_dsn, Base)
+    mgr.set_current_schema('testing')
+    session = mgr.session()
+
+    rec = Record(first_name=' Alice ', last_name='Smith ', city=' Bern ')
+    session.add(rec)
+    session.flush()
+
+    assert rec.first_name == 'Alice'
+    assert rec.last_name == 'Smith'
+    assert rec.city == 'Bern'
+
+    rec.first_name = '  Bob  '
+    rec.last_name = ''
+    rec.city = None
+    assert rec.first_name == 'Bob'
+    assert rec.last_name == ''
+    assert rec.city is None

--- a/tests/onegov/org/test_views_resources.py
+++ b/tests/onegov/org/test_views_resources.py
@@ -4157,15 +4157,15 @@ def test_allocation_rules_copy_paste(client: Client) -> None:
 
     # Copy the rule
     edit_page = client.get('/resource/room-1').click('Verfügbarkeitszeiträume')
-    copy_links = edit_page.html.find_all('a', string='Kopieren')  # type: ignore[call-overload]
-    client.post(copy_links[0].attrs['ic-post-to'])
+    copy_links = edit_page.html.find_all('a', string='Kopieren')
+    client.post(str(copy_links[0].attrs['ic-post-to']))
     edit_page = client.get(edit_page.request.path)
     assert 'in die Zwischenablage kopiert' in edit_page
 
     # Paste the rule in the other room
     edit_page = client.get('/resource/room-2').click('Verfügbarkeitszeiträume')
-    paste_links = edit_page.html.find_all('a', string='Einfügen')  # type: ignore[call-overload]
-    client.post(paste_links[0].attrs['ic-post-to'])
+    paste_links = edit_page.html.find_all('a', string='Einfügen')
+    client.post(str(paste_links[0].attrs['ic-post-to']))
     edit_page = client.get(edit_page.request.path)
     assert 'wurde eingefügt' in edit_page
     assert count_allocations(1) == 2

--- a/tests/onegov/people/test_cli.py
+++ b/tests/onegov/people/test_cli.py
@@ -4,6 +4,8 @@ from click.testing import CliRunner
 from onegov.people.cli import cli
 from onegov.people.models import Person
 from pathlib import Path
+from sqlalchemy import text
+import transaction
 from transaction import commit
 
 
@@ -157,3 +159,51 @@ def test_cli(
     ])
     assert result.exit_code == 0
     assert 'Imported 0 person(s)' in result.output
+
+    # Strip whitespace (simulate legacy data with spaces via raw SQL)
+    session.add(Person(
+        first_name='Flash', last_name='Gordon', function='Hero'))
+    session.add(Person(first_name='Ming', last_name='the Merciless'))
+    session.flush()
+    session.execute(text(
+        "UPDATE people SET first_name = ' Flash', last_name = 'Gordon ',"
+        " function = ' Hero ' WHERE last_name = 'Gordon'"
+    ))
+    commit()
+    session.expunge_all()
+
+    result = runner.invoke(cli, [
+        '--config', cfg_path,
+        '--select', '/foo/bar',
+        'strip-whitespace-from-names',
+        '--dry-run'
+    ])
+    assert result.exit_code == 0
+    assert 'Stripped whitespace from 1 person(s)' in result.output
+
+    session.expunge_all()
+    flash = session.query(Person).filter_by(last_name='Gordon ').first()
+    assert flash is not None, 'dry-run must not commit'
+
+    result = runner.invoke(cli, [
+        '--config', cfg_path,
+        '--select', '/foo/bar',
+        'strip-whitespace-from-names'
+    ])
+    assert result.exit_code == 0
+    assert 'Stripped whitespace from 1 person(s)' in result.output
+
+    # A second run must report 0 — proving the first run persisted the changes.
+    result = runner.invoke(cli, [
+        '--config', cfg_path,
+        '--select', '/foo/bar',
+        'strip-whitespace-from-names'
+    ])
+    assert result.exit_code == 0
+    assert 'Stripped whitespace from 0 person(s)' in result.output
+
+    transaction.abort()
+    session.expunge_all()
+    flash = session.query(Person).filter_by(last_name='Gordon').one()
+    assert flash.first_name == 'Flash'
+    assert flash.function == 'Hero'

--- a/tests/onegov/people/test_models.py
+++ b/tests/onegov/people/test_models.py
@@ -523,3 +523,28 @@ def test_membership_siblings(session: Session) -> None:
     assert [m.title for m in membership_x.siblings_by_agency] == ['X', 'Y']
     assert [m.title for m in membership_y.siblings_by_agency] == ['X', 'Y']
     assert [m.title for m in membership_z.siblings_by_agency] == ['Z']
+
+
+def test_person_strip_leading_and_trailing_whitespace(
+    session: Session
+) -> None:
+    session.add(Person(
+        first_name=' Hans Ulrich',
+        last_name='Maulwurf ',
+        function=' Director ',
+    ))
+    session.flush()
+    person = session.query(Person).one()
+
+    assert person.first_name == 'Hans Ulrich'
+    assert person.last_name == 'Maulwurf'
+    assert person.function == 'Director'
+
+    person.first_name = '  Anna  '
+    person.last_name = '  Schmidt  '
+    person.function = '  Manager  '
+    session.flush()
+
+    assert person.first_name == 'Anna'
+    assert person.last_name == 'Schmidt'
+    assert person.function == 'Manager'


### PR DESCRIPTION
Org: Strip leading/trailing whitespace from person name fields

Adds StripWhitespaceMixin to Person, Translator, Volunteer, and CourseAttendee so whitespaces get stripped on assignment. 

TYPE: Feature
LINK: ogc-3142
HINT: `onegov-people --select /onegov_org/* strip-whitespace-from-names`
HINT: `onegov-people --select /onegov_town6/* strip-whitespace-from-names`
HINT: `onegov-feriennet --select /onegov_feriennet/* strip-whitespace-from-names`
HINT: `onegov-translator --select /translator_directory/* strip-whitespace-from-names`

