### PR TITLE
Org: Fixes unstable sort order of whitelisted iFrame domains

### DIFF
--- a/src/onegov/org/forms/page.py
+++ b/src/onegov/org/forms/page.py
@@ -124,6 +124,9 @@ class IframeForm(PageBaseForm):
                 'child_src', set()):
             self.allowed_domains.append(domain) if domain != "'self'" else None
         if self.allowed_domains:
+            # keep displayed domain order stable
+            self.allowed_domains.sort()
+
             self.domain_hint.text = (
                 self.request.translate(
                     _('The following domains are allowed for iFrames:')


### PR DESCRIPTION
## Commit message

Org: Fixes unstable sort order of whitelisted iFrame domains

TYPE: Bugfix
LINK: OGC-3196

## Checklist

- [x] I have performed a self-review of my code
