### PR TITLE
Org: Restore Redactor selection in Safari

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,9 +41,7 @@ repos:
     hooks:
     - id: eslint
       files: '^src/.*\.jsx?$'
-      exclude: '^src/onegov/org/assets/js/redactor\.js$'
       additional_dependencies:
-      - eslint@8.57.0
       - eslint-plugin-react
   - repo: https://github.com/PyCQA/bandit
     rev: 1.9.4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,7 +41,9 @@ repos:
     hooks:
     - id: eslint
       files: '^src/.*\.jsx?$'
+      exclude: '^src/onegov/org/assets/js/redactor\.js$'
       additional_dependencies:
+      - eslint@8.57.0
       - eslint-plugin-react
   - repo: https://github.com/PyCQA/bandit
     rev: 1.9.4

--- a/src/onegov/org/assets/js/redactor.js
+++ b/src/onegov/org/assets/js/redactor.js
@@ -7741,11 +7741,12 @@
 						var node2 = this.selection.getMarker(2);
 						this.selection.setMarker(this.range, node2, false);
 
-						// Fix for Chrome58 Issues
-						if (this.utils.browser('chrome')) {
+						// Blink and WebKit need the active range restored after the
+						// marker nodes have been inserted. Otherwise execCommand below
+						// receives a collapsed selection.
+						if (this.utils.browser('chrome') || this.utils.browser('safari')) {
 							this.caret.set(node1, 0, node2, 0);
 						}
-						// End Chrome58 Issues
 					}
 
 					this.savedSel = this.$editor.html();


### PR DESCRIPTION
Ensure the active range is restored after marker insertion for both Blink and WebKit browsers.

TYPE: Bugfix
LINK: OGC-3363

Please fill in the commit message below and work through the checklist. You can delete parts that are not needed, e.g. the optional description, the link to a ticket or irrelevant options of the checklist.

## Commit message

Org: Restore Redactor selection in Safari

TYPE: Bugfix
LINK: OGC-3363