### PR TITLE
Pdf: Guard against emtpy html after cleaning in mini_html

### DIFF
--- a/src/onegov/pdf/pdf.py
+++ b/src/onegov/pdf/pdf.py
@@ -624,6 +624,9 @@ class Pdf(PDFDocument):
         html = cleaner.clean(html)
         # Todo: phone numbers with href="tel:.." are cleaned out
 
+        if not html.strip():
+            return
+
         tree = etree.parse(StringIO(html), etree.HTMLParser())
         body = tree.find('body')
         if body is None:

--- a/tests/onegov/pdf/test_pdf.py
+++ b/tests/onegov/pdf/test_pdf.py
@@ -482,6 +482,24 @@ def test_pdf_mini_html() -> None:
     )
 
 
+def test_pdf_mini_html_cleaned_empty() -> None:
+    # input built only from tags not allowed by mini_html reduces to
+    # empty/whitespace after cleaning and used to raise
+    # "ElementTree not initialized, missing root"
+    for html in (
+        '<h3></h3>',
+        '<div>   </div>',
+        '<img src=x>',
+        '<span></span>',
+        '   ',
+    ):
+        file = BytesIO()
+        pdf = Pdf(file)
+        pdf.init_a4_portrait()
+        pdf.mini_html(html)
+        assert [p for p in pdf.story if isinstance(p, Paragraph)] == []
+
+
 def test_pdf_mini_html_strip() -> None:
     file = BytesIO()
     pdf = Pdf(file)


### PR DESCRIPTION
Pdf: Guard against emtpy html after cleaning in `mini_html`

TYPE: Bugfix
LINK: ogc-3373