### PR TITLE
Feature/fix edit menu and breadcrubs

### DIFF
--- a/maintenance-schedule.yml
+++ b/maintenance-schedule.yml
@@ -16,6 +16,7 @@ schedule:
       - caicias
       - caicinus
       - caicus
+      - caerus
       - carcinus
   - date: Monday +7 days at 7:00
     nodes:

--- a/src/onegov/form/validators.py
+++ b/src/onegov/form/validators.py
@@ -552,13 +552,13 @@ class ValidFilterFormDefinition(ValidFormDefinition):
         # limit the definition to MultiCheckboxField, RadioField which can
         # be used for filter definition
         errors = None
-        for field in parsed_form._fields.values():
-            if not isinstance(field, (MultiCheckboxField, RadioField)):
-                error = field.gettext(self.invalid_field_type.format(
-                    label=field.label.text))
-                errors = form['definition'].errors
+        for parsed_field in parsed_form._fields.values():
+            if not isinstance(parsed_field, (MultiCheckboxField, RadioField)):
+                error = parsed_field.gettext(self.invalid_field_type.format(
+                    label=parsed_field.label.text))
+                errors = field.errors
                 if not isinstance(errors, list):
-                    errors = form['definition'].process_errors
+                    errors = field.process_errors
                     assert isinstance(errors, list)
                 errors.append(error)
 

--- a/src/onegov/org/assets/js/code_editor.js
+++ b/src/onegov/org/assets/js/code_editor.js
@@ -5,6 +5,10 @@ $(function() {
         var readonly = textarea.is('[readonly]');
         textarea.css('display', 'none');
 
+        // the editor replaces the textarea with its own widget, so make sure
+        // the field-dependency handling never re-shows the raw textarea
+        textarea.attr('data-always-hidden', '');
+
         var outside = $('<div class="code-editor-wrapper">');
         var inside = $('<div class="code-editor">');
         inside.position('absolute');

--- a/src/onegov/org/forms/event.py
+++ b/src/onegov/org/forms/event.py
@@ -19,13 +19,11 @@ from onegov.form.fields import MultiCheckboxField
 from onegov.form.fields import TimeField
 from onegov.form.fields import UploadField
 from onegov.form.fields import UploadFileWithORMSupport
-from onegov.form.utils import get_fields_from_class
 from onegov.file.attachments import IMAGE_MAX_SIZE
 from onegov.form.validators import (
     FileSizeLimit,
     ImageSizeLimit,
     ValidPhoneNumber,
-    ValidFilterFormDefinition,
     MIME_TYPES_EXCEL,
     MIME_TYPES_PDF,
 )
@@ -684,35 +682,3 @@ class EventImportForm(Form):
             transaction.abort()
 
         return count, errors
-
-
-class EventConfigurationForm(Form):
-    """ Form to configure filters for events view. """
-
-    definition = TextAreaField(
-        label=_('Definition'),
-        fieldset=_('General'),
-        validators=[
-            InputRequired(),
-            ValidFilterFormDefinition(
-                require_email_field=False,
-                require_title_fields=False,
-                reserved_fields={name for name, _ in
-                                 get_fields_from_class(EventForm)}
-                | {'syndicate', 'highlight'}
-            )
-        ],
-        render_kw={'rows': 32, 'data-editor': 'form'})
-
-    keyword_fields = TextAreaField(
-        label=_('Filters'),
-        fieldset=_('Display'),
-        render_kw={
-            'class_': 'formcode-select',
-            'data-fields-include': 'radio,checkbox'
-        })
-
-    force_remove = BooleanField(
-        label=_('Remove these filters from all affected events'),
-        fieldset=_('Confirmation'),
-    )

--- a/src/onegov/org/forms/settings.py
+++ b/src/onegov/org/forms/settings.py
@@ -25,11 +25,14 @@ from onegov.form.fields import PreviewField
 from onegov.form.fields import TagsField
 from onegov.form.fields import TranslatedSelectField
 from onegov.form.fields import URLField
+from onegov.form.utils import get_fields_from_class
 from onegov.form.validators import If
 from onegov.form.validators import StrictOptional
+from onegov.form.validators import ValidFilterFormDefinition
 from onegov.form.validators import ValidHostname
 from onegov.gis import CoordinatesField
 from onegov.org import _, log
+from onegov.org.forms.event import EventForm
 from onegov.org.forms.fields import (
     HtmlField,
     UploadOrSelectExistingMultipleFilesField,
@@ -2067,21 +2070,6 @@ class EventSettingsForm(Form):
         default=False
     )
 
-    event_locations = TagsField(
-        label=_('Values of the location filter'),
-    )
-
-    event_filter_type = RadioField(
-        label=_("Choose the filter type for events (default is 'Tags')"),
-        choices=(
-            ('tags', _('A predefined set of tags')),
-            ('filters', _('Manually configurable filters')),
-            ('tags_and_filters', _('Both, predefined tags as well as '
-                                   'configurable filters')),
-        ),
-        default='tags'
-    )
-
     event_header_title = StringField(
         label=_('Title of text above event list'),
         description=_('General information about the event calendar'),
@@ -2104,6 +2092,56 @@ class EventSettingsForm(Form):
         fieldset=_('Information below the event list')
     )
 
+    event_locations = TagsField(
+        label=_('Values of the location filter'),
+        fieldset=_('Filters'),
+    )
+
+    event_filter_type = RadioField(
+        label=_("Choose the filter type for events (default is 'Tags')"),
+        fieldset=_('Filters'),
+        choices=(
+            ('tags', _('A predefined set of tags')),
+            ('filters', _('Manually configurable filters')),
+            ('tags_and_filters', _('Both, predefined tags as well as '
+                                   'configurable filters')),
+        ),
+        default='tags'
+    )
+
+    event_filter_definition = TextAreaField(
+        label=_('Definition'),
+        fieldset=_('Filters'),
+        depends_on=('event_filter_type', '!tags'),
+        validators=[
+            ValidFilterFormDefinition(
+                require_email_field=False,
+                require_title_fields=False,
+                reserved_fields={name for name, _ in
+                                 get_fields_from_class(EventForm)}
+                                | {'syndicate', 'highlight'}
+            )
+        ],
+        render_kw={'rows': 16, 'data-editor': 'form'}
+    )
+
+    keyword_fields = TextAreaField(
+        label=_('Filters'),
+        fieldset=_('Filters'),
+        depends_on=('event_filter_type', '!tags'),
+        render_kw={
+            'class_': 'formcode-select',
+            'data-fields-include': 'radio,checkbox'
+        }
+    )
+
+    force_remove = BooleanField(
+        label=_('Remove these filters from all affected events'),
+        fieldset=_('Filters'),
+    )
+
+    # FIXME: keep this last; its upload widget emits a split <label> that
+    # confuses webtest's form parser for any field rendered after it
     event_files = UploadOrSelectExistingMultipleFilesField(
         label=_('Documents'),
         fieldset=_('General event documents')

--- a/src/onegov/org/layout.py
+++ b/src/onegov/org/layout.py
@@ -1702,13 +1702,19 @@ class PersonCollectionLayout(DefaultLayout):
     @cached_property
     def editbar_links(self) -> list[Link | LinkGroup] | None:
         if self.request.is_manager:
-            return [
-                Link(
+            links: list[Link | LinkGroup] = []
+
+            if self.request.is_admin:
+                links.append(Link(
                     text=_('Settings'),
-                    url=self.request.link(
-                        self.request.app.org, 'people-settings'),
+                    url=self.request.return_here(
+                        self.request.link(
+                            self.request.app.org, 'people-settings')
+                    ),
                     attrs={'class': 'settings-link'}
-                ),
+                ))
+
+            links.append(
                 LinkGroup(
                     title=_('Add'),
                     links=[
@@ -1721,8 +1727,9 @@ class PersonCollectionLayout(DefaultLayout):
                             attrs={'class': 'new-person'}
                         )
                     ]
-                ),
-            ]
+                )
+            )
+            return links
         return None
 
 
@@ -2286,6 +2293,7 @@ class ResourcesLayout(DefaultLayout):
                 Link(
                     text=_('Export All'),
                     url=self.request.link(self.model, name='export-all'),
+                    attrs={'class': 'export-link'},
                 ),
                 IFrameLink(
                     text=_('iFrame'),
@@ -2727,14 +2735,15 @@ class OccurrencesLayout(DefaultLayout, EventLayoutMixin):
     def editbar_links(self) -> list[Link | LinkGroup]:
         def links() -> Iterator[Link | LinkGroup]:
             if self.request.is_manager:
-                yield Link(
-                    text=_('Settings'),
-                    url=self.request.return_here(
-                        self.request.link(self.request.app.org,
-                                          'event-settings')
-                    ),
-                    attrs={'class': 'edit-link'}
-                )
+                if self.request.is_admin:
+                    yield Link(
+                        text=_('Settings'),
+                        url=self.request.return_here(
+                            self.request.link(self.request.app.org,
+                                              'event-settings')
+                        ),
+                        attrs={'class': 'edit-link'}
+                    )
 
                 yield Link(
                     text=_('Import'),
@@ -3040,20 +3049,24 @@ class NewsletterLayout(DefaultLayout):
             return None
 
         if self.is_collection:
-            links: list[Link | LinkGroup] = [
-                Link(
+            links: list[Link | LinkGroup] = []
+
+            if self.request.is_admin:
+                links.append(Link(
                     text=_('Settings'),
-                    url=self.request.link(
-                        self.request.app.org, 'newsletter-settings'
+                    url=self.request.return_here(
+                        self.request.link(
+                            self.request.app.org, 'newsletter-settings'
+                        )
                     ),
                     attrs={'class': 'settings-link'},
-                ),
-                Link(
-                    text=_('Subscribers'),
-                    url=self.request.link(self.recipients),
-                    attrs={'class': 'manage-subscribers'},
-                ),
-            ]
+                ))
+
+            links.append(Link(
+                text=_('Subscribers'),
+                url=self.request.link(self.recipients),
+                attrs={'class': 'manage-subscribers'},
+            ))
 
             if self.request.browser_session.has('clipboard_url'):
                 clipboard = Clipboard.from_session(self.request)

--- a/src/onegov/org/layout.py
+++ b/src/onegov/org/layout.py
@@ -3048,15 +3048,16 @@ class NewsletterLayout(DefaultLayout):
         if self.is_collection:
             links: list[Link | LinkGroup] = [
                 Link(
-                    text=_('Subscribers'),
-                    url=self.request.link(self.recipients),
-                    attrs={'class': 'manage-subscribers'}
-                ),
-                Link(
                     text=_('Settings'),
                     url=self.request.link(
-                        self.request.app.org, 'newsletter-settings'),
-                    attrs={'class': 'settings-link'}
+                        self.request.app.org, 'newsletter-settings'
+                    ),
+                    attrs={'class': 'settings-link'},
+                ),
+                Link(
+                    text=_('Subscribers'),
+                    url=self.request.link(self.recipients),
+                    attrs={'class': 'manage-subscribers'},
                 ),
             ]
 
@@ -3097,6 +3098,11 @@ class NewsletterLayout(DefaultLayout):
 
             return [
                 Link(
+                    text=_('Edit'),
+                    url=self.request.link(self.model, 'edit'),
+                    attrs={'class': 'edit-link'}
+                ),
+                Link(
                     text=_('Schedule email delivery'),
                     url=self.request.link(self.model, 'send'),
                     attrs={'class': 'send-link'}
@@ -3114,11 +3120,6 @@ class NewsletterLayout(DefaultLayout):
                         )
                     ),
                     attrs={'class': 'copy-link'},
-                ),
-                Link(
-                    text=_('Edit'),
-                    url=self.request.link(self.model, 'edit'),
-                    attrs={'class': 'edit-link'}
                 ),
                 Link(
                     text=_('Delete'),

--- a/src/onegov/org/layout.py
+++ b/src/onegov/org/layout.py
@@ -2281,50 +2281,7 @@ class ResourcesLayout(DefaultLayout):
                 Link(
                     text=_('Recipients'),
                     url=self.request.class_link(ResourceRecipientCollection),
-                    attrs={'class': 'manage-recipients'}
-                ),
-                LinkGroup(
-                    title=_('Add'),
-                    links=[
-                        Link(
-                            text=_('Room'),
-                            url=self.request.link(
-                                self.model,
-                                name='new-room'
-                            ),
-                            attrs={'class': 'new-room'}
-                        ),
-                        Link(
-                            text=_('Daypass'),
-                            url=self.request.link(
-                                self.model,
-                                name='new-daypass'
-                            ),
-                            attrs={'class': 'new-daypass'}
-                        ),
-                        Link(
-                            text=_('Resource Item'),
-                            url=self.request.link(
-                                self.model,
-                                name='new-daily-item'
-                            ),
-                            attrs={'class': 'new-daily-item'}
-                        ),
-                        Link(
-                            text=_('External resource link'),
-                            url=self.request.link(
-                                self.external_resources,
-                                query_params={
-                                    'to': self.resources_url,
-                                    'title': self.request.translate(
-                                        _('New external resource')),
-                                    'type': 'resource'
-                                },
-                                name='new'
-                            ),
-                            attrs={'class': 'new-resource-link'}
-                        )
-                    ]
+                    attrs={'class': 'manage-recipients'},
                 ),
                 Link(
                     text=_('Export All'),
@@ -2333,8 +2290,47 @@ class ResourcesLayout(DefaultLayout):
                 IFrameLink(
                     text=_('iFrame'),
                     url=self.request.link(self.model),
-                    attrs={'class': 'new-iframe'}
-                )
+                    attrs={'class': 'new-iframe'},
+                ),
+                LinkGroup(
+                    title=_('Add'),
+                    links=[
+                        Link(
+                            text=_('Room'),
+                            url=self.request.link(self.model, name='new-room'),
+                            attrs={'class': 'new-room'},
+                        ),
+                        Link(
+                            text=_('Daypass'),
+                            url=self.request.link(
+                                self.model, name='new-daypass'
+                            ),
+                            attrs={'class': 'new-daypass'},
+                        ),
+                        Link(
+                            text=_('Resource Item'),
+                            url=self.request.link(
+                                self.model, name='new-daily-item'
+                            ),
+                            attrs={'class': 'new-daily-item'},
+                        ),
+                        Link(
+                            text=_('External resource link'),
+                            url=self.request.link(
+                                self.external_resources,
+                                query_params={
+                                    'to': self.resources_url,
+                                    'title': self.request.translate(
+                                        _('New external resource')
+                                    ),
+                                    'type': 'resource',
+                                },
+                                name='new',
+                            ),
+                            attrs={'class': 'new-resource-link'},
+                        ),
+                    ],
+                ),
             ]
         return None
 

--- a/src/onegov/org/layout.py
+++ b/src/onegov/org/layout.py
@@ -2726,19 +2726,13 @@ class OccurrencesLayout(DefaultLayout, EventLayoutMixin):
     @cached_property
     def editbar_links(self) -> list[Link | LinkGroup]:
         def links() -> Iterator[Link | LinkGroup]:
-            if (self.request.is_admin and self.request.app.org.
-                    event_filter_type in ['filters', 'tags_and_filters']):
-                yield Link(
-                    text=_('Configure'),
-                    url=self.request.link(self.model, '+edit'),
-                    attrs={'class': 'filters-link'}
-                )
-
             if self.request.is_manager:
                 yield Link(
-                    text=_('Edit'),
-                    url=self.request.link(self.request.app.org,
-                                          'event-settings'),
+                    text=_('Settings'),
+                    url=self.request.return_here(
+                        self.request.link(self.request.app.org,
+                                          'event-settings')
+                    ),
                     attrs={'class': 'edit-link'}
                 )
 

--- a/src/onegov/org/layout.py
+++ b/src/onegov/org/layout.py
@@ -3240,17 +3240,17 @@ class ImageSetLayout(DefaultLayout):
         if self.request.is_manager:
             return [
                 Link(
-                    text=_('Choose images'),
-                    url=self.request.link(self.model, 'select'),
-                    attrs={'class': 'select'}
-                ),
-                Link(
                     text=_('Edit'),
                     url=self.request.link(
                         self.model,
                         name='edit'
                     ),
                     attrs={'class': 'edit-link'}
+                ),
+                Link(
+                    text=_('Choose images'),
+                    url=self.request.link(self.model, 'select'),
+                    attrs={'class': 'select'}
                 ),
                 Link(
                     text=_('Delete'),

--- a/src/onegov/org/locale/de_CH/LC_MESSAGES/onegov.org.po
+++ b/src/onegov/org/locale/de_CH/LC_MESSAGES/onegov.org.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE 1.0\n"
-"POT-Creation-Date: 2026-07-16 15:23+0200\n"
+"POT-Creation-Date: 2026-07-20 08:36+0200\n"
 "PO-Revision-Date: 2022-03-15 10:21+0100\n"
 "Last-Translator: Marc Sommerhalder <marc.sommerhalder@seantis.ch>\n"
 "Language-Team: German\n"
@@ -950,43 +950,50 @@ msgid "Elderly"
 msgstr "Senioren"
 
 #. FIXME: We define a very similar constant in our forms, we should move this
-#. to onegov.org.constants and use it for both. noqa: N806
+#. to onegov.org.constants and use it for both. ruff:ignore[non-lowercase-
+#. variable-in-function]
 #.
 msgid "Mo"
 msgstr "Mo"
 
 #. FIXME: We define a very similar constant in our forms, we should move this
-#. to onegov.org.constants and use it for both. noqa: N806
+#. to onegov.org.constants and use it for both. ruff:ignore[non-lowercase-
+#. variable-in-function]
 #.
 msgid "Tu"
 msgstr "Di"
 
 #. FIXME: We define a very similar constant in our forms, we should move this
-#. to onegov.org.constants and use it for both. noqa: N806
+#. to onegov.org.constants and use it for both. ruff:ignore[non-lowercase-
+#. variable-in-function]
 #.
 msgid "We"
 msgstr "Mi"
 
 #. FIXME: We define a very similar constant in our forms, we should move this
-#. to onegov.org.constants and use it for both. noqa: N806
+#. to onegov.org.constants and use it for both. ruff:ignore[non-lowercase-
+#. variable-in-function]
 #.
 msgid "Th"
 msgstr "Do"
 
 #. FIXME: We define a very similar constant in our forms, we should move this
-#. to onegov.org.constants and use it for both. noqa: N806
+#. to onegov.org.constants and use it for both. ruff:ignore[non-lowercase-
+#. variable-in-function]
 #.
 msgid "Fr"
 msgstr "Fr"
 
 #. FIXME: We define a very similar constant in our forms, we should move this
-#. to onegov.org.constants and use it for both. noqa: N806
+#. to onegov.org.constants and use it for both. ruff:ignore[non-lowercase-
+#. variable-in-function]
 #.
 msgid "Sa"
 msgstr "Sa"
 
 #. FIXME: We define a very similar constant in our forms, we should move this
-#. to onegov.org.constants and use it for both. noqa: N806
+#. to onegov.org.constants and use it for both. ruff:ignore[non-lowercase-
+#. variable-in-function]
 #.
 msgid "Su"
 msgstr "So"
@@ -1118,12 +1125,6 @@ msgstr "Erstellt"
 
 msgid "Expected header line with the following columns:"
 msgstr "Die erste Zeile soll folgende Spaltennamen haben:"
-
-msgid "Remove these filters from all affected events"
-msgstr "Diese(n) Filter bei allen betroffenen Veranstaltungen entfernen"
-
-msgid "Confirmation"
-msgstr "Bestätigung"
 
 msgid "Comment"
 msgstr "Kommentar"
@@ -2339,6 +2340,9 @@ msgstr "Dateien in separatem Fenster öffnen"
 msgid "Short links"
 msgstr "Kurzlinks"
 
+msgid "Preview"
+msgstr "Vorschau"
+
 #, python-format
 msgid ""
 "Malformed short link on line ${number}. Each line needs to be a pair of "
@@ -2595,9 +2599,6 @@ msgstr "Zürich"
 
 msgid "Other holidays"
 msgstr "Andere Feiertage"
-
-msgid "Preview"
-msgstr "Vorschau"
 
 msgid "School holidays"
 msgstr "Schulferien"
@@ -2979,21 +2980,6 @@ msgid "Events are automatically deleted once they have occurred"
 msgstr ""
 "Veranstaltungen werden automatisch gelöscht, sobald sie stattgefunden haben"
 
-msgid "Values of the location filter"
-msgstr "Werte des Ortfilters"
-
-msgid "Choose the filter type for events (default is 'Tags')"
-msgstr "Wählen Sie den Filtertyp für Veranstaltungen (Standard ist 'Tags')"
-
-msgid "A predefined set of tags"
-msgstr "Ein vordefiniertes Set von Tags"
-
-msgid "Manually configurable filters"
-msgstr "Manuell konfigurierbare Filter"
-
-msgid "Both, predefined tags as well as configurable filters"
-msgstr "Sowohl vordefinierte Tags als auch konfigurierbare Filter"
-
 msgid "Title of text above event list"
 msgstr "Titel des Textes über der Veranstaltungs-Liste"
 
@@ -3014,6 +3000,24 @@ msgstr "Informationen unterhalb der Veranstaltungs-Liste"
 
 msgid "Text below the event list"
 msgstr "Text unterhalb der Veranstaltungs-Liste"
+
+msgid "Values of the location filter"
+msgstr "Werte des Ortfilters"
+
+msgid "Choose the filter type for events (default is 'Tags')"
+msgstr "Wählen Sie den Filtertyp für Veranstaltungen (Standard ist 'Tags')"
+
+msgid "A predefined set of tags"
+msgstr "Ein vordefiniertes Set von Tags"
+
+msgid "Manually configurable filters"
+msgstr "Manuell konfigurierbare Filter"
+
+msgid "Both, predefined tags as well as configurable filters"
+msgstr "Sowohl vordefinierte Tags als auch konfigurierbare Filter"
+
+msgid "Remove these filters from all affected events"
+msgstr "Diese(n) Filter bei allen betroffenen Veranstaltungen entfernen"
 
 msgid "Documents"
 msgstr "Dokumente"
@@ -3634,18 +3638,6 @@ msgstr "Textbaustein löschen"
 msgid "Recipients"
 msgstr "Empfänger"
 
-msgid "Room"
-msgstr "Raum"
-
-msgid "Resource Item"
-msgstr "Gegenstand"
-
-msgid "External resource link"
-msgstr "Externer Reservationslink"
-
-msgid "New external resource"
-msgstr "Neue externe Reservation"
-
 #.
 #. FIXME: Why are we using ResouceLayout and not ResourcesLayout? this is a
 #. weird hack, if you want to be able to use the ResourceLayout with
@@ -3657,6 +3649,18 @@ msgstr "Alle Exportieren"
 
 msgid "iFrame"
 msgstr "iFrame"
+
+msgid "Room"
+msgstr "Raum"
+
+msgid "Resource Item"
+msgstr "Gegenstand"
+
+msgid "External resource link"
+msgstr "Externer Reservationslink"
+
+msgid "New external resource"
+msgstr "Neue externe Reservation"
 
 msgid "Find Your Spot"
 msgstr "Terminsuche / Serienreservation"
@@ -3720,9 +3724,6 @@ msgstr "Es existieren Reservationen für diese Reservations-Ressource"
 #, python-format
 msgid "Every ${days} until ${end}"
 msgstr "Jeden ${days} bis zum ${end}."
-
-msgid "Configure"
-msgstr "Konfigurieren"
 
 msgid "This event can't be edited."
 msgstr "Diese Veranstaltung kann nicht bearbeitet werden."
@@ -3825,6 +3826,9 @@ msgstr "Fakturierte Belege als PDF exportieren"
 
 msgid "Directory"
 msgstr "Verzeichnis"
+
+msgid "Configure"
+msgstr "Konfigurieren"
 
 msgid "All entries will be deleted as well!"
 msgstr "Alle Einträge werden ebenfalls gelöscht!"
@@ -4522,8 +4526,8 @@ msgstr "Anzahl"
 msgid "VAT"
 msgstr "MwSt"
 
-#.
 #. credit card
+#.
 msgid "Payment"
 msgstr "Zahlung"
 
@@ -5386,8 +5390,8 @@ msgstr ""
 msgid "New customer message in Ticket ${link}"
 msgstr "Neue Kunden Nachricht in Ticket ${link}"
 
-#. Canonical text for ${link} is: "visit the request status page"
 #. Canonical text for ${link} is: "visit the request page"
+#. Canonical text for ${link} is: "visit the request status page"
 msgid "Please ${link} to reply."
 msgstr "Bitte ${link} um zu antworten"
 
@@ -6617,8 +6621,8 @@ msgid "Delete availability period"
 msgstr "Verfügbarkeitszeitraum löschen"
 
 #.
-#. type:ignore[attr-defined]  # trigger updates
 #. type:ignore[attr-defined]
+#. type:ignore[attr-defined]  # trigger updates
 msgid "Your changes were saved"
 msgstr "Ihre Änderungen wurden gespeichert"
 
@@ -7032,6 +7036,9 @@ msgstr "Neues Dokumentenformular"
 
 msgid "Edit Document Form"
 msgstr "Dokumentenformular bearbeiten"
+
+msgid "News Settings"
+msgstr "News Einstellungen"
 
 msgid ""
 "Notifications have already been sent for this news item. A new notification "
@@ -7450,20 +7457,6 @@ msgstr "Dieses Wochenende"
 
 msgid "This week"
 msgstr "Diese Woche"
-
-#, python-format
-msgid "The filter \"${keyword}\" is still applied to ${count} event(s)."
-msgstr ""
-"Der Filter \"${keyword}\" ist noch bei ${count} Veranstaltung(en) gesetzt."
-
-#, python-format
-msgid "The filter choice \"${choice}\" is still applied to ${count} event(s)."
-msgstr ""
-"Die Filterauswahl \"${choice}\" ist noch bei ${count} Veranstaltung(en) "
-"gesetzt."
-
-msgid "Edit Event Filter Configuration"
-msgstr "Filterkonfiguration für Veranstaltungen bearbeiten"
 
 msgid "Event Export"
 msgstr "Veranstaltungs-Export"
@@ -7992,6 +7985,17 @@ msgstr "Optionale Module"
 msgid "People directory"
 msgstr "Personenverzeichnis"
 
+#, python-format
+msgid "The filter \"${keyword}\" is still applied to ${count} event(s)."
+msgstr ""
+"Der Filter \"${keyword}\" ist noch bei ${count} Veranstaltung(en) gesetzt."
+
+#, python-format
+msgid "The filter choice \"${choice}\" is still applied to ${count} event(s)."
+msgstr ""
+"Die Filterauswahl \"${choice}\" ist noch bei ${count} Veranstaltung(en) "
+"gesetzt."
+
 msgid "Chat"
 msgstr "Chat"
 
@@ -8000,6 +8004,9 @@ msgstr "Feiertage / Schulferien"
 
 msgid "No holidays defined"
 msgstr "Keine Feiertage definiert"
+
+msgid "No short links defined"
+msgstr "Keine Kurzlinks definiert"
 
 msgid "Link Migration"
 msgstr "Migration Links"
@@ -8385,6 +8392,12 @@ msgstr "Der Benutzer wurde erfolgreich erstellt"
 
 msgid "Please enter your e-mail address in order to continue"
 msgstr "Bitte geben Sie ihre E-Mail Adresse ein um fortzufahren"
+
+#~ msgid "Confirmation"
+#~ msgstr "Bestätigung"
+
+#~ msgid "Edit Event Filter Configuration"
+#~ msgstr "Filterkonfiguration für Veranstaltungen bearbeiten"
 
 #~ msgid ""
 #~ "This entry is published and this directory has an admin notification "

--- a/src/onegov/org/locale/fr_CH/LC_MESSAGES/onegov.org.po
+++ b/src/onegov/org/locale/fr_CH/LC_MESSAGES/onegov.org.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE 1.0\n"
-"POT-Creation-Date: 2026-07-16 15:23+0200\n"
+"POT-Creation-Date: 2026-07-20 08:36+0200\n"
 "PO-Revision-Date: 2022-03-15 10:50+0100\n"
 "Last-Translator: Marc Sommerhalder <marc.sommerhalder@seantis.ch>\n"
 "Language-Team: French\n"
@@ -951,43 +951,50 @@ msgid "Elderly"
 msgstr "Âgées"
 
 #. FIXME: We define a very similar constant in our forms, we should move this
-#. to onegov.org.constants and use it for both. noqa: N806
+#. to onegov.org.constants and use it for both. ruff:ignore[non-lowercase-
+#. variable-in-function]
 #.
 msgid "Mo"
 msgstr "Lu"
 
 #. FIXME: We define a very similar constant in our forms, we should move this
-#. to onegov.org.constants and use it for both. noqa: N806
+#. to onegov.org.constants and use it for both. ruff:ignore[non-lowercase-
+#. variable-in-function]
 #.
 msgid "Tu"
 msgstr "Ma"
 
 #. FIXME: We define a very similar constant in our forms, we should move this
-#. to onegov.org.constants and use it for both. noqa: N806
+#. to onegov.org.constants and use it for both. ruff:ignore[non-lowercase-
+#. variable-in-function]
 #.
 msgid "We"
 msgstr "Me"
 
 #. FIXME: We define a very similar constant in our forms, we should move this
-#. to onegov.org.constants and use it for both. noqa: N806
+#. to onegov.org.constants and use it for both. ruff:ignore[non-lowercase-
+#. variable-in-function]
 #.
 msgid "Th"
 msgstr "Je"
 
 #. FIXME: We define a very similar constant in our forms, we should move this
-#. to onegov.org.constants and use it for both. noqa: N806
+#. to onegov.org.constants and use it for both. ruff:ignore[non-lowercase-
+#. variable-in-function]
 #.
 msgid "Fr"
 msgstr "Ve"
 
 #. FIXME: We define a very similar constant in our forms, we should move this
-#. to onegov.org.constants and use it for both. noqa: N806
+#. to onegov.org.constants and use it for both. ruff:ignore[non-lowercase-
+#. variable-in-function]
 #.
 msgid "Sa"
 msgstr "Sa"
 
 #. FIXME: We define a very similar constant in our forms, we should move this
-#. to onegov.org.constants and use it for both. noqa: N806
+#. to onegov.org.constants and use it for both. ruff:ignore[non-lowercase-
+#. variable-in-function]
 #.
 msgid "Su"
 msgstr "Di"
@@ -1119,12 +1126,6 @@ msgstr "Créé"
 
 msgid "Expected header line with the following columns:"
 msgstr "La première ligne doit avoir les noms de colonne suivants:"
-
-msgid "Remove these filters from all affected events"
-msgstr "Supprimer ces filtres de tous les événements concernés"
-
-msgid "Confirmation"
-msgstr "Confirmation"
 
 msgid "Comment"
 msgstr "Commentaire"
@@ -2340,6 +2341,9 @@ msgstr "Ouvrir les fichiers dans une fenêtre de navigateur séparée"
 msgid "Short links"
 msgstr "Lien court"
 
+msgid "Preview"
+msgstr "Preview"
+
 #, python-format
 msgid ""
 "Malformed short link on line ${number}. Each line needs to be a pair of "
@@ -2598,9 +2602,6 @@ msgstr "Zurich"
 
 msgid "Other holidays"
 msgstr "Autres jours fériés"
-
-msgid "Preview"
-msgstr "Preview"
 
 msgid "School holidays"
 msgstr "Vacances scolaires"
@@ -2985,23 +2986,6 @@ msgstr ""
 "Les événements sont automatiquement supprimés une fois qu'ils se sont "
 "produits"
 
-msgid "Values of the location filter"
-msgstr "Valeurs du filtre de localisation"
-
-msgid "Choose the filter type for events (default is 'Tags')"
-msgstr ""
-"Choisissez le type de filtre pour les événements (la valeur par défaut est "
-"'tags')"
-
-msgid "A predefined set of tags"
-msgstr "Un ensemble prédéfini de balises"
-
-msgid "Manually configurable filters"
-msgstr "Filtres configurables manuellement"
-
-msgid "Both, predefined tags as well as configurable filters"
-msgstr "Les deux, balises prédéfinies et filtres configurables"
-
 msgid "Title of text above event list"
 msgstr "Titre du texte au-dessus de la liste des événements"
 
@@ -3022,6 +3006,26 @@ msgstr "Information en dessous de la liste des événements"
 
 msgid "Text below the event list"
 msgstr "Texte en dessous de la liste des événements"
+
+msgid "Values of the location filter"
+msgstr "Valeurs du filtre de localisation"
+
+msgid "Choose the filter type for events (default is 'Tags')"
+msgstr ""
+"Choisissez le type de filtre pour les événements (la valeur par défaut est "
+"'tags')"
+
+msgid "A predefined set of tags"
+msgstr "Un ensemble prédéfini de balises"
+
+msgid "Manually configurable filters"
+msgstr "Filtres configurables manuellement"
+
+msgid "Both, predefined tags as well as configurable filters"
+msgstr "Les deux, balises prédéfinies et filtres configurables"
+
+msgid "Remove these filters from all affected events"
+msgstr "Supprimer ces filtres de tous les événements concernés"
 
 msgid "Documents"
 msgstr "Documents"
@@ -3646,18 +3650,6 @@ msgstr "Supprimer le module de texte"
 msgid "Recipients"
 msgstr "Destinataires"
 
-msgid "Room"
-msgstr "Espace"
-
-msgid "Resource Item"
-msgstr "Article"
-
-msgid "External resource link"
-msgstr "Lien de ressource externe"
-
-msgid "New external resource"
-msgstr "Nouvelle ressource externe"
-
 #.
 #. FIXME: Why are we using ResouceLayout and not ResourcesLayout? this is a
 #. weird hack, if you want to be able to use the ResourceLayout with
@@ -3669,6 +3661,18 @@ msgstr "Exporter tout"
 
 msgid "iFrame"
 msgstr "iFrame"
+
+msgid "Room"
+msgstr "Espace"
+
+msgid "Resource Item"
+msgstr "Article"
+
+msgid "External resource link"
+msgstr "Lien de ressource externe"
+
+msgid "New external resource"
+msgstr "Nouvelle ressource externe"
 
 msgid "Find Your Spot"
 msgstr "Rechercher les dates / Réservations récurrentes"
@@ -3731,9 +3735,6 @@ msgstr "Des réservations existantes sont associées à cette ressource"
 #, python-format
 msgid "Every ${days} until ${end}"
 msgstr "Tous les ${days} jusqu'à ${end}"
-
-msgid "Configure"
-msgstr "Configurer"
 
 msgid "This event can't be edited."
 msgstr "Cet événement ne peut pas être édité."
@@ -3834,6 +3835,9 @@ msgstr "Exporter l'exécution de la facture au format PDF"
 
 msgid "Directory"
 msgstr "Dossier"
+
+msgid "Configure"
+msgstr "Configurer"
 
 msgid "All entries will be deleted as well!"
 msgstr "Toutes les entrées seront également supprimées !"
@@ -4527,8 +4531,8 @@ msgstr "Quantité"
 msgid "VAT"
 msgstr "TVA"
 
-#.
 #. credit card
+#.
 msgid "Payment"
 msgstr "Paiement"
 
@@ -5391,8 +5395,8 @@ msgstr ""
 msgid "New customer message in Ticket ${link}"
 msgstr "Nouveau message du client dans le ticket ${link}"
 
-#. Canonical text for ${link} is: "visit the request status page"
 #. Canonical text for ${link} is: "visit the request page"
+#. Canonical text for ${link} is: "visit the request status page"
 msgid "Please ${link} to reply."
 msgstr "Veuillez vous rendre sur ${link} pour répondre."
 
@@ -6629,8 +6633,8 @@ msgid "Delete availability period"
 msgstr "Supprimer la période de disponibilité"
 
 #.
-#. type:ignore[attr-defined]  # trigger updates
 #. type:ignore[attr-defined]
+#. type:ignore[attr-defined]  # trigger updates
 msgid "Your changes were saved"
 msgstr "Vos modifications ont été enregistrées"
 
@@ -7044,6 +7048,9 @@ msgstr "Nouveau formulaire de document"
 
 msgid "Edit Document Form"
 msgstr "Modifier le formulaire de document"
+
+msgid "News Settings"
+msgstr "Paramètres des nouvelles"
 
 msgid ""
 "Notifications have already been sent for this news item. A new notification "
@@ -7461,18 +7468,6 @@ msgstr "Ce week-end"
 
 msgid "This week"
 msgstr "Cette semaine"
-
-#, python-format
-msgid "The filter \"${keyword}\" is still applied to ${count} event(s)."
-msgstr "Le filtre \"${keyword}\" est encore appliqué à ${count} événement(s)."
-
-#, python-format
-msgid "The filter choice \"${choice}\" is still applied to ${count} event(s)."
-msgstr ""
-"Le choix de filtre \"${choice}\" est encore appliqué à ${count} événement(s)."
-
-msgid "Edit Event Filter Configuration"
-msgstr "Modifier la configuration du filtre d'événements"
 
 msgid "Event Export"
 msgstr "Exporter un événement"
@@ -8000,6 +7995,15 @@ msgstr "Modules optionnels"
 msgid "People directory"
 msgstr "Annuaire des personnes"
 
+#, python-format
+msgid "The filter \"${keyword}\" is still applied to ${count} event(s)."
+msgstr "Le filtre \"${keyword}\" est encore appliqué à ${count} événement(s)."
+
+#, python-format
+msgid "The filter choice \"${choice}\" is still applied to ${count} event(s)."
+msgstr ""
+"Le choix de filtre \"${choice}\" est encore appliqué à ${count} événement(s)."
+
 msgid "Chat"
 msgstr "Discussion"
 
@@ -8008,6 +8012,9 @@ msgstr "Jours fériés / Vacances scolaires"
 
 msgid "No holidays defined"
 msgstr "Aucun jour férié défini"
+
+msgid "No short links defined"
+msgstr "Aucun lien court défini"
 
 msgid "Link Migration"
 msgstr "Migration des liens"
@@ -8393,6 +8400,12 @@ msgstr "L'utilisateur a bien été créé"
 
 msgid "Please enter your e-mail address in order to continue"
 msgstr "Veuillez saisir votre adresse e-mail pour continuer"
+
+#~ msgid "Confirmation"
+#~ msgstr "Confirmation"
+
+#~ msgid "Edit Event Filter Configuration"
+#~ msgstr "Modifier la configuration du filtre d'événements"
 
 #~ msgid ""
 #~ "This entry is published and this directory has an admin notification "

--- a/src/onegov/org/locale/it_CH/LC_MESSAGES/onegov.org.po
+++ b/src/onegov/org/locale/it_CH/LC_MESSAGES/onegov.org.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"POT-Creation-Date: 2026-07-16 15:23+0200\n"
+"POT-Creation-Date: 2026-07-20 08:36+0200\n"
 "PO-Revision-Date: 2022-03-15 10:52+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -951,43 +951,50 @@ msgid "Elderly"
 msgstr "Anziani"
 
 #. FIXME: We define a very similar constant in our forms, we should move this
-#. to onegov.org.constants and use it for both. noqa: N806
+#. to onegov.org.constants and use it for both. ruff:ignore[non-lowercase-
+#. variable-in-function]
 #.
 msgid "Mo"
 msgstr "Lu"
 
 #. FIXME: We define a very similar constant in our forms, we should move this
-#. to onegov.org.constants and use it for both. noqa: N806
+#. to onegov.org.constants and use it for both. ruff:ignore[non-lowercase-
+#. variable-in-function]
 #.
 msgid "Tu"
 msgstr "Ma"
 
 #. FIXME: We define a very similar constant in our forms, we should move this
-#. to onegov.org.constants and use it for both. noqa: N806
+#. to onegov.org.constants and use it for both. ruff:ignore[non-lowercase-
+#. variable-in-function]
 #.
 msgid "We"
 msgstr "Me"
 
 #. FIXME: We define a very similar constant in our forms, we should move this
-#. to onegov.org.constants and use it for both. noqa: N806
+#. to onegov.org.constants and use it for both. ruff:ignore[non-lowercase-
+#. variable-in-function]
 #.
 msgid "Th"
 msgstr "Gi"
 
 #. FIXME: We define a very similar constant in our forms, we should move this
-#. to onegov.org.constants and use it for both. noqa: N806
+#. to onegov.org.constants and use it for both. ruff:ignore[non-lowercase-
+#. variable-in-function]
 #.
 msgid "Fr"
 msgstr "Ve"
 
 #. FIXME: We define a very similar constant in our forms, we should move this
-#. to onegov.org.constants and use it for both. noqa: N806
+#. to onegov.org.constants and use it for both. ruff:ignore[non-lowercase-
+#. variable-in-function]
 #.
 msgid "Sa"
 msgstr "Sa"
 
 #. FIXME: We define a very similar constant in our forms, we should move this
-#. to onegov.org.constants and use it for both. noqa: N806
+#. to onegov.org.constants and use it for both. ruff:ignore[non-lowercase-
+#. variable-in-function]
 #.
 msgid "Su"
 msgstr "Do"
@@ -1119,12 +1126,6 @@ msgstr "Creato"
 
 msgid "Expected header line with the following columns:"
 msgstr "La prima riga deve avere i seguenti nomi di colonna:"
-
-msgid "Remove these filters from all affected events"
-msgstr "Rimuovi questi filtri da tutti gli eventi interessati"
-
-msgid "Confirmation"
-msgstr "Conferma"
 
 msgid "Comment"
 msgstr "Commento"
@@ -2341,6 +2342,9 @@ msgstr "Apri i file in una finestra separata"
 msgid "Short links"
 msgstr "Link abbreviato"
 
+msgid "Preview"
+msgstr "Anteprima"
+
 #, python-format
 msgid ""
 "Malformed short link on line ${number}. Each line needs to be a pair of "
@@ -2599,9 +2603,6 @@ msgstr "Zurigo"
 
 msgid "Other holidays"
 msgstr "Altre feste"
-
-msgid "Preview"
-msgstr "Anteprima"
 
 msgid "School holidays"
 msgstr "Vacanze scolastiche"
@@ -2987,23 +2988,6 @@ msgstr ""
 "Gli eventi vengono cancellati automaticamente una volta che si sono "
 "verificati"
 
-msgid "Values of the location filter"
-msgstr "Valori del filtro posizione"
-
-msgid "Choose the filter type for events (default is 'Tags')"
-msgstr ""
-"Scegliere il tipo di filtro per gli eventi (l'impostazione predefinita è "
-"'tag')"
-
-msgid "A predefined set of tags"
-msgstr "Un insieme predefinito di tag"
-
-msgid "Manually configurable filters"
-msgstr "Filtri configurabili manualmente"
-
-msgid "Both, predefined tags as well as configurable filters"
-msgstr "Entrambi, tag predefiniti e filtri configurabili"
-
 msgid "Title of text above event list"
 msgstr "Titolo del testo sopra l'elenco degli eventi"
 
@@ -3024,6 +3008,26 @@ msgstr "Informazioni sotto l'elenco degli eventi"
 
 msgid "Text below the event list"
 msgstr "Testo sotto l'elenco degli eventi"
+
+msgid "Values of the location filter"
+msgstr "Valori del filtro posizione"
+
+msgid "Choose the filter type for events (default is 'Tags')"
+msgstr ""
+"Scegliere il tipo di filtro per gli eventi (l'impostazione predefinita è "
+"'tag')"
+
+msgid "A predefined set of tags"
+msgstr "Un insieme predefinito di tag"
+
+msgid "Manually configurable filters"
+msgstr "Filtri configurabili manualmente"
+
+msgid "Both, predefined tags as well as configurable filters"
+msgstr "Entrambi, tag predefiniti e filtri configurabili"
+
+msgid "Remove these filters from all affected events"
+msgstr "Rimuovi questi filtri da tutti gli eventi interessati"
 
 msgid "Documents"
 msgstr "Documenti"
@@ -3638,18 +3642,6 @@ msgstr "Elimina modulo di testo"
 msgid "Recipients"
 msgstr "Destinatari"
 
-msgid "Room"
-msgstr "Camera"
-
-msgid "Resource Item"
-msgstr "Elemento risorsa"
-
-msgid "External resource link"
-msgstr "Link a risorse esterne"
-
-msgid "New external resource"
-msgstr "Nuova risorsa esterna"
-
 #.
 #. FIXME: Why are we using ResouceLayout and not ResourcesLayout? this is a
 #. weird hack, if you want to be able to use the ResourceLayout with
@@ -3661,6 +3653,18 @@ msgstr "Esporta tutte"
 
 msgid "iFrame"
 msgstr "iFrame"
+
+msgid "Room"
+msgstr "Camera"
+
+msgid "Resource Item"
+msgstr "Elemento risorsa"
+
+msgid "External resource link"
+msgstr "Link a risorse esterne"
+
+msgid "New external resource"
+msgstr "Nuova risorsa esterna"
 
 msgid "Find Your Spot"
 msgstr "Cerca le date / Prenotazioni ricorrenti"
@@ -3723,9 +3727,6 @@ msgstr "Sono presenti delle prenotazioni associate a questa risorsa"
 #, python-format
 msgid "Every ${days} until ${end}"
 msgstr "Ogni ${days} fino al ${end}"
-
-msgid "Configure"
-msgstr "Configura"
 
 msgid "This event can't be edited."
 msgstr "Questo evento non può essere modificato."
@@ -3826,6 +3827,9 @@ msgstr "Esporta l'esecuzione della fattura come PDF"
 
 msgid "Directory"
 msgstr "Cartella"
+
+msgid "Configure"
+msgstr "Configura"
 
 msgid "All entries will be deleted as well!"
 msgstr "Anche tutti gli elementi verranno eliminati!"
@@ -4516,8 +4520,8 @@ msgstr "Quantità"
 msgid "VAT"
 msgstr "IVA"
 
-#.
 #. credit card
+#.
 msgid "Payment"
 msgstr "Pagamento"
 
@@ -5369,8 +5373,8 @@ msgstr ""
 msgid "New customer message in Ticket ${link}"
 msgstr "Nuovo messaggio del cliente nel ticket ${link}"
 
-#. Canonical text for ${link} is: "visit the request status page"
 #. Canonical text for ${link} is: "visit the request page"
+#. Canonical text for ${link} is: "visit the request status page"
 msgid "Please ${link} to reply."
 msgstr "Per favore ${link} per rispondere."
 
@@ -6603,8 +6607,8 @@ msgid "Delete availability period"
 msgstr "Elimina il periodo di disponibilità"
 
 #.
-#. type:ignore[attr-defined]  # trigger updates
 #. type:ignore[attr-defined]
+#. type:ignore[attr-defined]  # trigger updates
 msgid "Your changes were saved"
 msgstr "Le modifiche sono state salvate"
 
@@ -7004,6 +7008,9 @@ msgstr "Nuovo modulo documento"
 
 msgid "Edit Document Form"
 msgstr "Modifica modulo documento"
+
+msgid "News Settings"
+msgstr "Impostazioni notizie"
 
 msgid ""
 "Notifications have already been sent for this news item. A new notification "
@@ -7424,18 +7431,6 @@ msgstr "Questo fine settimana"
 
 msgid "This week"
 msgstr "Questa settimana"
-
-#, python-format
-msgid "The filter \"${keyword}\" is still applied to ${count} event(s)."
-msgstr "Il filtro \"${keyword}\" è ancora applicato a ${count} evento/i."
-
-#, python-format
-msgid "The filter choice \"${choice}\" is still applied to ${count} event(s)."
-msgstr ""
-"La scelta del filtro \"${choice}\" è ancora applicata a ${count} evento/i."
-
-msgid "Edit Event Filter Configuration"
-msgstr "Modifica configurazione filtro eventi"
 
 msgid "Event Export"
 msgstr "Esportazione degli eventi"
@@ -7962,6 +7957,15 @@ msgstr "Moduli opzionali"
 msgid "People directory"
 msgstr "Elenco persone"
 
+#, python-format
+msgid "The filter \"${keyword}\" is still applied to ${count} event(s)."
+msgstr "Il filtro \"${keyword}\" è ancora applicato a ${count} evento/i."
+
+#, python-format
+msgid "The filter choice \"${choice}\" is still applied to ${count} event(s)."
+msgstr ""
+"La scelta del filtro \"${choice}\" è ancora applicata a ${count} evento/i."
+
 msgid "Chat"
 msgstr "Chat"
 
@@ -7970,6 +7974,9 @@ msgstr "Festività / Vacanze scolastiche"
 
 msgid "No holidays defined"
 msgstr "Nessuna festività definita"
+
+msgid "No short links defined"
+msgstr "Nessun link abbreviato definito"
 
 msgid "Link Migration"
 msgstr "Migrazione dei link"
@@ -8351,6 +8358,12 @@ msgstr "Utente creato correttamente"
 
 msgid "Please enter your e-mail address in order to continue"
 msgstr "Inserisci il tuo indirizzo e-mail per continuare"
+
+#~ msgid "Confirmation"
+#~ msgstr "Conferma"
+
+#~ msgid "Edit Event Filter Configuration"
+#~ msgstr "Modifica configurazione filtro eventi"
 
 #~ msgid ""
 #~ "This entry is published and this directory has an admin notification "

--- a/src/onegov/org/models/traitinfo.py
+++ b/src/onegov/org/models/traitinfo.py
@@ -83,6 +83,7 @@ class TraitInfo:
         # forward declare Page attributes we rely on
         title: Mapped[str]
         meta: Mapped[dict[str, Any]]
+        parent: Mapped[Page | None]
 
         @property
         def editable(self) -> bool: ...
@@ -181,10 +182,13 @@ class TraitInfo:
         """ Yields the edit links shown on the private view of this trait. """
 
         if self.editable:
+            is_news_root = self.trait == 'news' and self.parent is None
             yield Link(
-                _('Edit'),
+                _('Settings') if is_news_root else _('Edit'),
                 request.link(Editor('edit', self)),
-                classes=('edit-link', )
+                classes=(
+                    ('settings-link', ) if is_news_root else ('edit-link', )
+                )
             )
 
             assert request.path_info is not None

--- a/src/onegov/org/models/traitinfo.py
+++ b/src/onegov/org/models/traitinfo.py
@@ -259,8 +259,8 @@ class TraitInfo:
                     yes_button_text=trait_messages['delete_button'],
                     extra_information=extra_warning,
                     redirect_after=(
-                        request.link(self.parent)  # type:ignore[attr-defined]
-                        if self.parent is not None  # type:ignore[attr-defined]
+                        request.link(self.parent)
+                        if self.parent is not None
                         else request.class_link(Organisation)
                     ),
                     items=items,

--- a/src/onegov/org/templates/export.pt
+++ b/src/onegov/org/templates/export.pt
@@ -9,7 +9,7 @@
                     ${explanation}
                 </div>
                 <h3 i18n:translate="" tal:condition="count is not None|nothing">Entries in export: <tal:b i18n:name="count">${count}</tal:b></h3>
-                <div metal:use-macro="layout.macros['form']" />
+                <div metal:use-macro="layout.macros['form']" tal:define="form_id 'main-form'" />
             </div>
             <div class="columns small-12 medium-4">
                 <div class="filter-panel" tal:condition="filters|nothing">

--- a/src/onegov/org/theme/styles/org.scss
+++ b/src/onegov/org/theme/styles/org.scss
@@ -1696,7 +1696,7 @@ $cleanup-link-icon: '\f0d0';
 $copy-link-icon: '\f0c5';
 $delete-link-icon: '\f014';
 $disabled-icon: '\f05e';
-$edit-link-icon: '\f040';
+$edit-link-icon: '\f03a';
 $save-link-icon: '\f0c7';
 $cancel-link-icon: '\f00d';
 $export-link-icon: '\f019';

--- a/src/onegov/org/views/editor.py
+++ b/src/onegov/org/views/editor.py
@@ -181,6 +181,7 @@ def handle_edit_page(
     layout: EditorLayout | PageLayout | None = None
 ) -> RenderData | Response:
     assert self.page is not None
+    site_title: str
     if self.page.trait == 'news' and self.page.parent is None:
         site_title = _('News Settings')
     else:

--- a/src/onegov/org/views/editor.py
+++ b/src/onegov/org/views/editor.py
@@ -181,7 +181,10 @@ def handle_edit_page(
     layout: EditorLayout | PageLayout | None = None
 ) -> RenderData | Response:
     assert self.page is not None
-    site_title = self.page.trait_messages[self.trait]['edit_page_title']
+    if self.page.trait == 'news' and self.page.parent is None:
+        site_title = _('News Settings')
+    else:
+        site_title = self.page.trait_messages[self.trait]['edit_page_title']
 
     layout = layout or EditorLayout(self, request, site_title)
     layout.site_title = site_title  # type:ignore[union-attr]

--- a/src/onegov/org/views/occurrence.py
+++ b/src/onegov/org/views/occurrence.py
@@ -5,21 +5,13 @@ from datetime import date
 from markupsafe import Markup
 from morepath import redirect
 from morepath.request import Response
-from onegov.core.security import Public, Private, Secret
+from onegov.core.security import Public, Private
 from onegov.core.utils import linkify, normalize_for_url
 from onegov.event import Occurrence, OccurrenceCollection
-from onegov.event.models.event import EventFilterValue
-from onegov.form import as_internal_id
-from onegov.org.models.organisation import (
-    flatten_event_filter_fields_from_definition,
-)
-from onegov.form.errors import (InvalidFormSyntax, MixedTypeError,
-                                DuplicateLabelError)
 from onegov.org import _, OrgApp
 from onegov.org.elements import Link
 from onegov.core.elements import Link as CoreLink
 from onegov.org.forms import ExportForm, EventImportForm
-from onegov.org.forms.event import EventConfigurationForm
 from onegov.org.layout import OccurrenceLayout, OccurrencesLayout
 from onegov.org.views.utils import show_tags, show_filters
 from onegov.ticket import TicketCollection
@@ -224,151 +216,6 @@ def view_occurrence(
         'title': self.title,
         'show_tags': show_tags(request),
         'show_filters': show_filters(request),
-    }
-
-
-@OrgApp.form(model=OccurrenceCollection, name='edit',
-             template='directory_form.pt', permission=Secret,
-             form=EventConfigurationForm)
-def handle_edit_event_filters(
-    self: OccurrenceCollection,
-    request: OrgRequest,
-    form: EventConfigurationForm,
-    layout: OccurrencesLayout | None = None
-) -> RenderData | BaseResponse:
-
-    show_force_remove = False
-    try:
-        if form.submitted(request):
-            old_keywords = {
-                as_internal_id(k)
-                for k in
-                request.app.org.event_filter_configuration.get('keywords', [])
-            }
-            new_keywords = {
-                as_internal_id(k)
-                for k in (form.keyword_fields.data or '').splitlines()
-            }
-            old_field_choices = {
-                f.id: {c.label for c in getattr(f, 'choices', ())}
-                for f in request.app.org.event_filter_fields
-            }
-            new_field_choices = {
-                f.id: {c.label for c in getattr(f, 'choices', ())}
-                for f in flatten_event_filter_fields_from_definition(
-                    form.definition.data
-                )
-            }
-
-            removed_keywords = old_keywords - new_keywords
-            removed_choices: dict[str, set[str]] = {
-                keyword: (
-                    old_field_choices.get(keyword, set())
-                    - new_field_choices.get(keyword, set())
-                )
-                for keyword in old_keywords & new_keywords
-                if old_field_choices.get(keyword, set())
-                - new_field_choices.get(keyword, set())
-            }
-
-            if form.force_remove.data:
-                for keyword in removed_keywords:
-                    (
-                        request.session.query(EventFilterValue)
-                        .filter_by(keyword=keyword)
-                        .delete()
-                    )
-                for keyword, choices in removed_choices.items():
-                    for choice in choices:
-                        (
-                            request.session.query(EventFilterValue)
-                            .filter_by(keyword=keyword, value=choice)
-                            .delete()
-                        )
-            else:
-                blocked = False
-                for keyword in removed_keywords:
-                    count = (
-                        request.session.query(EventFilterValue)
-                        .filter_by(keyword=keyword)
-                        .count()
-                    )
-                    if count:
-                        request.alert(_(
-                            'The filter "${keyword}" is still applied to '
-                            '${count} event(s).',
-                            mapping={'keyword': keyword, 'count': count}
-                        ))
-                        blocked = True
-
-                for keyword, choices in removed_choices.items():
-                    for choice in choices:
-                        count = (
-                            request.session.query(EventFilterValue)
-                            .filter_by(keyword=keyword, value=choice)
-                            .count()
-                        )
-                        if count:
-                            request.alert(_(
-                                'The filter choice "${choice}" is still '
-                                'applied to ${count} event(s).',
-                                mapping={'choice': choice, 'count': count}
-                            ))
-                            blocked = True
-
-                if blocked:
-                    show_force_remove = True
-
-            if not show_force_remove:
-                keywords = (form.keyword_fields.data or '').splitlines()
-                request.app.org.event_filter_configuration = {
-                    'order': [],
-                    'keywords': keywords
-                }
-                request.app.org.event_filter_definition = form.definition.data
-
-                request.success(_('Your changes were saved'))
-                return request.redirect(request.link(self))
-
-        elif not request.POST:
-            # Store the model data on the form
-            form.definition.data = request.app.org.event_filter_definition
-            form.keyword_fields.data = '\r\n'.join(
-                request.app.org.event_filter_configuration.get('keywords', []))
-
-    except InvalidFormSyntax as e:
-        request.warning(
-            _('Syntax Error in line ${line}', mapping={'line': e.line})
-        )
-    except AttributeError:
-        request.warning(_('Syntax error in form'))
-
-    except MixedTypeError as e:
-        request.warning(
-            _('Syntax error in field ${field_name}',
-              mapping={'field_name': e.field_name})
-        )
-    except DuplicateLabelError as e:
-        request.warning(
-            _('Error: Duplicate label ${label}', mapping={'label': e.label})
-        )
-
-    if not show_force_remove:
-        form.delete_field('force_remove')
-
-    layout = layout or OccurrencesLayout(self, request)
-    layout.include_code_editor()
-    layout.breadcrumbs.append(Link(_('Edit'), '#'))
-    layout.editbar_links = []
-
-    return {
-        'layout': layout,
-        'title': _('Edit Event Filter Configuration'),
-        'form': form,
-        'form_width': 'large',
-        'migration': None,
-        'model': self,
-        'error': None,
     }
 
 

--- a/src/onegov/org/views/settings.py
+++ b/src/onegov/org/views/settings.py
@@ -10,7 +10,11 @@ from onegov.api.models import ApiKey
 from onegov.core.elements import Link, Confirm, Intercooler, BackLink
 from onegov.core.security import Secret
 from onegov.core.templates import render_macro
+from onegov.event.models.event import EventFilterValue
+from onegov.form import as_internal_id
 from onegov.form import Form
+from onegov.form.errors import (
+    DuplicateLabelError, InvalidFormSyntax, MixedTypeError)
 from onegov.org import _
 from onegov.org.app import OrgApp
 from onegov.org.forms import AnalyticsSettingsForm
@@ -33,6 +37,8 @@ from onegov.org.management import LinkHealthCheck
 from onegov.org.management import LinkMigration
 from onegov.org.models import Organisation
 from onegov.org.models import SwissHolidays
+from onegov.org.models.organisation import (
+    flatten_event_filter_fields_from_definition)
 from onegov.org.path import ShortLink
 from uuid import uuid4
 
@@ -409,7 +415,149 @@ def handle_event_settings(
     form: EventSettingsForm,
     layout: SettingsLayout | None = None
 ) -> RenderData | Response:
-    return handle_generic_settings(self, request, form, _('Events'), layout)
+
+    layout = layout or SettingsLayout(self, request, _('Events'))
+    layout.edit_mode = True
+    layout.editmode_links[1] = BackLink(attrs={'class': 'cancel-link'})
+    layout.include_code_editor()
+    request.include('fontpreview')
+
+    show_force_remove = False
+    try:
+        if form.submitted(request):
+            use_filters = form.event_filter_type.data in (
+                'filters', 'tags_and_filters')
+
+            if use_filters:
+                old_keywords = {
+                    as_internal_id(k)
+                    for k in self.event_filter_configuration.get(
+                        'keywords', [])
+                }
+                new_keywords = {
+                    as_internal_id(k)
+                    for k in (form.keyword_fields.data or '').splitlines()
+                }
+                old_field_choices = {
+                    f.id: {c.label for c in getattr(f, 'choices', ())}
+                    for f in self.event_filter_fields
+                }
+                new_field_choices = {
+                    f.id: {c.label for c in getattr(f, 'choices', ())}
+                    for f in flatten_event_filter_fields_from_definition(
+                        form.event_filter_definition.data
+                    )
+                }
+
+                removed_keywords = old_keywords - new_keywords
+                removed_choices: dict[str, set[str]] = {
+                    keyword: (
+                        old_field_choices.get(keyword, set())
+                        - new_field_choices.get(keyword, set())
+                    )
+                    for keyword in old_keywords & new_keywords
+                    if old_field_choices.get(keyword, set())
+                    - new_field_choices.get(keyword, set())
+                }
+
+                if form.force_remove.data:
+                    for keyword in removed_keywords:
+                        (
+                            request.session.query(EventFilterValue)
+                            .filter_by(keyword=keyword)
+                            .delete()
+                        )
+                    for keyword, choices in removed_choices.items():
+                        for choice in choices:
+                            (
+                                request.session.query(EventFilterValue)
+                                .filter_by(keyword=keyword, value=choice)
+                                .delete()
+                            )
+                else:
+                    blocked = False
+                    for keyword in removed_keywords:
+                        count = (
+                            request.session.query(EventFilterValue)
+                            .filter_by(keyword=keyword)
+                            .count()
+                        )
+                        if count:
+                            request.alert(_(
+                                'The filter "${keyword}" is still applied to '
+                                '${count} event(s).',
+                                mapping={'keyword': keyword, 'count': count}
+                            ))
+                            blocked = True
+
+                    for keyword, choices in removed_choices.items():
+                        for choice in choices:
+                            count = (
+                                request.session.query(EventFilterValue)
+                                .filter_by(keyword=keyword, value=choice)
+                                .count()
+                            )
+                            if count:
+                                request.alert(_(
+                                    'The filter choice "${choice}" is still '
+                                    'applied to ${count} event(s).',
+                                    mapping={'choice': choice, 'count': count}
+                                ))
+                                blocked = True
+
+                    if blocked:
+                        show_force_remove = True
+
+            if not show_force_remove:
+                # populate the regular settings; the filter fields are
+                # persisted explicitly below (keyword_fields maps into a dict
+                # and we must not touch the stored filters when disabled)
+                form.populate_obj(self, exclude={
+                    'event_filter_definition', 'keyword_fields', 'force_remove'
+                })
+
+                if use_filters:
+                    keywords = (form.keyword_fields.data or '').splitlines()
+                    self.event_filter_definition = (
+                        form.event_filter_definition.data)
+                    self.event_filter_configuration = {
+                        'order': [],
+                        'keywords': keywords
+                    }
+
+                request.success(_('Your changes were saved'))
+                return request.redirect(request.link(self, name='settings'))
+
+        elif request.method == 'GET':
+            form.process(obj=self)
+            form.keyword_fields.data = '\r\n'.join(
+                self.event_filter_configuration.get('keywords', []))
+
+    except InvalidFormSyntax as e:
+        request.warning(
+            _('Syntax Error in line ${line}', mapping={'line': e.line})
+        )
+    except AttributeError:
+        request.warning(_('Syntax error in form'))
+    except MixedTypeError as e:
+        request.warning(
+            _('Syntax error in field ${field_name}',
+              mapping={'field_name': e.field_name})
+        )
+    except DuplicateLabelError as e:
+        request.warning(
+            _('Error: Duplicate label ${label}', mapping={'label': e.label})
+        )
+
+    if not show_force_remove:
+        form.delete_field('force_remove')
+
+    return {
+        'layout': layout,
+        'title': _('Events'),
+        'form': form,
+        'form_width': 'large',
+    }
 
 
 @OrgApp.form(

--- a/src/onegov/shared/assets/js/form_dependencies.js
+++ b/src/onegov/shared/assets/js/form_dependencies.js
@@ -105,7 +105,11 @@ var evaluate_dependencies = function(form, input, dependencies) {
         }
 
         input.closest('label, .group-label').show().siblings('.error').toggle(true);
-        input.toggle(true);
+
+        // keep enhancement-hidden inputs (code editor, formcode select) hidden
+        if (!always_hidden) {
+            input.toggle(true);
+        }
     } else {
         input.toggle(false);
         if (hide_label) {

--- a/src/onegov/town6/templates/export.pt
+++ b/src/onegov/town6/templates/export.pt
@@ -11,7 +11,7 @@
             <div class="callout panel" tal:condition="has_note|nothing">
                 <p tal:content="note_html"></p>
             </div>
-            <div metal:use-macro="layout.macros['form']" />
+            <div metal:use-macro="layout.macros['form']" tal:define="form_id 'main-form'" />
             </div>
             <div class="small-12 medium-4 cell">
                 <div class="filter-panel" tal:condition="filters|nothing">

--- a/src/onegov/town6/theme/styles/header.scss
+++ b/src/onegov/town6/theme/styles/header.scss
@@ -12,7 +12,7 @@ $cleanup-link-icon: '\f0d0';
 $copy-link-icon: '\f0c5';
 $delete-link-icon: '\f2ed';
 $disabled-icon: '\f05e';
-$edit-link-icon: '\f044';
+$edit-link-icon: '\f03a';
 $save-link-icon: '\f0c7';
 $cancel-link-icon: '\f00d';
 $export-link-icon: '\f019';
@@ -551,7 +551,7 @@ $editbar-fg-color-active: $white;
     .cleanup-link::before { @include icon-bold($cleanup-link-icon); }
     .copy-link::before { @include icon($copy-link-icon); }
     .delete-link::before { @include icon($delete-link-icon); }
-    .edit-link::before { @include icon($edit-link-icon); }
+    .edit-link::before { @include icon_bold($edit-link-icon); }
     .save-link::before { @include icon($save-link-icon); }
     .cancel-link::before { @include icon-bold($cancel-link-icon); }
     .move-link::before { @include icon-bold($move-link-icon); }

--- a/src/onegov/town6/views/occurrence.py
+++ b/src/onegov/town6/views/occurrence.py
@@ -1,14 +1,13 @@
 """ The onegov org collection of images uploaded to the site. """
 from __future__ import annotations
 
-from onegov.core.security import Public, Private, Secret
+from onegov.core.security import Public, Private
 
 from onegov.event import Occurrence, OccurrenceCollection
-from onegov.org.forms.event import EventConfigurationForm
 from onegov.town6.layout import OccurrenceLayout
 from onegov.org.views.occurrence import (
     view_occurrences, view_occurrence, export_occurrences,
-    import_occurrences, handle_edit_event_filters)
+    import_occurrences)
 from onegov.town6 import TownApp
 from onegov.org.forms import ExportForm, EventImportForm
 from onegov.town6.layout import OccurrencesLayout
@@ -41,22 +40,6 @@ def town_view_occurrence(
     layout = OccurrenceLayout(self, request)
     request.include('monthly-view')
     return view_occurrence(self, request, layout)
-
-
-@TownApp.form(
-    model=OccurrenceCollection,
-    name='edit',
-    template='directory_form.pt',
-    permission=Secret,
-    form=EventConfigurationForm
-)
-def town_handle_edit_event_filters(
-    self: OccurrenceCollection,
-    request: TownRequest,
-    form: EventConfigurationForm
-) -> RenderData | Response:
-    layout = OccurrencesLayout(self, request)
-    return handle_edit_event_filters(self, request, form, layout)
 
 
 @TownApp.form(

--- a/tests/onegov/org/test_api.py
+++ b/tests/onegov/org/test_api.py
@@ -90,12 +90,8 @@ def test_view_api(
     # Configure event filters
     settings = client.get('/event-settings')
     settings.form['event_filter_type'] = 'filters'
-    settings.form.submit().follow()
-
-    events_page = client.get('/events')
-    filter_settings = events_page.click('Konfigurieren')
-    filter_settings.form[
-        'definition'
+    settings.form[
+        'event_filter_definition'
     ] = """
         Altersgruppe =
             [ ] Kind
@@ -106,8 +102,8 @@ def test_view_api(
         Empfehlung =
             [ ] Ja
     """
-    filter_settings.form['keyword_fields'].value = 'Altersgruppe\nEmpfehlung'
-    filter_settings.form.submit().follow()
+    settings.form['keyword_fields'].value = 'Altersgruppe\nEmpfehlung'
+    settings.form.submit().follow()
 
     endpoints = collection('/api')
     event_fiters = filters(endpoints.queries[0])

--- a/tests/onegov/org/test_views_event.py
+++ b/tests/onegov/org/test_views_event.py
@@ -769,6 +769,13 @@ def test_import_export_events(client: Client) -> None:
 
     client.login_editor()
 
+    # settings are admin-only, the rest of the edit bar is not
+    events = client.get('/events')
+    assert not events.pyquery('.edit-bar a.edit-link')
+    assert events.pyquery('.edit-bar a.export-link')
+    assert client.get(
+        '/event-settings', expect_errors=True).status_code == 403
+
     # Export
     page = client.get('/events').click('Export')
     page.form['file_format'] = 'xlsx'
@@ -977,9 +984,16 @@ def test_export_events_json_xml_csv(client: Client) -> None:
 def test_event_filter_settings_stale_data(client: Client) -> None:
     client.login_admin()
 
-    settings = client.get('/event-settings')
+    # the edit bar link returns here after saving
+    events = client.get('/events')
+    settings_link = events.pyquery('.edit-bar a.edit-link').attr('href')
+    assert settings_link is not None
+    assert 'return-to=' in settings_link
+
+    settings = client.get(settings_link)
     settings.form['event_filter_type'] = 'filters'
-    settings.form.submit()
+    saved = settings.form.submit()
+    assert saved.headers['Location'].endswith('/events')
 
     # Set up a filter with two choices
     page = client.get('/event-settings')

--- a/tests/onegov/org/test_views_event.py
+++ b/tests/onegov/org/test_views_event.py
@@ -203,9 +203,8 @@ def test_view_occurrences_event_filter(client: Client) -> None:
         assert client.login_admin()
         assert client.app.org.event_filter_type in ['filters',
                                                     'tags_and_filters']
-        page = client.get('/events')
-        page = page.click('Konfigurieren')
-        page.form['definition'] = """
+        page = client.get('/event-settings')
+        page.form['event_filter_definition'] = """
             My Special Filter *=
                 [ ] A Filter
                 [ ] B Filter
@@ -283,10 +282,7 @@ def test_many_filters(client: Client) -> None:
     assert client.login_admin()
     page = client.get('/event-settings')
     page.form['event_filter_type'] = 'filters'
-    page.form.submit()
-    page = client.get('/events')
-    page = page.click('Konfigurieren')
-    page.form['definition'] = """
+    page.form['event_filter_definition'] = """
         Weitere Filter =
             [ ] Gemeinde
             [ ] Schule
@@ -986,9 +982,9 @@ def test_event_filter_settings_stale_data(client: Client) -> None:
     settings.form.submit()
 
     # Set up a filter with two choices
-    page = client.get('/events').click('Konfigurieren')
+    page = client.get('/event-settings')
     assert 'force_remove' not in page.form.fields  # not shown on initial load
-    page.form['definition'] = """
+    page.form['event_filter_definition'] = """
         My Filter =
             [ ] Choice A
             [ ] Choice B
@@ -1004,9 +1000,9 @@ def test_event_filter_settings_stale_data(client: Client) -> None:
     page.form.submit()
 
     # Removing Choice A (in use) is blocked — force_remove checkbox appears
-    page = client.get('/events').click('Konfigurieren')
+    page = client.get('/event-settings')
     assert 'force_remove' not in page.form.fields
-    page.form['definition'] = """
+    page.form['event_filter_definition'] = """
         My Filter =
             [ ] Choice B
     """
@@ -1030,8 +1026,8 @@ def test_event_filter_settings_stale_data(client: Client) -> None:
     assert not page.form['my_filter'].value
 
     # Re-setup: re-add Choice A, re-apply to event
-    page = client.get('/events').click('Konfigurieren')
-    page.form['definition'] = """
+    page = client.get('/event-settings')
+    page.form['event_filter_definition'] = """
         My Filter =
             [ ] Choice A
             [ ] Choice B
@@ -1047,8 +1043,8 @@ def test_event_filter_settings_stale_data(client: Client) -> None:
     page.form.submit()
 
     # Block again — manually clearing the event also allows removing the choice
-    page = client.get('/events').click('Konfigurieren')
-    page.form['definition'] = """
+    page = client.get('/event-settings')
+    page.form['event_filter_definition'] = """
         My Filter =
             [ ] Choice B
     """
@@ -1062,8 +1058,8 @@ def test_event_filter_settings_stale_data(client: Client) -> None:
     page.form['my_filter'] = []
     page.form.submit()
 
-    page = client.get('/events').click('Konfigurieren')
-    page.form['definition'] = """
+    page = client.get('/event-settings')
+    page.form['event_filter_definition'] = """
         My Filter =
             [ ] Choice B
     """
@@ -1072,9 +1068,9 @@ def test_event_filter_settings_stale_data(client: Client) -> None:
     assert 'Choice A' not in (client.app.org.event_filter_definition or '')
 
     # Removing an unused choice (Choice B) is allowed without blocking
-    page = client.get('/events').click('Konfigurieren')
+    page = client.get('/event-settings')
     assert 'force_remove' not in page.form.fields
-    page.form['definition'] = """
+    page.form['event_filter_definition'] = """
         My Filter =
             [ ] Choice A
     """
@@ -1091,8 +1087,8 @@ def test_event_filter_settings_stale_data(client: Client) -> None:
 
     # Deselecting the whole keyword while events use it is blocked,
     # checkbox appears
-    page = client.get('/events').click('Konfigurieren')
-    page.form['definition'] = """
+    page = client.get('/event-settings')
+    page.form['event_filter_definition'] = """
         My Filter =
             [ ] Choice A
     """
@@ -1111,8 +1107,8 @@ def test_event_filter_settings_stale_data(client: Client) -> None:
     assert not client.app.org.event_filter_configuration.get('keywords')
 
     # Re-setup: re-enable keyword and re-apply filter to event
-    page = client.get('/events').click('Konfigurieren')
-    page.form['definition'] = """
+    page = client.get('/event-settings')
+    page.form['event_filter_definition'] = """
         My Filter =
             [ ] Choice A
     """
@@ -1125,8 +1121,8 @@ def test_event_filter_settings_stale_data(client: Client) -> None:
     page.form['my_filter'] = ['Choice A']
     page.form.submit()
 
-    page = client.get('/events').click('Konfigurieren')
-    page.form['definition'] = """
+    page = client.get('/event-settings')
+    page.form['event_filter_definition'] = """
         My Filter =
             [ ] Choice A
     """
@@ -1141,8 +1137,8 @@ def test_event_filter_settings_stale_data(client: Client) -> None:
     page.form['my_filter'] = []
     page.form.submit()
 
-    page = client.get('/events').click('Konfigurieren')
-    page.form['definition'] = """
+    page = client.get('/event-settings')
+    page.form['event_filter_definition'] = """
         My Filter =
             [ ] Choice A
     """

--- a/tests/onegov/org/test_views_event.py
+++ b/tests/onegov/org/test_views_event.py
@@ -770,9 +770,9 @@ def test_import_export_events(client: Client) -> None:
     client.login_editor()
 
     # settings are admin-only, the rest of the edit bar is not
-    events = client.get('/events')
-    assert not events.pyquery('.edit-bar a.edit-link')
-    assert events.pyquery('.edit-bar a.export-link')
+    events_page = client.get('/events')
+    assert not events_page.pyquery('.edit-bar a.edit-link')
+    assert events_page.pyquery('.edit-bar a.export-link')
     assert client.get(
         '/event-settings', expect_errors=True).status_code == 403
 

--- a/tests/onegov/org/test_views_forms.py
+++ b/tests/onegov/org/test_views_forms.py
@@ -1409,8 +1409,9 @@ def test_event_configuration_validation(client: Client) -> None:
 
     client.login_admin()
 
-    page = client.get('/events/+edit')
-    page.form['definition'] = """
+    page = client.get('/event-settings')
+    page.form['event_filter_type'] = 'filters'
+    page.form['event_filter_definition'] = """
     Kalender *=
         ( ) Sport Veranstaltungskalender
         ( ) Agenda Verkehrsgarten
@@ -1424,8 +1425,9 @@ def test_event_configuration_validation(client: Client) -> None:
     assert 'Invalid field type for field \'Email Adresse\'.' in page
 
     # test multiple errors
-    page = client.get('/events/+edit')
-    page.form['definition'] = """
+    page = client.get('/event-settings')
+    page.form['event_filter_type'] = 'filters'
+    page.form['event_filter_definition'] = """
     Kalender *=
         ( ) Sport Veranstaltungskalender
         ( ) Agenda Verkehrsgarten

--- a/tests/onegov/org/test_views_news.py
+++ b/tests/onegov/org/test_views_news.py
@@ -26,11 +26,11 @@ def test_news(client: Client) -> None:
     # Top page with path /news is fix, and all others are children
     links = edit_bar_links(page, 'text')
     assert 'URL ändern' not in links
-    # 5 links: Edit, Copy, iFrame, Closing link for the Iframe Modal,
+    # 5 links: Settings, Copy, iFrame, Closing link for the Iframe Modal,
     # Add News Entry
     assert len(links) == 5
 
-    edit = page.click('Bearbeiten')
+    edit = page.click('Einstellungen', href='editor/edit')
     edit.form['contact'] = 'We could show this address on the root news page'
     edit.form['access'] = 'private'
     edit.form.submit().follow()

--- a/tests/onegov/org/test_views_newsletter.py
+++ b/tests/onegov/org/test_views_newsletter.py
@@ -345,6 +345,12 @@ def test_newsletter_subscribers_and_edit_bar(client: Client) -> None:
         assert page.pyquery('a.manage-subscribers')
         assert page.pyquery('a.new-newsletter')
 
+    # settings are admin-only, so editors get no link
+    assert admin.get('/newsletters').pyquery('a.settings-link')
+    assert not editor.get('/newsletters').pyquery('a.settings-link')
+    assert editor.get(
+        '/newsletter-settings', expect_errors=True).status_code == 403
+
     member = client.spawn()
     member.login_member()
     anom = client.spawn()
@@ -356,6 +362,15 @@ def test_newsletter_subscribers_and_edit_bar(client: Client) -> None:
         assert 'Abonnenten' not in page
         assert not page.pyquery('a.manage-subscribers')
         assert not page.pyquery('a.new-newsletter')
+        assert not page.pyquery('a.settings-link')
+
+    # the edit bar link returns here after saving
+    page = admin.get('/newsletters')
+    settings_link = page.pyquery('a.settings-link').attr('href')
+    assert 'return-to=' in settings_link
+
+    saved = admin.get(settings_link).form.submit()
+    assert saved.headers['Location'].endswith('/newsletters')
 
 
 def test_newsletter_subscribers_management(client: Client) -> None:

--- a/tests/onegov/org/test_views_people.py
+++ b/tests/onegov/org/test_views_people.py
@@ -16,7 +16,14 @@ if TYPE_CHECKING:
 
 def test_people_view(client: Client) -> None:
     client.login_admin()
-    settings = client.get('/people-settings')
+
+    # the edit bar link returns here after saving
+    people = client.get('/people')
+    settings_link = people.pyquery('.edit-bar a.settings-link').attr('href')
+    assert settings_link is not None
+    assert 'return-to=' in settings_link
+
+    settings = client.get(settings_link)
     settings.form['hidden_people_fields'] = ['academic_title', 'profession']
     settings.form['organisation_hierarchy'] = """
     - Organisation 1:
@@ -36,13 +43,19 @@ def test_people_view(client: Client) -> None:
       - Sub-Organisation 2.1
       - Sub-Organisation 2.2
     """
-    settings.form.submit()
+    saved = settings.form.submit()
+    assert saved.headers['Location'].endswith('/people')
     client.logout()
 
     client.login_editor()
 
     people = client.get('/people')
     assert people.status_int == 200
+
+    # settings are admin-only, so editors get no link
+    assert not people.pyquery('a.settings-link')
+    assert client.get(
+        '/people-settings', expect_errors=True).status_code == 403
 
     new_person = people.click('Person', index=1)
     new_person.form['academic_title'] = 'Dr.'


### PR DESCRIPTION
Org: Improve edit bar for several views

TYPE: Feature
LINK: None

Changed:
- directories: switch icon
- resources: Add menu to the far right
- newsletters: Settings to the left, change order to: Edit, Send, Test, Copy, Delete
- photoalbums: Edit far left
- events: Merge config filter and settings form
- news: Settings for root news, else keep Edit; adjust title

back / cancel using url param instead of browser history back in separate pr: https://github.com/OneGov/onegov-cloud/pull/2591