### PR TITLE
Adds caerus wab production server to maintenance schedule config

### DIFF
--- a/maintenance-schedule.yml
+++ b/maintenance-schedule.yml
@@ -16,6 +16,7 @@ schedule:
       - caicias
       - caicinus
       - caicus
+      - caerus
       - carcinus
   - date: Monday +7 days at 7:00
     nodes:


### PR DESCRIPTION
Core: Adds `caerus` WAB production server to maintenance schedule config [skip-ci]

TYPE: Feature
LINK: None