### PR TITLE
Ignore invalid year filter value

### DIFF
--- a/src/onegov/org/models/political_business.py
+++ b/src/onegov/org/models/political_business.py
@@ -290,7 +290,7 @@ class PoliticalBusinessCollection(
         self.term = term
         self.status = set(status) if status else set()
         self.types = set(types) if types else set()
-        self.years = set(years) if years else set()
+        self.years = {y for y in years if 1 <= y <= 9998} if years else set()
         self.batch_size = 20
 
     @property

--- a/src/onegov/org/models/political_business.py
+++ b/src/onegov/org/models/political_business.py
@@ -288,8 +288,8 @@ class PoliticalBusinessCollection(
         self.request = request
         self.page = page
         self.term = term
-        self.status = set(status) if status else set()
-        self.types = set(types) if types else set()
+        self.status = {s for s in status if s is not None} if status else set()
+        self.types = {t for t in types if t is not None} if types else set()
         self.years = {y for y in years if 1 <= y <= 9998} if years else set()
         self.batch_size = 20
 

--- a/tests/onegov/town6/test_views_political_business.py
+++ b/tests/onegov/town6/test_views_political_business.py
@@ -110,6 +110,9 @@ def test_political_businesses(client_with_fts: Client) -> None:
             '/political-businesses?q=----------------------------------light'
         )
 
+        # out-of-range year parameter must not raise a ValueError
+        client.get('/political-businesses?years=843169290', status=200)
+
     # delete businesses
     (client.get('/political-businesses')
      .click('ow many congressmen does it take to change a light bulb?')

--- a/tests/onegov/town6/test_views_political_business.py
+++ b/tests/onegov/town6/test_views_political_business.py
@@ -110,8 +110,14 @@ def test_political_businesses(client_with_fts: Client) -> None:
             '/political-businesses?q=----------------------------------light'
         )
 
-        # out-of-range year parameter must not raise a ValueError
-        client.get('/political-businesses?years=843169290', status=200)
+        # out-of-range year and invalid status/type params must not error
+        # and must not filter out valid results
+        assert '02.10.2025' in client.get(
+            '/political-businesses?years=843169290')
+        assert '02.10.2025' in client.get(
+            '/political-businesses?status=bogus')
+        assert '02.10.2025' in client.get(
+            '/political-businesses?types=mabis')
 
     # delete businesses
     (client.get('/political-businesses')


### PR DESCRIPTION
Town6: Out-of-range year and invalid status/type params for political business view must not error and must not filter out valid results

TYPE: Bugfix
LINK: https://seantis-gmbh.sentry.io/issues/7576204851