### PR TITLE
Core: Fixes HTTP 500 on null bytes in filter query parameters

### DIFF
--- a/src/onegov/core/utils.py
+++ b/src/onegov/core/utils.py
@@ -175,6 +175,39 @@ def normalize_for_filename(
     return sanitized
 
 
+#: Characters PostgreSQL cannot store in ``text`` / ``jsonb`` columns - null
+#: bytes and lone surrogates - which raise a ``DataError`` when bound as a
+#: query parameter. They only appear in malformed or malicious requests.
+_unstorable_text = re.compile(r'[\x00\ud800-\udfff]')
+
+
+def sanitize_query_param(value: object) -> str | None:
+    """ Returns ``value`` as a non-empty string safe to use as a database
+    query parameter, or ``None``.
+
+    Drops values with characters PostgreSQL cannot store as ``text`` /
+    ``jsonb`` (null bytes, lone surrogates), which would otherwise raise an
+    unhandled ``DataError`` (HTTP 500) when used in a filter.
+    """
+    if not isinstance(value, str) or not value:
+        return None
+    if _unstorable_text.search(value):
+        return None
+    return value
+
+
+def sanitize_query_params(values: Iterable[object] | None) -> list[str]:
+    """ Like :func:`sanitize_query_param`, but for a sequence: drops items
+    that are empty or unsafe to use as a database query parameter. """
+    if not values:
+        return []
+    return [
+        sanitized
+        for value in values
+        if (sanitized := sanitize_query_param(value)) is not None
+    ]
+
+
 def increment_name(name: str) -> str:
     """ Takes the given name and adds a numbered suffix beginning at 1.
 

--- a/src/onegov/event/collections/occurrences.py
+++ b/src/onegov/event/collections/occurrences.py
@@ -23,6 +23,8 @@ from webob.multidict import MultiDict
 
 from onegov.core.collection import Pagination
 from onegov.core.orm import SessionManager
+from onegov.core.utils import sanitize_query_param
+from onegov.core.utils import sanitize_query_params
 from onegov.core.utils import toggle
 from onegov.event.models import Event
 from onegov.event.models import EventFilterValue
@@ -145,14 +147,14 @@ class OccurrenceCollection(Pagination[Occurrence]):
 
         super().__init__(page=page)
         self.session = session
-        self.term = term
+        self.term = sanitize_query_param(term)
         self.range = range if range in self.date_ranges else None
         self.start, self.end = self.range_to_dates(range, start, end)
         self.outdated = outdated
-        self.tags = tags if tags else []
+        self.tags = sanitize_query_params(tags)
         self.filter_keywords = cast('MultiDict[str, str]', filter_keywords)
-        self.locations = locations if locations else []
-        self.sources = sources if sources else []
+        self.locations = sanitize_query_params(locations)
+        self.sources = sanitize_query_params(sources)
         self.syndicate = syndicate
         self.highlight = highlight
         self.available_accesses = available_accesses

--- a/src/onegov/org/models/page.py
+++ b/src/onegov/org/models/page.py
@@ -6,6 +6,7 @@ from onegov.core.collection import Pagination
 from onegov.core.orm.abstract import AdjacencyListCollection
 from onegov.core.orm.mixins import (
     content_property, dict_markup_property, dict_property, meta_property)
+from onegov.core.utils import sanitize_query_param, sanitize_query_params
 from onegov.form import Form, move_fields
 from onegov.org import _
 from onegov.org.forms import LinkForm, PageForm, IframeForm
@@ -316,7 +317,7 @@ class TopicCollection(Pagination[Topic], AdjacencyListCollection[Topic]):
         self.request = request
         self.session = request.session
         self.page = page
-        self.term = term
+        self.term = sanitize_query_param(term)
 
     @property
     def q(self) -> str | None:
@@ -403,9 +404,9 @@ class NewsCollection(Pagination[News], AdjacencyListCollection[News]):
         self.request = request
         self.session = request.session
         self.page = page
-        self.term = term
+        self.term = sanitize_query_param(term)
         self.filter_years = filter_years or []
-        self.filter_tags = filter_tags or []
+        self.filter_tags = sanitize_query_params(filter_tags)
         if root is not None:
             self.root = root
 

--- a/src/onegov/org/models/search.py
+++ b/src/onegov/org/models/search.py
@@ -5,7 +5,6 @@ import math
 from functools import cached_property
 from onegov.core.collection import Pagination
 from onegov.core.orm.types import MarkupText
-from onegov.core.utils import sanitize_query_param
 from onegov.event.models import Event
 from onegov.search import SearchIndex
 from onegov.search.utils import language_from_locale

--- a/src/onegov/org/models/search.py
+++ b/src/onegov/org/models/search.py
@@ -5,6 +5,7 @@ import math
 from functools import cached_property
 from onegov.core.collection import Pagination
 from onegov.core.orm.types import MarkupText
+from onegov.core.utils import sanitize_query_param
 from onegov.event.models import Event
 from onegov.search import SearchIndex
 from onegov.search.utils import language_from_locale

--- a/src/onegov/org/views/people.py
+++ b/src/onegov/org/views/people.py
@@ -6,6 +6,7 @@ from sqlalchemy import and_, func, type_coerce
 from sqlalchemy.orm import undefer
 from onegov.core.orm.types import JSON
 from onegov.core.security import Public, Private
+from onegov.core.utils import sanitize_query_param
 from onegov.org import _, OrgApp
 from onegov.org.elements import Link
 from onegov.org.forms import PersonForm
@@ -112,17 +113,12 @@ def view_people(
     layout: PersonCollectionLayout | None = None
 ) -> RenderData:
 
-    _org = request.params.get('organisation')
-    selected_org: str | None = _org if isinstance(_org, str) and _org else None
-    _sub_org = request.params.get('sub_organisation')
-    selected_sub_org: str | None = (
-        _sub_org if isinstance(_sub_org, str) and _sub_org else None)
+    selected_org = sanitize_query_param(request.params.get('organisation'))
+    selected_sub_org = sanitize_query_param(
+        request.params.get('sub_organisation'))
     selected_search: str | None = None
     if request.app.fts_search_enabled:
-        _search = request.params.get('search')
-        selected_search = (
-            _search if isinstance(_search, str) and _search else None
-        )
+        selected_search = sanitize_query_param(request.params.get('search'))
 
     top_orgs = get_top_level_organisations(
         request.app.org.organisation_hierarchy or [])

--- a/tests/onegov/core/test_utils.py
+++ b/tests/onegov/core/test_utils.py
@@ -93,7 +93,8 @@ def test_normalize_for_filename(
 
 def test_sanitize_query_param() -> None:
     # regular, non-empty strings pass through unchanged
-    assert utils.sanitize_query_param('Bildung und Sport') == 'Bildung und Sport'
+    assert utils.sanitize_query_param('Bildung und Sport') == (
+        'Bildung und Sport')
     assert utils.sanitize_query_param('../../../etc/passwd') == (
         '../../../etc/passwd')
 

--- a/tests/onegov/core/test_utils.py
+++ b/tests/onegov/core/test_utils.py
@@ -91,6 +91,37 @@ def test_normalize_for_filename(
         assert utils.normalize_for_filename(input_text) == expected
 
 
+def test_sanitize_query_param() -> None:
+    # regular, non-empty strings pass through unchanged
+    assert utils.sanitize_query_param('Bildung und Sport') == 'Bildung und Sport'
+    assert utils.sanitize_query_param('../../../etc/passwd') == (
+        '../../../etc/passwd')
+
+    # empty / non-string values are dropped
+    assert utils.sanitize_query_param('') is None
+    assert utils.sanitize_query_param(None) is None
+    assert utils.sanitize_query_param(42) is None
+
+    # values that PostgreSQL cannot store as text/jsonb are dropped, so they
+    # never reach the database as a query parameter (see ONEGOV-CLOUD-5X0)
+    assert utils.sanitize_query_param('-../../../etc/passwd\x00') is None
+    assert utils.sanitize_query_param('foo\x00bar') is None
+    # lone surrogates are rejected for the same reason
+    assert utils.sanitize_query_param('foo\ud800bar') is None
+    assert utils.sanitize_query_param('\udfff') is None
+
+
+def test_sanitize_query_params() -> None:
+    assert utils.sanitize_query_params(['a', 'b']) == ['a', 'b']
+    assert utils.sanitize_query_params(None) == []
+    assert utils.sanitize_query_params([]) == []
+
+    # only the offending values are dropped, the rest are kept in order
+    assert utils.sanitize_query_params(
+        ['keep', 'drop\x00', '', 'also-keep', 'bad\ud800']
+    ) == ['keep', 'also-keep']
+
+
 def test_touch(temporary_directory: str) -> None:
     path = os.path.join(temporary_directory, 'test.txt')
 

--- a/tests/onegov/org/test_views_event.py
+++ b/tests/onegov/org/test_views_event.py
@@ -171,6 +171,19 @@ def test_view_occurrences(client: Client) -> None:
         'Diese Termine exportieren').text.startswith('BEGIN:VCALENDAR')
 
 
+def test_view_occurrences_null_byte_filter(client: Client) -> None:
+    # a null byte in a filter param must not reach the database (where it
+    # would raise an unhandled DataError / HTTP 500)
+    for query in ('tags=x%00', 'locations=x%00'):
+        page = client.get(f'/events/?{query}', expect_errors=True)
+        assert page.status_code == 200
+
+    # the JSON portlet endpoint reads the same filters from cat1/cat2
+    for query in ('cat1=x%00', 'cat2=x%00'):
+        page = client.get(f'/events/json?{query}', expect_errors=True)
+        assert page.status_code == 200
+
+
 def test_view_occurrences_event_filter(client: Client) -> None:
     """
     This test switches the application settings event filter type between

--- a/tests/onegov/org/test_views_news.py
+++ b/tests/onegov/org/test_views_news.py
@@ -223,3 +223,12 @@ def test_news_filter_invalid_years(client: Client) -> None:
 
     page = client.get('/news?filter_years=2020')
     assert 'Aktuelles' in page
+
+
+def test_news_filter_null_byte(client: Client) -> None:
+    # a null byte in a filter param must not reach the database (where it
+    # would raise an unhandled DataError / HTTP 500), it should simply be
+    # ignored
+    page = client.get('/news?filter_tags=x%00', expect_errors=True)
+    assert page.status_code == 200
+    assert 'Aktuelles' in page

--- a/tests/onegov/org/test_views_people.py
+++ b/tests/onegov/org/test_views_people.py
@@ -132,6 +132,27 @@ def test_with_people(client: Client) -> None:
     assert edit_page.form['people-1-context_specific_function'].value == ''
 
 
+def test_people_view_null_byte_filter(client: Client) -> None:
+    # a null byte in a filter param must not reach the database (where it
+    # would raise an unhandled DataError / HTTP 500), it should simply be
+    # ignored - see the path-traversal scanner payload in ONEGOV-CLOUD-5X0
+    client.login_editor()
+
+    new_person = client.get('/people').click('Person', index=1)
+    new_person.form['first_name'] = 'Flash'
+    new_person.form['last_name'] = 'Gordon'
+    new_person.form.submit()
+
+    for param in ('organisation', 'sub_organisation', 'search'):
+        page = client.get(
+            f'/people?{param}=-../../../etc/passwd%00',
+            expect_errors=True
+        )
+        assert page.status_code == 200
+        # the null byte value is dropped, so no filter is applied
+        assert 'Gordon Flash' in page
+
+
 def test_people_view_organisation_filter(client: Client) -> None:
     org_1 = 'The Nexus'
     sub_org_11 = 'Nexus Innovators'


### PR DESCRIPTION
Core: Guards query-parameter filters against null bytes

TYPE: Feature
LINK: https://seantis-gmbh.sentry.io/issues/7595041870