### PR TITLE
Bugfix/default locale for rss feed

### DIFF
--- a/src/onegov/org/views/page.py
+++ b/src/onegov/org/views/page.py
@@ -11,7 +11,6 @@ from onegov.core.elements import Link as CoreLink
 from onegov.core.security import Public, Private
 from onegov.core.utils import append_query_param
 from onegov.org import _, OrgApp
-from onegov.org.app import get_i18n_default_locale
 from onegov.org.elements import Link
 from onegov.org.homepage_widgets import get_lead
 from onegov.org.layout import PageLayout, NewsLayout
@@ -179,7 +178,11 @@ def view_news_collection(
                 query_params={'format': 'rss'}
             ) if next_page else None,
             feed_title=request.domain + ' News',
-            language=request.app.org.locales or get_i18n_default_locale(),
+            language=(
+                request.app.org.locales
+                or request.app.default_locale
+                or 'de_CH'
+            ),
         )
         return Response(
             rss_str,

--- a/src/onegov/org/views/page.py
+++ b/src/onegov/org/views/page.py
@@ -11,6 +11,7 @@ from onegov.core.elements import Link as CoreLink
 from onegov.core.security import Public, Private
 from onegov.core.utils import append_query_param
 from onegov.org import _, OrgApp
+from onegov.org.app import get_i18n_default_locale
 from onegov.org.elements import Link
 from onegov.org.homepage_widgets import get_lead
 from onegov.org.layout import PageLayout, NewsLayout
@@ -178,7 +179,7 @@ def view_news_collection(
                 query_params={'format': 'rss'}
             ) if next_page else None,
             feed_title=request.domain + ' News',
-            language=request.app.org.meta['locales'],
+            language=request.app.org.locales or get_i18n_default_locale(),
         )
         return Response(
             rss_str,

--- a/tests/onegov/org/test_views_news.py
+++ b/tests/onegov/org/test_views_news.py
@@ -77,8 +77,8 @@ def test_news(client: Client) -> None:
     assert "It is lots of fun" not in page.text
     assert '<language>' in page.text
 
-    # RSS feed must not crash when org has no locales configured
-    client.app.org.locales = None
+    # RSS feed must not crash when org has no locales configured (KeyError)
+    client.app.org.meta.pop('locales', None)
     transaction.commit()
     page = client.get('/news?format=rss')
     assert '<language>de_CH</language>' in page.text

--- a/tests/onegov/org/test_views_news.py
+++ b/tests/onegov/org/test_views_news.py
@@ -75,6 +75,13 @@ def test_news(client: Client) -> None:
     assert "We have a new homepage" in page.text
     assert "It is very good" in page.text
     assert "It is lots of fun" not in page.text
+    assert '<language>' in page.text
+
+    # RSS feed must not crash when org has no locales configured
+    client.app.org.locales = None
+    transaction.commit()
+    page = client.get('/news?format=rss')
+    assert '<language>de_CH</language>' in page.text
 
     page = client.get('/news/we-have-a-new-homepage')
     client.delete(page.pyquery('a[ic-delete-from]').attr('ic-delete-from'))


### PR DESCRIPTION
Org: Fixes default language for RSS feed

If by any reason the organisations `locales` is not set, the RSS feed failed as no default language was assigned

TYPE: Bugfix
LINK: https://seantis-gmbh.sentry.io/issues/4098479098