### PR TITLE
Ogc 2953 text options height

### DIFF
--- a/src/onegov/form/assets/css/text-module-picker.css
+++ b/src/onegov/form/assets/css/text-module-picker.css
@@ -16,6 +16,8 @@
     border: 1px solid #ccc;
     list-style: none;
     z-index: 100;
+    max-height: 50vh;
+    overflow-y: auto;
 }
 
 .text-module-picker.active .text-module-options {


### PR DESCRIPTION
Please fill in the commit message below and work through the checklist. You can delete parts that are not needed, e.g. the optional description, the link to a ticket or irrelevant options of the checklist.

## Commit message

Town6: Make text options dropdown scrollable

TYPE: Feature
LINK: OGC-2953