### PR TITLE
Bugfix/agency converter for browse query param

### DIFF
--- a/src/onegov/agency/collections/agencies.py
+++ b/src/onegov/agency/collections/agencies.py
@@ -36,10 +36,8 @@ class ExtendedAgencyCollection(AdjacencyListCollection[ExtendedAgency]):
     def __init__(
         self,
         session: Session,
-        # FIXME: These really should be float/int, we just need to add
-        #        convertes to the path configuration...
         root_pdf_modified: str | None = None,
-        browse: str | None = None
+        browse: int | None = None
     ) -> None:
         super().__init__(session)
         self.root_pdf_modified = root_pdf_modified

--- a/src/onegov/agency/layout.py
+++ b/src/onegov/agency/layout.py
@@ -128,7 +128,7 @@ class NavTreeMixin:
             isinstance(self.model, ExtendedAgencyCollection)
             and self.model.browse
         ):
-            return self.model.by_id(self.model.browse)  # type:ignore[arg-type]
+            return self.model.by_id(self.model.browse)
         return None
 
     @cached_property

--- a/src/onegov/agency/path.py
+++ b/src/onegov/agency/path.py
@@ -44,11 +44,12 @@ def get_people(
 @AgencyApp.path(
     model=ExtendedAgencyCollection,
     path='/organizations',
+    converters={'browse': int}
 )
 def get_agencies(
     app: AgencyApp,
     root_pdf_modified: str | None = None,
-    browse: str | None = None
+    browse: int | None = None
 ) -> ExtendedAgencyCollection:
     return ExtendedAgencyCollection(app.session(), root_pdf_modified, browse)
 

--- a/src/onegov/agency/views/agencies.py
+++ b/src/onegov/agency/views/agencies.py
@@ -259,7 +259,7 @@ def view_agency_as_nav_item(
         response.headers.add(
             'X-IC-PushURL',
             request.class_link(
-                ExtendedAgencyCollection, {'browse': str(self.id)})
+                ExtendedAgencyCollection, {'browse': self.id})
         )
 
     return render_macro(

--- a/tests/onegov/agency/test_views.py
+++ b/tests/onegov/agency/test_views.py
@@ -966,9 +966,25 @@ def test_view_agencies_browse(client: Client[AgencyApp]) -> None:
     manage.form['title'] = 'Nationalrat'
     manage.form.submit()
 
+    manage = bund.click('Organisation', href='new')
+    manage.form['title'] = 'Bundesrat'
+    manage.form['access'] = 'private'
+    manage.form.submit()
+
+    manage = client.get('/organizations').click('Organisation', href='new')
+    manage.form['title'] = 'Kantonsbehörden'
+    kanton = manage.form.submit().follow()
+
+    manage = kanton.click('Organisation', href='new')
+    manage.form['title'] = 'Regierungsrat'
+    manage.form.submit()
+
     session = client.app.session()
     nationalrat = session.query(ExtendedAgency).filter_by(
         title='Nationalrat'
+    ).one()
+    bundesrat = session.query(ExtendedAgency).filter_by(
+        title='Bundesrat'
     ).one()
 
     anonymous = client.spawn()
@@ -979,4 +995,23 @@ def test_view_agencies_browse(client: Client[AgencyApp]) -> None:
     page = anonymous.get(f'/organizations?browse={nationalrat.id}')
     assert 'Nationalrat' in page
 
+    # unrelated branches remain collapsed
+    assert 'Regierungsrat' not in page
+
     anonymous.get('/organizations?browse=bogus', status=400)
+    anonymous.get('/organizations?browse=1&browse=2', status=400)
+    anonymous.get('/organizations?browse=', status=400)
+
+    # remain on main page for invalid id
+    page = anonymous.get('/organizations?browse=999999')
+    assert page.status_code == 200
+    assert 'Bundesbehörden' in page
+    assert 'Nationalrat' not in page
+
+    # browsing a private agency does not reveal it to anonymous users
+    page = anonymous.get(f'/organizations?browse={bundesrat.id}')
+    assert 'Bundesbehörden' in page
+    assert 'Bundesrat' not in page
+
+    page = client.get(f'/organizations?browse={bundesrat.id}')
+    assert 'Bundesrat' in page

--- a/tests/onegov/agency/test_views.py
+++ b/tests/onegov/agency/test_views.py
@@ -953,3 +953,30 @@ def test_agency_map(client: Client[AgencyApp]) -> None:
 
     page = client.get('/organization/finanzkontrolle')
     assert 'marker-map' in page
+
+
+def test_view_agencies_browse(client: Client[AgencyApp]) -> None:
+    client.login_admin()
+
+    manage = client.get('/organizations').click('Organisation', href='new')
+    manage.form['title'] = 'Bundesbehörden'
+    bund = manage.form.submit().follow()
+
+    manage = bund.click('Organisation', href='new')
+    manage.form['title'] = 'Nationalrat'
+    manage.form.submit()
+
+    session = client.app.session()
+    nationalrat = session.query(ExtendedAgency).filter_by(
+        title='Nationalrat'
+    ).one()
+
+    anonymous = client.spawn()
+
+    # the children are loaded lazily, so they are not part of the response
+    assert 'Nationalrat' not in anonymous.get('/organizations')
+
+    page = anonymous.get(f'/organizations?browse={nationalrat.id}')
+    assert 'Nationalrat' in page
+
+    anonymous.get('/organizations?browse=bogus', status=400)


### PR DESCRIPTION
Agency: Adds converter for query parameter browse

The converter became necessary after upgrading to `psycopg` 3 with stricter typing

TYPE: Bugfix
LINK: https://seantis-gmbh.sentry.io/issues/7624203551
