### PR TITLE
Org: descriptive subjects with resource, date and activity

### DIFF
--- a/src/onegov/org/locale/de_CH/LC_MESSAGES/onegov.org.po
+++ b/src/onegov/org/locale/de_CH/LC_MESSAGES/onegov.org.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE 1.0\n"
-"POT-Creation-Date: 2026-06-01 12:55+0200\n"
+"POT-Creation-Date: 2026-06-11 11:12+0200\n"
 "PO-Revision-Date: 2022-03-15 10:21+0100\n"
 "Last-Translator: Marc Sommerhalder <marc.sommerhalder@seantis.ch>\n"
 "Language-Team: German\n"
@@ -4358,8 +4358,8 @@ msgstr "Anzahl"
 msgid "VAT"
 msgstr "MwSt"
 
-#. credit card
 #.
+#. credit card
 msgid "Payment"
 msgstr "Zahlung"
 
@@ -5174,8 +5174,8 @@ msgstr "Neue Kunden Nachricht in Ticket ${link}"
 msgid "${author} wrote"
 msgstr "${author} schrieb"
 
-#. Canonical text for ${link} is: "visit the request page"
 #. Canonical text for ${link} is: "visit the request status page"
+#. Canonical text for ${link} is: "visit the request page"
 msgid "Please ${link} to reply."
 msgstr "Bitte ${link} um zu antworten"
 
@@ -5723,9 +5723,6 @@ msgstr ""
 "Es tut uns leid, aber die Seite nach der Sie suchen konnte nicht gefunden "
 "werden. Bitte überprüfen Sie die Internetadresse oder verwenden Sie die "
 "Suche im Navigationsbereich."
-
-msgid "Back"
-msgstr "Zurück"
 
 msgid "Link to organizers page"
 msgstr "Link zur Veranstalterseite"
@@ -6332,8 +6329,8 @@ msgid "Delete availability period"
 msgstr "Verfügbarkeitszeitraum löschen"
 
 #.
-#. type:ignore[attr-defined]
 #. type:ignore[attr-defined]  # trigger updates
+#. type:ignore[attr-defined]
 msgid "Your changes were saved"
 msgstr "Ihre Änderungen wurden gespeichert"
 
@@ -7403,6 +7400,9 @@ msgstr "Neue Termine für ${title}"
 msgid "Confirm your reservation"
 msgstr "Bestätigen Sie Ihre Reservation"
 
+msgid "Request"
+msgstr "Anfrage"
+
 #. by default we will redirect to the created ticket
 msgid "Thank you for your reservation!"
 msgstr "Vielen Dank für Ihre Reservation!"
@@ -7424,8 +7424,8 @@ msgstr ""
 "${site_id} ist fehlgeschlagen. Bitte stellen Sie sicher, dass die "
 "hinterlegten Zugangsdaten immer noch gültig sind."
 
-msgid "Your reservations were accepted"
-msgstr "Ihre Reservationen wurden bestätigt"
+msgid "Accepted"
+msgstr "Angenommen"
 
 #, python-format
 msgid "Reservation(s) confirmed ${org} ${resource}"
@@ -7460,9 +7460,6 @@ msgid ""
 msgstr ""
 "Die mit der Reservation verknüpfte Zahlung muss rückgängig gemacht werden "
 "bevor die Reservation gelöscht werden kann"
-
-msgid "The following reservations were rejected"
-msgstr "Die folgenden Reservationen wurden abgelehnt"
 
 #, python-format
 msgid "${org} Rejected Reservation"
@@ -8032,6 +8029,15 @@ msgstr "Der Benutzer wurde erfolgreich erstellt"
 
 msgid "Please enter your e-mail address in order to continue"
 msgstr "Bitte geben Sie ihre E-Mail Adresse ein um fortzufahren"
+
+#~ msgid "Back"
+#~ msgstr "Zurück"
+
+#~ msgid "Your reservations were accepted"
+#~ msgstr "Ihre Reservationen wurden bestätigt"
+
+#~ msgid "The following reservations were rejected"
+#~ msgstr "Die folgenden Reservationen wurden abgelehnt"
 
 #~ msgid "(Redesign only)"
 #~ msgstr "(verfügbar im Redesign)"

--- a/src/onegov/org/locale/fr_CH/LC_MESSAGES/onegov.org.po
+++ b/src/onegov/org/locale/fr_CH/LC_MESSAGES/onegov.org.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE 1.0\n"
-"POT-Creation-Date: 2026-06-01 12:55+0200\n"
+"POT-Creation-Date: 2026-06-11 11:12+0200\n"
 "PO-Revision-Date: 2022-03-15 10:50+0100\n"
 "Last-Translator: Marc Sommerhalder <marc.sommerhalder@seantis.ch>\n"
 "Language-Team: French\n"
@@ -4365,8 +4365,8 @@ msgstr "Quantité"
 msgid "VAT"
 msgstr "TVA"
 
-#. credit card
 #.
+#. credit card
 msgid "Payment"
 msgstr "Paiement"
 
@@ -5181,8 +5181,8 @@ msgstr "Nouveau message du client dans le ticket ${link}"
 msgid "${author} wrote"
 msgstr "${author} a écrit"
 
-#. Canonical text for ${link} is: "visit the request page"
 #. Canonical text for ${link} is: "visit the request status page"
+#. Canonical text for ${link} is: "visit the request page"
 msgid "Please ${link} to reply."
 msgstr "Veuillez vous rendre sur ${link} pour répondre."
 
@@ -5732,9 +5732,6 @@ msgstr ""
 "Désolé, la page que vous cherchez n'a pu être trouvée. Essayez de vérifier "
 "qu'il n'y a pas d'erreurs dans l'URL ou utilisez la fenêtre de recherche "
 "située en haut."
-
-msgid "Back"
-msgstr "Retour"
 
 msgid "Link to organizers page"
 msgstr "Lien vers la page de l'organisateur"
@@ -6346,8 +6343,8 @@ msgid "Delete availability period"
 msgstr "Supprimer la période de disponibilité"
 
 #.
-#. type:ignore[attr-defined]
 #. type:ignore[attr-defined]  # trigger updates
+#. type:ignore[attr-defined]
 msgid "Your changes were saved"
 msgstr "Vos modifications ont été enregistrées"
 
@@ -7415,6 +7412,9 @@ msgstr "Nouvelles dates pour ${title}"
 msgid "Confirm your reservation"
 msgstr "Confirmer votre réservation"
 
+msgid "Request"
+msgstr "Demande"
+
 #. by default we will redirect to the created ticket
 msgid "Thank you for your reservation!"
 msgstr "Merci pour votre réservation !"
@@ -7436,8 +7436,8 @@ msgstr ""
 "site ${site_id}. Veuillez vous assurer que vos informations d'identification "
 "sont toujours valides."
 
-msgid "Your reservations were accepted"
-msgstr "Vos réservations ont été acceptées"
+msgid "Accepted"
+msgstr "Accepté"
 
 #, python-format
 msgid "Reservation(s) confirmed ${org} ${resource}"
@@ -7472,9 +7472,6 @@ msgid ""
 msgstr ""
 "Le paiement associé à cette réservation doit être remboursé avant qu'elle "
 "puisse être rejetée"
-
-msgid "The following reservations were rejected"
-msgstr "Les réservations suivantes ont été rejetées"
 
 #, python-format
 msgid "${org} Rejected Reservation"
@@ -8043,6 +8040,15 @@ msgstr "L'utilisateur a bien été créé"
 
 msgid "Please enter your e-mail address in order to continue"
 msgstr "Veuillez saisir votre adresse e-mail pour continuer"
+
+#~ msgid "Back"
+#~ msgstr "Retour"
+
+#~ msgid "Your reservations were accepted"
+#~ msgstr "Vos réservations ont été acceptées"
+
+#~ msgid "The following reservations were rejected"
+#~ msgstr "Les réservations suivantes ont été rejetées"
 
 #~ msgid "(Redesign only)"
 #~ msgstr "(Redesign uniquement)"

--- a/src/onegov/org/locale/it_CH/LC_MESSAGES/onegov.org.po
+++ b/src/onegov/org/locale/it_CH/LC_MESSAGES/onegov.org.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"POT-Creation-Date: 2026-06-01 12:55+0200\n"
+"POT-Creation-Date: 2026-06-11 11:12+0200\n"
 "PO-Revision-Date: 2022-03-15 10:52+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -4356,8 +4356,8 @@ msgstr "Quantità"
 msgid "VAT"
 msgstr "IVA"
 
-#. credit card
 #.
+#. credit card
 msgid "Payment"
 msgstr "Pagamento"
 
@@ -5161,8 +5161,8 @@ msgstr "Nuovo messaggio del cliente nel ticket ${link}"
 msgid "${author} wrote"
 msgstr "${author} ha scritto"
 
-#. Canonical text for ${link} is: "visit the request page"
 #. Canonical text for ${link} is: "visit the request status page"
+#. Canonical text for ${link} is: "visit the request page"
 msgid "Please ${link} to reply."
 msgstr "Per favore ${link} per rispondere."
 
@@ -5706,9 +5706,6 @@ msgstr ""
 "Spiacenti, la pagina che stai cercando non è stata trovata. Prova a "
 "controllare l'URL per eventuali errori o utilizza la casella di ricerca in "
 "alto."
-
-msgid "Back"
-msgstr "Indietro"
 
 msgid "Link to organizers page"
 msgstr "Link alla pagina dell'organizzatore"
@@ -6321,8 +6318,8 @@ msgid "Delete availability period"
 msgstr "Elimina il periodo di disponibilità"
 
 #.
-#. type:ignore[attr-defined]
 #. type:ignore[attr-defined]  # trigger updates
+#. type:ignore[attr-defined]
 msgid "Your changes were saved"
 msgstr "Le modifiche sono state salvate"
 
@@ -7379,6 +7376,9 @@ msgstr "Nuove date per ${title}"
 msgid "Confirm your reservation"
 msgstr "Conferma la prenotazione"
 
+msgid "Request"
+msgstr "Richiesta"
+
 #. by default we will redirect to the created ticket
 msgid "Thank you for your reservation!"
 msgstr "Grazie per la tua prenotazione!"
@@ -7399,8 +7399,8 @@ msgstr ""
 "Impossibile creare visite con l'API di dormakaba per l'ID del sito "
 "${site_id}. Assicurarsi che le credenziali siano ancora valide."
 
-msgid "Your reservations were accepted"
-msgstr "Le tue prenotazioni sono state accettate"
+msgid "Accepted"
+msgstr "Accettato"
 
 #, python-format
 msgid "Reservation(s) confirmed ${org} ${resource}"
@@ -7435,9 +7435,6 @@ msgid ""
 msgstr ""
 "Il pagamento associato a questa prenotazione deve essere rimborsato prima "
 "che la prenotazione possa essere rifiutata"
-
-msgid "The following reservations were rejected"
-msgstr "Le seguenti prenotazioni sono state rifiutate"
 
 #, python-format
 msgid "${org} Rejected Reservation"
@@ -8002,6 +7999,15 @@ msgstr "Utente creato correttamente"
 
 msgid "Please enter your e-mail address in order to continue"
 msgstr "Inserisci il tuo indirizzo e-mail per continuare"
+
+#~ msgid "Back"
+#~ msgstr "Indietro"
+
+#~ msgid "Your reservations were accepted"
+#~ msgstr "Le tue prenotazioni sono state accettate"
+
+#~ msgid "The following reservations were rejected"
+#~ msgstr "Le seguenti prenotazioni sono state rifiutate"
 
 #~ msgid "(Redesign only)"
 #~ msgstr "(Solo riprogettazione)"

--- a/src/onegov/org/views/reservation.py
+++ b/src/onegov/org/views/reservation.py
@@ -53,6 +53,20 @@ if TYPE_CHECKING:
     from onegov.org.request import OrgRequest
 
 
+def reservation_subject(
+    resource_title: str,
+    reservations: Sequence[Reservation],
+    activity: str,
+) -> str:
+    dates = sorted(
+        {r.display_start().strftime('%d.%m.%Y') for r in reservations}
+    )
+    date_str = ', '.join(dates[:3])
+    if len(dates) > 3:
+        date_str += ', ...'
+    return f'{resource_title} - {date_str} - {activity}'
+
+
 def assert_anonymous_access_only_temporary(
     resource: Resource,
     reservation: Reservation,
@@ -820,7 +834,9 @@ def finalize_reservation(self: Resource, request: OrgRequest) -> Response:
     send_ticket_mail(
         request=request,
         template='mail_ticket_opened.pt',
-        subject=_('Your request has been registered'),
+        subject=reservation_subject(
+            self.title, reservations, request.translate(_('Request'))
+        ),
         receivers=(reservations[0].email,),
         ticket=ticket,
         content={
@@ -835,7 +851,9 @@ def finalize_reservation(self: Resource, request: OrgRequest) -> Response:
         send_ticket_mail(
             request=request,
             template='mail_ticket_opened_info.pt',
-            subject=_('New ticket'),
+            subject=reservation_subject(
+                self.title, reservations, request.translate(_('New ticket'))
+            ),
             ticket=ticket,
             receivers=(email, ),
             content={
@@ -1075,7 +1093,9 @@ def accept_reservation(
         send_ticket_mail(
             request=request,
             template='mail_reservation_accepted.pt',
-            subject=_('Your reservations were accepted'),
+            subject=reservation_subject(
+                resource.title, reservations, request.translate(_('Accepted'))
+            ),
             receivers=(self.email,),
             ticket=ticket,
             content={
@@ -1340,7 +1360,9 @@ def reject_reservation(
     send_ticket_mail(
         request=request,
         template='mail_reservation_rejected.pt',
-        subject=_('The following reservations were rejected'),
+        subject=reservation_subject(
+            resource.title, targeted, request.translate(_('Rejected'))
+        ),
         receivers=(self.email, ),
         ticket=ticket,
         content={
@@ -1601,7 +1623,11 @@ def send_reservation_summary(
         send_ticket_mail(
             request=request,
             template='mail_reservation_summary.pt',
-            subject=_('Reservation summary'),
+            subject=reservation_subject(
+                self.handler.resource.title,
+                self.handler.reservations,
+                request.translate(_('Summary')),
+            ),
             receivers=(recipient, ),
             ticket=self,
             force=True,

--- a/src/onegov/org/views/reservation.py
+++ b/src/onegov/org/views/reservation.py
@@ -55,7 +55,7 @@ if TYPE_CHECKING:
 
 def reservation_subject(
     resource_title: str,
-    reservations: Sequence[Reservation],
+    reservations: Sequence[Any],
     activity: str,
 ) -> str:
     dates = sorted(
@@ -1608,6 +1608,8 @@ def send_reservation_summary(
     if self.handler.deleted or not self.handler.reservations:
         raise exc.HTTPNotFound()
 
+    resource = self.handler.resource
+    assert resource is not None
     recipient = self.handler.email
     if recipient:
         assert request.current_username
@@ -1624,7 +1626,7 @@ def send_reservation_summary(
             request=request,
             template='mail_reservation_summary.pt',
             subject=reservation_subject(
-                self.handler.resource.title,
+                resource.title,
                 self.handler.reservations,
                 request.translate(_('Summary')),
             ),
@@ -1633,7 +1635,7 @@ def send_reservation_summary(
             force=True,
             content={
                 'model': self,
-                'resource': self.handler.resource,
+                'resource': resource,
                 'reservations': self.handler.reservations,
                 'code': self.handler.data.get('key_code'),
                 'changes': self.handler.get_changes(request),

--- a/tests/onegov/org/test_notifications.py
+++ b/tests/onegov/org/test_notifications.py
@@ -82,9 +82,10 @@ def test_new_reservation_notification(client: Client[TestOrgApp]) -> None:
     for mail in mails:
         assert mail is not None
         if mail['To'] == 'jessie@example.org':  # email to customer
-            assert ("Ihre Anfrage wurde erfasst" in mail['Subject']
-                    or "Ihre Reservationen wurden bestätigt" in
-                    mail['Subject'])
+            assert (
+                'Gymnasium - 29.01.2024 - Anfrage' in mail['Subject']
+                or 'Gymnasium - 29.01.2024 - Angenommen' in mail['Subject']
+            )
             assert "Gymnasium" in mail['TextBody']
             assert 'Montag, 29. Januar 2024' in mail['TextBody']
             assert "Anzahl:" in mail['TextBody']

--- a/tests/onegov/org/test_views_resources.py
+++ b/tests/onegov/org/test_views_resources.py
@@ -1123,7 +1123,7 @@ def test_auto_accept_reservations(client: Client) -> None:
     assert len(os.listdir(client.app.maildir)) == 1
     message = client.get_email(0)
     assert message is not None
-    assert 'Ihre Reservationen wurden bestätigt' in message['Subject']
+    assert 'Tageskarte - 28.08.2015 - Angenommen' in message['Subject']
     assert 'Foobar' in message['TextBody']
     assert message['Attachments']
     _, pdf_content = extract_pdf_info(BytesIO(

--- a/tests/onegov/town6/test_notifications.py
+++ b/tests/onegov/town6/test_notifications.py
@@ -81,9 +81,10 @@ def test_new_reservation_notification(client: Client) -> None:
     mails = [client.get_email(i) for i in range(3)]
     for mail in mails:
         if mail['To'] == 'jessie@example.org':  # email to customer
-            assert ("Ihre Anfrage wurde erfasst" in mail['Subject']
-                    or "Ihre Reservationen wurden bestätigt" in
-                    mail['Subject'])
+            assert (
+                'Gymnasium - 29.01.2024 - Anfrage' in mail['Subject']
+                or 'Gymnasium - 29.01.2024 - Angenommen' in mail['Subject']
+            )
             assert "Gymnasium" in mail['TextBody']
             assert 'Montag, 29. Januar 2024' in mail['TextBody']
             assert "Anzahl:" in mail['TextBody']


### PR DESCRIPTION
## Commit message

Org: descriptive subjects with resource, date and activity.

Subjects now show resource name, reservation date(s), and activity type
(e.g. "Turnhalle - 15.06.2026 - Anfrage") instead of generic text.
Threading via Message-ID/In-Reply-To/References already groups emails
in mail clients.

<Optional Description>

TYPE: Feature
LINK: OGC-2158

## Checklist

- [x] I have performed a self-review of my code

