### PR TITLE
Fix rollout schedule landing a week late

### DIFF
--- a/maintenance-schedule.yml
+++ b/maintenance-schedule.yml
@@ -1,23 +1,23 @@
 schedule:
-  - date: Next Tuesday at 12:00
+  - date: Tuesday at 12:00
     nodes:
       - loxo
       - pherusa
       - tyche
-  - date: Next Tuesday at 14:00
+  - date: Tuesday at 14:00
     nodes:
       - aether
       - alecto
       - theros
       - arete
       - calais
-  - date: Next Tuesday at 15:00
+  - date: Tuesday at 15:00
     nodes:
       - caicias
       - caicinus
       - caicus
       - carcinus
-  - date: Next Monday +7 days at 7:00
+  - date: Monday +7 days at 7:00
     nodes:
       - ister
       - istrus


### PR DESCRIPTION
Fix rollout schedule landing a week late [skip-ci]
                                                                                      
Next Tuesday'/'Next Monday' resolve to the following calendar week when the script is run on a Monday. Bare weekday names schedule the upcoming occurrence instead.  

TYPE: Bugfix
LINK: None