### PR TITLE
Pdf: Fix mypy errors for pdfrw PdfReader import 2

### DIFF
--- a/src/onegov/pdf/flowables.py
+++ b/src/onegov/pdf/flowables.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from pdfrw import PdfReader  # type:ignore[import-untyped]
-from pdfrw.buildxobj import pagexobj  # type:ignore[import-untyped]
-from pdfrw.toreportlab import makerl  # type:ignore[import-untyped]
+from pdfrw import PdfReader  # type:ignore
+from pdfrw.buildxobj import pagexobj  # type:ignore
+from pdfrw.toreportlab import makerl  # type:ignore
 from reportlab.platypus import Flowable
 
 

--- a/tests/onegov/election_day/utils/test_pdf_generator.py
+++ b/tests/onegov/election_day/utils/test_pdf_generator.py
@@ -5,7 +5,7 @@ from datetime import timedelta
 from onegov.election_day.models import BallotResult
 from onegov.election_day.models import Vote
 from onegov.election_day.utils.pdf_generator import PdfGenerator
-from pdfrw import PdfReader  # type: ignore[import-untyped]
+from pdfrw import PdfReader  # type: ignore
 from tests.onegov.election_day.common import DummyRequest
 from tests.onegov.election_day.utils.common import add_election_compound
 from tests.onegov.election_day.utils.common import add_majorz_election

--- a/tests/onegov/pdf/test_pdf.py
+++ b/tests/onegov/pdf/test_pdf.py
@@ -12,7 +12,7 @@ from onegov.pdf import page_fn_header_logo_and_footer
 from onegov.pdf import Pdf
 from onegov.pdf.utils import extract_pdf_info
 from pdfdocument.document import MarkupParagraph
-from pdfrw import PdfReader  # type: ignore[import-untyped]
+from pdfrw import PdfReader  # type: ignore
 from pytest import mark
 from reportlab.lib.enums import TA_CENTER
 from reportlab.lib.enums import TA_LEFT


### PR DESCRIPTION
Pdf: Fix mypy errors for pdfrw PdfReader import 2 [skip-ci]

TYPE: Feature
LINK: None

It doesn't seem to be needed as master builds normally