### PR TITLE
Org: Optimize ticket assignment user queries

### DIFF
--- a/src/onegov/org/forms/ticket.py
+++ b/src/onegov/org/forms/ticket.py
@@ -17,6 +17,7 @@ from onegov.org import _
 from onegov.pdf.pdf import TABLE_CELL_CHAR_LIMIT
 from onegov.user import User
 from onegov.user import UserCollection
+from sqlalchemy.orm import joinedload
 from wtforms.fields import BooleanField
 from wtforms.fields import TextAreaField
 from functools import cached_property
@@ -137,6 +138,8 @@ class ExtendedInternalTicketChatMessageForm(InternalTicketChatMessageForm):
 
 class TicketAssignmentForm(Form):
 
+    usernames: dict[str, str]
+
     user = ChosenSelectField(
         _('User'),
         choices=[],
@@ -147,12 +150,19 @@ class TicketAssignmentForm(Form):
 
     @property
     def username(self) -> str | None:
-        if self.user.data in (choice[0] for choice in self.user.choices):
-            query = self.request.session.query(User.username)
-            return query.filter_by(id=self.user.data).scalar()
-        return None
+        return self.usernames.get(str(self.user.data))
 
     def on_request(self) -> None:
+        query = UserCollection(self.request.session).query()
+        query = query.filter(User.active.is_(True))
+        query = query.options(joinedload(User.groups))
+
+        users = [
+            user
+            for user in query
+            if self.request.has_permission(self.model, Private, user)
+        ]
+        self.usernames = {str(user.id): user.username for user in users}
         self.user.choices = [
             (
                 str(user.id),
@@ -160,11 +170,7 @@ class TicketAssignmentForm(Form):
                 if user.groups
                 else user.title
             )
-            for user in UserCollection(self.request.session).query()
-            if (
-                self.request.has_permission(self.model, Private, user)
-                and user.active == True
-            )
+            for user in users
         ]
 
 

--- a/tests/onegov/org/test_forms.py
+++ b/tests/onegov/org/test_forms.py
@@ -24,6 +24,7 @@ from onegov.reservation import LibresIntegration
 from onegov.ticket import Ticket, TicketPermission
 from onegov.user import UserCollection
 from onegov.user import UserGroupCollection
+from sqlalchemy import event
 from unittest.mock import MagicMock
 from uuid import UUID
 from webob.multidict import MultiDict
@@ -950,9 +951,13 @@ def test_settings_ticket_permissions(session: Session) -> None:
 
 def test_ticket_assignment_form(session: Session) -> None:
     users = UserCollection(session)
-    user_a = users.add(username='a', password='pwd', role='admin')
+    group = UserGroupCollection(session).add(name='A')
+    user_a = users.add(
+        username='a', password='pwd', role='admin', groups=[group]
+    )
     users.add(username='e', password='pwd', role='editor')
     users.add(username='m', password='pwd', role='member')
+    users.add(username='i', password='pwd', role='admin', active=False)
 
     request: Any = Bunch(
         session=session,
@@ -961,9 +966,27 @@ def test_ticket_assignment_form(session: Session) -> None:
     form = TicketAssignmentForm(data={'user': user_a.id})
     form.model = None
     form.request = request
-    form.on_request()
 
-    assert sorted(name for id_, name in form.user.choices) == ['a', 'e']  # type: ignore
+    statements: list[str] = []
+
+    def count_query(*args: Any) -> None:
+        statements.append(args[2])
+
+    session.expire_all()
+    connection = session.connection()
+    event.listen(connection, 'before_cursor_execute', count_query)
+    try:
+        form.on_request()
+        assert form.username == 'a'
+        assert form.username == 'a'
+    finally:
+        event.remove(connection, 'before_cursor_execute', count_query)
+
+    assert len(statements) == 1
+    names = sorted(  # type: ignore[misc, str-unpack]
+        name for id_, name in form.user.choices
+    )
+    assert names == ['a (A)', 'e']
     assert form.username == 'a'
 
 


### PR DESCRIPTION
Please fill in the commit message below and work through the checklist. You can delete parts that are not needed, e.g. the optional description, the link to a ticket or irrelevant options of the checklist.

## Commit message

Org: Optimize ticket assignment user queries

 Cause: all 13,985 users triggered  a separate lazy 
group query, producing roughly 14,000 queries.

TYPE: Bugfix
LINK: OGC-3381



## Checklist

- [x] I have performed a self-review of my code
- [x] I have tested my code thoroughly by hand

