### PR TITLE
Bugfix/3366 directories save entry with publication in the past leads to loss of attachmnts

### DIFF
--- a/src/onegov/directory/models/directory.py
+++ b/src/onegov/directory/models/directory.py
@@ -3,12 +3,17 @@ from __future__ import annotations
 
 from email_validator import validate_email
 from enum import Enum
+from io import BytesIO
 from onegov.core.cache import instance_lru_cache
 from onegov.core.crypto import random_token
 from onegov.core.orm import Base, observes
 from onegov.core.orm.mixins import ContentMixin
 from onegov.core.orm.mixins import TimestampMixin
-from onegov.core.utils import increment_name, normalize_for_url
+from onegov.core.utils import (
+    dictionary_to_binary,
+    increment_name,
+    normalize_for_url,
+)
 from onegov.directory.errors import ValidationError
 from onegov.directory.migration import DirectoryMigration
 from onegov.directory.types import (
@@ -280,7 +285,7 @@ class Directory(Base, ContentMixin, TimestampMixin,
                     value_field is None
                     or value_field.data == {}
                     or value_field.data is not None
-                )
+                ) and getattr(value_field, 'action', None) != 'keep'
 
                 if delete:
                     assert session is not None
@@ -335,7 +340,34 @@ class Directory(Base, ContentMixin, TimestampMixin,
                     # keep files if selected in the dialog
                     if getattr(field_values, 'action', None) == 'keep':
                         original = (entry.values or {}).get(field.id, {})
-                        updated[field.id] = original
+                        if original:
+                            updated[field.id] = original
+                            continue
+
+                        # new entry: rebuild from the resent upload
+                        data = getattr(field_values, 'data', None) or {}
+                        if not data.get('data'):
+                            updated[field.id] = {}
+                            continue
+
+                        new_file = DirectoryFile(
+                            id=random_token(),
+                            name=data['filename'],
+                            note=field.id,
+                            reference=as_fileintent(
+                                content=BytesIO(
+                                    dictionary_to_binary(data)  # type: ignore[arg-type]
+                                ),
+                                filename=data['filename']
+                            )
+                        )
+                        entry.files.append(new_file)
+                        updated[field.id] = {
+                            'data': '@' + new_file.id,
+                            'filename': data['filename'],
+                            'mimetype': new_file.reference.file.content_type,
+                            'size': new_file.reference.file.content_length
+                        }
                         continue
 
                     # delete files if selected in the dialog

--- a/src/onegov/form/fields.py
+++ b/src/onegov/form/fields.py
@@ -379,12 +379,26 @@ class UploadField(FileField):
             # resend_upload
             action = valuelist[0]
             fieldstorage = valuelist[1]
-            # NOTE: I'm not sure why mypy complains here, a total version
-            #       of a TypedDict should be assignable to a non-total version
-            self.data = binary_to_dictionary(  # type: ignore[assignment]
-                dictionary_to_binary({'data': str(valuelist[3])}),
-                str(valuelist[2])
-            )
+            raw_data = str(valuelist[3])
+            if raw_data.startswith('@'):
+                # reference to a persisted file: keep the loaded metadata
+                # (size, mimetype) so display and validation still work
+                original = self.object_data
+                if isinstance(original, dict) and \
+                        original.get('data') == raw_data:
+                    self.data = original  # type: ignore[assignment]
+                else:
+                    self.data = {
+                        'data': raw_data,
+                        'filename': str(valuelist[2]),
+                    }
+            else:
+                # mypy: total TypedDict assignable to non-total, unclear why
+                self.data = binary_to_dictionary(  # type: ignore[assignment]
+                    dictionary_to_binary({'data': raw_data}),
+                    str(valuelist[2])
+
+                )
         elif len(valuelist) == 2:
             # force_simple
             action, fieldstorage = valuelist
@@ -429,7 +443,8 @@ class UploadField(FileField):
     ) -> None:
         if validation_stopped:
             return
-        if self.data and self.mimetypes:
+        # kept reference has no mimetype; already validated on first upload
+        if self.data and self.mimetypes and self.data.get('mimetype'):
             if self.data.get('mimetype') not in self.mimetypes:
                 raise ValidationError(_(
                     'Files of this type are not supported.'))

--- a/src/onegov/form/fields.py
+++ b/src/onegov/form/fields.py
@@ -358,7 +358,7 @@ class UploadField(FileField):
         return getattr(self, '_data', None)
 
     @data.setter
-    def data(self, value: FileDict) -> None:
+    def data(self, value: StrictFileDict | FileDict) -> None:
         self._data = value
 
     @property
@@ -393,11 +393,9 @@ class UploadField(FileField):
                         'filename': str(valuelist[2]),
                     }
             else:
-                # mypy: total TypedDict assignable to non-total, unclear why
-                self.data = binary_to_dictionary(  # type: ignore[assignment]
+                self.data = binary_to_dictionary(
                     dictionary_to_binary({'data': raw_data}),
                     str(valuelist[2])
-
                 )
         elif len(valuelist) == 2:
             # force_simple

--- a/src/onegov/form/parser/form.py
+++ b/src/onegov/form/parser/form.py
@@ -328,7 +328,7 @@ def handle_field(
                 FileSizeLimit(DEFAULT_UPLOAD_LIMIT)
             ],
             allowed_mimetypes=expected_extensions.whitelist,
-            render_kw={'accept': accept},
+            render_kw={'accept': accept, 'resend_upload': True},
             description=field.field_help
         )
 
@@ -346,7 +346,7 @@ def handle_field(
                 FileSizeLimit(DEFAULT_UPLOAD_LIMIT)
             ],
             allowed_mimetypes=expected_extensions.whitelist,
-            render_kw={'accept': accept},
+            render_kw={'accept': accept, 'resend_upload': True},
             description=field.field_help
         )
 

--- a/src/onegov/form/widgets.py
+++ b/src/onegov/form/widgets.py
@@ -215,7 +215,7 @@ class UploadWidget(FileInput):
                 data=field.data.get('data', ''),
             )
 
-        size = field.data['size']
+        size = field.data.get('size', -1)
         if size < 0:
             display_size = ''
         else:

--- a/src/onegov/org/forms/fields.py
+++ b/src/onegov/org/forms/fields.py
@@ -195,7 +195,7 @@ class UploadOrSelectExistingFileField(UploadOrLinkExistingFileField):
             action = valuelist[0]
             fieldstorage = valuelist[1]
             existing = valuelist[2]
-            self.data = binary_to_dictionary(  # type: ignore[assignment]
+            self.data = binary_to_dictionary(
                 dictionary_to_binary({'data': str(valuelist[4])}),
                 str(valuelist[3])
             )

--- a/src/onegov/org/views/directory.py
+++ b/src/onegov/org/views/directory.py
@@ -24,7 +24,6 @@ from onegov.directory.errors import MissingFileError
 from onegov.directory.errors import ValidationError
 from onegov.directory.models.directory import EntrySubscription
 from onegov.form import FormCollection, as_internal_id, move_fields
-from onegov.form.fields import UploadField
 from onegov.org import OrgApp, _
 from onegov.org.forms import DirectoryForm, DirectoryImportForm
 from onegov.org.forms.directory import DirectoryRecipientForm, DirectoryUrlForm
@@ -746,10 +745,6 @@ def handle_new_directory_entry(
 
         request.success(_('Added a new directory entry'))
         return request.redirect(request.link(entry))
-
-    if form.errors:
-        for field in form.match_fields(include_classes=(UploadField, )):
-            getattr(form, field).data = {}
 
     layout = layout or DirectoryEntryCollectionLayout(self, request)
     layout.include_code_editor()

--- a/tests/onegov/org/test_views_directory.py
+++ b/tests/onegov/org/test_views_directory.py
@@ -22,7 +22,7 @@ from pytz import UTC
 from textwrap import dedent
 from sedate import standardize_date, utcnow, to_timezone, replace_timezone
 from tests.shared.utils import (
-    create_image, get_meta, extract_filename_from_response)
+    create_image, create_pdf, get_meta, extract_filename_from_response)
 from webtest import Upload
 
 from typing import TYPE_CHECKING
@@ -102,7 +102,8 @@ def create_directory(
     extended_submitter: bool = False,
     title: str = 'Meetings',
     lead: str | None = None,
-    text: str | None = None
+    text: str | None = None,
+    pdf: bool = False
 ) -> ExtendedResponse:
 
     client.login_admin()
@@ -112,11 +113,18 @@ def create_directory(
         page.form['lead'] = lead
     if text:
         page.form['text'] = text
-    page.form['structure'] = """
+    if pdf:
+        page.form['structure'] = """
+                    Name *= ___
+                    Pic *= *.jpg|*.png|*.gif
+                    Pdf *= *.pdf
+                """
+    else:
+        page.form['structure'] = """
                     Name *= ___
                     Pic *= *.jpg|*.png|*.gif
                 """
-    page.form['content_fields'] = 'Name\nPic'
+    page.form['content_fields'] = 'Name\nPic\nPdf' if pdf else 'Name\nPic'
     page.form['content_hide_labels'] = 'Pic'
     page.form['title_format'] = '[Name]'
     page.form['enable_map'] = 'entry'
@@ -164,8 +172,7 @@ def test_publication_added_by_admin(client: Client) -> None:
     page.form['publication_end'] = dt_for_form(now - timedelta(days=1))
     page = page.form.submit()
     assert 'Das Publikationsende muss in der Zukunft liegen' in page
-    # we have to submit the file again, can't evade that
-    page.form['pic'] = Upload('annual.jpg', create_image().read())
+    # the uploaded file survives the validation error, no need to resend it
     annual_end = now + timedelta(days=1)
     page.form['publication_end'] = dt_for_form(annual_end)
     entry = page.form.submit().follow()
@@ -197,6 +204,73 @@ def test_publication_added_by_admin(client: Client) -> None:
     assert 'publication_start' not in page.form.fields
 
 
+def test_attachment_preserved_on_validation_error(client: Client) -> None:
+    # Uploading a file and submitting an entry with a publication date in
+    # the past triggers a validation error. The already uploaded file must
+    # survive the re-render so the user doesn't lose the attachment.
+    utc_now = utcnow()
+    now = to_timezone(utc_now, 'Europe/Zurich')
+
+    meetings = create_directory(client, publication=True, pdf=True)
+
+    page = meetings.click('Eintrag', index=0)
+    page.form['name'] = 'Annual'
+    page.form['pic'] = Upload('annual.jpg', create_image().read())
+    page.form['pdf'] = Upload('annual.pdf', create_pdf().read())
+    page.form['publication_start'] = dt_for_form(now)
+    page.form['publication_end'] = dt_for_form(now - timedelta(days=1))
+    page = page.form.submit()
+    assert 'Das Publikationsende muss in der Zukunft liegen' in page
+
+    # fix the publication date, but do NOT re-upload the files
+    annual_end = now + timedelta(days=1)
+    page.form['publication_end'] = dt_for_form(annual_end)
+    entry = page.form.submit().follow()
+
+    # the image attachment must have been preserved
+    assert get_meta(entry, 'og:image')
+    assert get_meta(entry, 'og:image:alt') == 'annual.jpg'
+
+    # the pdf attachment must have been preserved too
+    files = {f.name for f in dir_query(client).one().files}
+    assert 'annual.pdf' in files
+
+
+def test_attachment_preserved_on_edit_validation_error(
+    client: Client
+) -> None:
+    # Editing an existing entry with an attachment and saving it with a
+    # publication date in the past must not lose the attachment.
+    utc_now = utcnow()
+    now = to_timezone(utc_now, 'Europe/Zurich')
+
+    meetings = create_directory(client, publication=True, pdf=True)
+
+    page = meetings.click('Eintrag', index=0)
+    page.form['name'] = 'Annual'
+    page.form['pic'] = Upload('annual.jpg', create_image().read())
+    page.form['pdf'] = Upload('annual.pdf', create_pdf().read())
+    page.form['publication_start'] = dt_for_form(now)
+    page.form['publication_end'] = dt_for_form(now + timedelta(days=10))
+    entry = page.form.submit().follow()
+    assert get_meta(entry, 'og:image')
+
+    edit = client.get(entry.request.url + '/edit')
+    edit.form['publication_end'] = dt_for_form(now - timedelta(days=1))
+    page = edit.form.submit()
+    assert 'Das Publikationsende muss in der Zukunft liegen' in page
+
+    # fix the date without touching the attachments
+    page.form['publication_end'] = dt_for_form(now + timedelta(days=5))
+    entry = page.form.submit().follow()
+    assert get_meta(entry, 'og:image')
+    assert get_meta(entry, 'og:image:alt') == 'annual.jpg'
+
+    # the pdf attachment must have been preserved too
+    files = {f.name for f in dir_query(client).one().files}
+    assert 'annual.pdf' in files
+
+
 def test_required_publication(client: Client) -> None:
     utc_now = utcnow()
     now = to_timezone(utc_now, 'Europe/Zurich')
@@ -213,8 +287,7 @@ def test_required_publication(client: Client) -> None:
     page.form['publication_start'] = dt_for_form(now)
     page = page.form.submit()
     assert 'Dieses Feld wird benötigt' in page
-    # we have to submit the file again, can't evade that
-    page.form['pic'] = Upload('annual.jpg', create_image().read())
+    # the uploaded file survives the validation error, no need to resend it
     annual_end = now + timedelta(days=1)
     page.form['publication_end'] = dt_for_form(annual_end)
     page.form.submit().follow()

--- a/tests/shared/utils.py
+++ b/tests/shared/utils.py
@@ -139,12 +139,34 @@ def create_image(
     return im
 
 
+@overload
 def create_pdf(
-    filename: str = 'simple.pdf',
+    filename: None = None,
+    content: str = ...
+) -> BytesIO: ...
+
+
+@overload
+def create_pdf(
+    filename: str,
+    content: str = ...
+) -> Canvas: ...
+
+
+def create_pdf(
+    filename: str | None = None,
     content: str = "Hello, I am a PDF document created with Python!"
-) -> Canvas:
+) -> Canvas | BytesIO:
 
     from reportlab.pdfgen import canvas
+
+    if filename is None:
+        buffer = BytesIO()
+        c = canvas.Canvas(buffer)
+        c.drawString(100, 750, content)
+        c.save()
+        buffer.seek(0)
+        return buffer
 
     c = canvas.Canvas(filename)
     c.drawString(100, 750, content)


### PR DESCRIPTION
Directory: Preserve attachments on entry save with past publication date 

Uploading a file and saving/editing a directory entry with a publication date in the past triggered a validation error that discarded the attachment. The upload now survives the re-render (new entries) and edits keep the persisted file. 
                                                          
TYPE: Bugfix                                                                                    
LINK: OGC-3366 