### PR TITLE
Skip agencies with no portrait during link check

### DIFF
--- a/src/onegov/org/management.py
+++ b/src/onegov/org/management.py
@@ -285,6 +285,8 @@ class LinkHealthCheck(ModelsWithLinksMixin):
                         self.filter_urls(urls)
                     )
         for agency in AgencyCollection(self.request.session).query():
+            if not agency.portrait:
+                continue
             urls = self.extractor.find_urls(agency.portrait, only_unique=True)
             if urls:
                 yield (

--- a/tests/onegov/org/test_management.py
+++ b/tests/onegov/org/test_management.py
@@ -68,6 +68,16 @@ def test_link_health_check(org_app: TestOrgApp) -> None:
         parent=None,
         portrait=Markup('<a href="http://www.google.com"></a>')
     )
+    agencies.add(
+        title='Empty portrait',
+        parent=None,
+        portrait=Markup('')
+    )
+    agencies.add(
+        title='No portrait',
+        parent=None,
+        portrait=None
+    )
 
     # check external
     check = LinkHealthCheck(request, 'external')


### PR DESCRIPTION
Agency: Skip agencies with no portrait during link check

TYPE: Bugfix
LINK: https://seantis-gmbh.sentry.io/issues/7541280427