### PR TITLE
Improve number formatting

### DIFF
--- a/src/onegov/feriennet/templates/billing.pt
+++ b/src/onegov/feriennet/templates/billing.pt
@@ -9,11 +9,11 @@
                 <tal:b metal:use-macro="layout.macros.period_hints" />
 
                 <div class="hint hint-costs" i18n:translate tal:condition="bills">
-                    The total amount is <strong tal:content="'{:.2f}'.format(model.total)" i18n:name="amount" /> CHF.
+                    The total amount is <strong tal:content="layout.format_number(model.total)" i18n:name="amount" /> CHF.
                 </div>
 
                 <div class="hint hint-outstanding" i18n:translate tal:condition="bills">
-                    The outstanding amount is <strong tal:content="'{:.2f}'.format(model.outstanding)" i18n:name="amount" /> CHF.
+                    The outstanding amount is <strong tal:content="layout.format_number(model.outstanding)" i18n:name="amount" /> CHF.
                 </div>
             </div>
         </div>
@@ -38,10 +38,10 @@
                                 <span class="outstanding">
                                     <tal:b condition="details.outstanding == 0" i18n:translate>Paid</tal:b>
                                     <tal:b condition="details.outstanding > 0" i18n:translate>
-                                        <tal:b i18n:name="amount" tal:replace="'{:.2f}'.format(details.outstanding)" /> unpaid
+                                        <tal:b i18n:name="amount" tal:replace="layout.format_number(details.outstanding)" /> unpaid
                                     </tal:b>
                                     <tal:b condition="details.outstanding < 0" i18n:translate>
-                                        <tal:b i18n:name="amount" tal:replace="'{:.2f}'.format(details.outstanding * -1)" /> overpaid
+                                        <tal:b i18n:name="amount" tal:replace="layout.format_number(details.outstanding * -1)" /> overpaid
                                     </tal:b>
 
                                     <tal:b tal:define="actions tuple(invoice_links(details))" tal:condition="actions">
@@ -110,7 +110,7 @@
                                                         </i>
                                                     </tal:b>
                                                 </td>
-                                                <td class="amount">${'{:.2f}'.format(item.amount)}</td>
+                                                <td class="amount">${layout.format_number(item.amount)}</td>
                                                 <td class="payment-status" tal:condition="not item.paid">
                                                     <span i18n:translate class="show-for-sr">Unpaid</span>
                                                     <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
@@ -137,7 +137,7 @@
                                             <td class="amount">
                                                 <tal:b tal:condition="not details.paid" i18n:translate >amount unpaid</tal:b>
                                                 <tal:b tal:condition="details.paid" i18n:translate >paid</tal:b>
-                                                ${'{:.2f}'.format(details.total)}
+                                                ${layout.format_number(details.total)}
                                             </td>
                                             <td></td>
                                         </tr>

--- a/src/onegov/feriennet/templates/invoices.pt
+++ b/src/onegov/feriennet/templates/invoices.pt
@@ -51,7 +51,7 @@
                             <span class="outstanding">
                                 <tal:b condition="invoice.paid" i18n:translate>Paid</tal:b>
                                 <tal:b condition="not: invoice.paid" i18n:translate>
-                                    <tal:b i18n:name="amount" tal:replace="'{:.2f}'.format(invoice.outstanding_amount)" /> unpaid
+                                    <tal:b i18n:name="amount" tal:replace="layout.format_number(invoice.outstanding_amount)" /> unpaid
                                 </tal:b>
                             </span>
                         </div>
@@ -94,7 +94,7 @@
                                             </span>
                                             <span tal:condition="invoice.paid or item.paid" class="item-payment-status" i18n:translate>paid</span>
                                             <span tal:condition="not invoice.paid and not item.paid" class="item-payment-status" i18n:translate>amount unpaid</span>
-                                            <span class="item-amount" tal:content="'{:.2f}'.format(item.amount)"></span>
+                                            <span class="item-amount" tal:content="layout.format_number(item.amount)"></span>
                                         </div>
                                             <span class="item-organizer" tal:condition="item.organizer">
                                                 <tal:b i18n:translate>Organizer:</tal:b> ${item.organizer}
@@ -135,11 +135,11 @@
                                 <li class="invoice-total">
                                 <strong>
                                     <span class="item-text" i18n:translate="">Total</span>
-                                    <span class="item-amount" tal:content="'{:.2f}'.format(invoice.total_amount)"></span>
+                                    <span class="item-amount" tal:content="layout.format_number(invoice.total_amount)"></span>
                                 </strong>
                                 </li>
                                 <li class="amount-total ${invoice.paid and 'item-green' or 'item-red'}" tal:condition="not invoice.paid">
-                                    <span class="item-payment-status item-amount">${'{:.2f}'.format(invoice.outstanding_amount)}</span>
+                                    <span class="item-payment-status item-amount">${layout.format_number(invoice.outstanding_amount)}</span>
                                     <span class="item-payment-status item-amount" i18n:translate>amount unpaid</span>
                                 </li>
                             </ul>
@@ -190,7 +190,7 @@
                                         Amount
                                     </div>
                                     <div class="cell small-12 medium-8">
-                                        ${'{:.2f}'.format(invoice.outstanding_amount)} CHF
+                                        ${layout.format_number(invoice.outstanding_amount)} CHF
                                     </div>
                                     <tal:b switch="layout.org.meta.get('bank_reference_schema')">
                                         <tal:b tal:case="string:esr-v1">

--- a/src/onegov/feriennet/templates/macros.pt
+++ b/src/onegov/feriennet/templates/macros.pt
@@ -511,7 +511,7 @@
                                     <span i18n:translate class="show-for-sr">Cost</span>
 
                                     <span i18n:translate>
-                                        starting at <tal:b i18n:name='price'>${'{:.2f}'.format(min_cost)}</tal:b> CHF
+                                        starting at <tal:b i18n:name='price'>${layout.format_number(min_cost)}</tal:b> CHF
                                     </span>
                                 </span>
                             </tal:b>
@@ -609,7 +609,7 @@
                 </div>
 
                 <div class="bring-cash" tal:condition="period.all_inclusive and occasion.cost and period.pay_organiser_directly" >
-                    <p i18n:translate>Please bring <tal:b i18n:name="cost" replace="occasion.cost" /> CHF in cash.</p>
+                    <p i18n:translate>Please bring <tal:b i18n:name="cost" replace="layout.format_number(occasion.cost)" /> CHF in cash.</p>
                 </div>
             </div>
 
@@ -649,7 +649,7 @@
                             <span i18n:translate class="show-for-sr">Cost</span>
 
                             <tal:b i18n:translate>
-                                <tal:b i18n:name="cost" replace="occasion.cost" /> CHF
+                                <tal:b i18n:name="cost" replace="layout.format_number(occasion.cost)" /> CHF
                             </tal:b>
                         </p>
                     </div>
@@ -661,7 +661,7 @@
                             <span i18n:translate class="show-for-sr">Cost</span>
 
                             <tal:b condition="cost" i18n:translate>
-                                <tal:b i18n:name="cost" replace="cost" /> CHF
+                                <tal:b i18n:name="cost" replace="layout.format_number(cost)" /> CHF
                             </tal:b>
                             <tal:b condition="not:cost" i18n:translate>
                                 Free of charge
@@ -833,11 +833,11 @@
 
     <div tal:condition="period.all_inclusive and period.booking_cost"
          class="hint hint-costs" i18n:translate>
-            The passport costs <tal:b i18n:name="amount" tal:replace="period.booking_cost" /> CHF per child. Individual activities may incur additional charges.
+            The passport costs <tal:b i18n:name="amount" tal:replace="layout.format_number(period.booking_cost)" /> CHF per child. Individual activities may incur additional charges.
     </div>
     <div tal:condition="period.all_inclusive is False and period.booking_cost"
          class="hint hint-costs" i18n:translate>
-            A booking costs <tal:b i18n:name="amount" tal:replace="period.booking_cost" /> CHF per child. Individual activities may incur additional charges.
+            A booking costs <tal:b i18n:name="amount" tal:replace="layout.format_number(period.booking_cost)" /> CHF per child. Individual activities may incur additional charges.
     </div>
 
     <div tal:condition="period.minutes_between"


### PR DESCRIPTION
Feriennet: Improve number formatting

Separates groups of thousands `1´000` (locale specific separator)

TYPE: Feature
LINK: None