### PR TITLE
Pin cssselect as pyquery does not yet support cssselect 1.5

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -237,6 +237,9 @@ test =
     aiosmtpd
     collection-json
     coverage
+    # cssselect 1.5 dropped XPathExpr.join(closing_combiner=...) which
+    # pyquery 2.0.1 still calls; remove once pyquery supports cssselect 1.5
+    cssselect<1.5
     faker
     findimports
     freezegun


### PR DESCRIPTION
Core: Pin `cssselect` as `pyquery` does not yet support the latest version 1.5.0 [skip-ci]

TYPE: Bugfix
LINK: None
