### PR TITLE
Org: Stores pricing settings on reservations, so they remain stable

### DIFF
--- a/src/onegov/org/pricing_schemes/stadtschulen_zug.py
+++ b/src/onegov/org/pricing_schemes/stadtschulen_zug.py
@@ -24,7 +24,10 @@ CATEGORIES = ('A', 'B', 'C')
 class StadtschulenZug(
     ResourcePricingScheme,
     name='stadtschulen_zug',
-    label='Freizeitbetreuungsanlagen'
+    label='Freizeitbetreuungsanlagen',
+    content_names=(
+        'stadtschulen_zug_price_table',
+    )
 ):
 
     @classmethod

--- a/src/onegov/org/views/reservation.py
+++ b/src/onegov/org/views/reservation.py
@@ -1993,7 +1993,6 @@ def add_reservation(
     # if the matched allocation isn't partly available expand it to the
     # whole allocation for a better user experience, but don't ever shrink
     # it, since that's most certainly not what they want to have happen.
-    allocation = None
     for allocation in resource.scheduler.allocations_in_range(start, end):
         if not allocation.overlaps(start, end):
             continue

--- a/src/onegov/org/views/reservation.py
+++ b/src/onegov/org/views/reservation.py
@@ -237,6 +237,10 @@ def reserve_allocation(self: Allocation, request: OrgRequest) -> JSON_ro:
 
         return respond_with_error(request, err)
 
+    # store the current pricing settings on the reservation
+    data: dict[str, Any] = {}
+    resource.store_pricing_settings(data, self)
+
     # ...otherwise, try to reserve
     scheduler = resource.scheduler
     try:
@@ -245,6 +249,7 @@ def reserve_allocation(self: Allocation, request: OrgRequest) -> JSON_ro:
         scheduler.reserve(
             email='0xdeadbeef@example.org',  # will be set later
             dates=(start, end),
+            data=data,
             quota=quota,
             session_id=resource.bound_session_id(request),
             single_token_per_session=True
@@ -1988,6 +1993,7 @@ def add_reservation(
     # if the matched allocation isn't partly available expand it to the
     # whole allocation for a better user experience, but don't ever shrink
     # it, since that's most certainly not what they want to have happen.
+    allocation = None
     for allocation in resource.scheduler.allocations_in_range(start, end):
         if not allocation.overlaps(start, end):
             continue
@@ -2009,6 +2015,13 @@ def add_reservation(
         temp_token = resource.scheduler.reserve(
             self.email,
             (start, end),
+            # NOTE: Copy all of the settings apart from kaba, we will
+            #       sort out kaba further below
+            data={
+                key: value
+                for key, value in self.data.items()
+                if key != 'kaba'
+            } if self.data else None,
             quota=form.quota.data
         )
     except LibresError as e:

--- a/src/onegov/reservation/models/custom_reservation.py
+++ b/src/onegov/reservation/models/custom_reservation.py
@@ -66,20 +66,9 @@ class CustomReservation(Reservation, ModelBase, Payable):
     ) -> InvoiceItemMeta | None:
         """ Returns an invoice item for this reservation. """
 
-        allocation = allocation or self.allocation_obj
-        data = allocation and allocation.data or {}
-        pricing_method = data.get('pricing_method', 'inherit')
-        if pricing_method not in (
-            'inherit',
-            'per_hour',
-            'per_item'
-        ):
-            return None
-
-        resource = resource or self.resource_obj
-        if pricing_method == 'inherit':
-            pricing_method = resource.pricing_method
-
+        data = self.data
+        if data and 'pricing_method' in data:
+            pricing_method = data['pricing_method']
             if pricing_method not in (
                 'per_hour',
                 'per_item',
@@ -87,13 +76,50 @@ class CustomReservation(Reservation, ModelBase, Payable):
             ):
                 return None
 
-            price_per_hour = resource.price_per_hour
-            price_per_item = resource.price_per_item
-            pricing_scheme_name = resource.pricing_scheme
+            resource = resource or self.resource_obj
+            price_per_hour = data.get(
+                'price_per_hour',
+                resource.price_per_hour
+            )
+            price_per_item = data.get(
+                'price_per_item',
+                resource.price_per_item
+            )
+            pricing_scheme_name = data.get(
+                'pricing_scheme',
+                resource.pricing_scheme
+            )
+            cost_object = data.get('cost_object', resource.cost_object)
         else:
-            price_per_hour = data.get('price_per_hour', 0.0)
-            price_per_item = data.get('price_per_item', 0.0)
-            pricing_scheme_name = None
+            resource = resource or self.resource_obj
+            allocation = allocation or self.allocation_obj
+            allocation_data = allocation and allocation.data or {}
+            pricing_method = allocation_data.get('pricing_method', 'inherit')
+            if pricing_method not in (
+                'inherit',
+                'per_hour',
+                'per_item'
+            ):
+                return None
+
+            if pricing_method == 'inherit':
+                pricing_method = resource.pricing_method
+
+                if pricing_method not in (
+                    'per_hour',
+                    'per_item',
+                    'pricing_scheme'
+                ):
+                    return None
+
+                price_per_hour = resource.price_per_hour
+                price_per_item = resource.price_per_item
+                pricing_scheme_name = resource.pricing_scheme
+            else:
+                price_per_hour = allocation_data.get('price_per_hour', 0.0)
+                price_per_item = allocation_data.get('price_per_item', 0.0)
+                pricing_scheme_name = None
+            cost_object = resource.cost_object
 
         # technically we could have multiple allocations per reservation
         # but in practice we don't use that feature. Each reservation
@@ -112,7 +138,7 @@ class CustomReservation(Reservation, ModelBase, Payable):
             return InvoiceItemMeta(
                 text=resource.title,
                 group='reservation',
-                cost_object=resource.cost_object,
+                cost_object=cost_object,
                 extra={'reservation_id': self.id},
                 unit=Decimal(price_per_hour),
                 quantity=hours,
@@ -125,7 +151,7 @@ class CustomReservation(Reservation, ModelBase, Payable):
             return InvoiceItemMeta(
                 text=resource.title,
                 group='reservation',
-                cost_object=resource.cost_object,
+                cost_object=cost_object,
                 extra={'reservation_id': self.id},
                 unit=Decimal(price_per_item),
                 quantity=Decimal(count),
@@ -150,7 +176,7 @@ class CustomReservation(Reservation, ModelBase, Payable):
             return InvoiceItemMeta(
                 text=resource.title,
                 group='reservation',
-                cost_object=resource.cost_object,
+                cost_object=cost_object,
                 extra={'reservation_id': self.id},
                 unit=amount,
             )
@@ -171,16 +197,20 @@ class CustomReservation(Reservation, ModelBase, Payable):
         The price per token is calculcated by combining all the prices.
 
         """
+        data = self.data
         resource = resource or self.resource_obj
-        allocation = allocation or self.allocation_obj
+        if data and 'currency' in data:
+            currency = data['currency'] or resource.currency
+        else:
+            allocation = allocation or self.allocation_obj
+            allocation_data = allocation and allocation.data or {}
+            if allocation_data.get('pricing_method', 'inherit') == 'inherit':
+                currency = resource.currency
+            else:
+                currency = allocation_data.get('currency') or resource.currency
 
         item = self.invoice_item(resource, allocation, submission_data)
         if item is None:
             return None
 
-        data = allocation and allocation.data or {}
-        if data.get('pricing_method', 'inherit') == 'inherit':
-            currency = resource.currency
-        else:
-            currency = data.get('currency') or resource.currency
         return Price(item.amount, currency)

--- a/src/onegov/reservation/models/resource.py
+++ b/src/onegov/reservation/models/resource.py
@@ -17,6 +17,7 @@ from onegov.file import MultiAssociatedFiles
 from onegov.form.parser import ParsedForm
 from onegov.form.orm_types import Formcode
 from onegov.pay import InvoiceItemMeta, Price, process_payment
+from onegov.reservation.pricing_scheme import PRICING_SCHEMES
 from sedate import align_date_to_day, utcnow
 from sqlalchemy import ForeignKey
 from sqlalchemy.ext.hybrid import hybrid_property
@@ -365,6 +366,19 @@ class Resource(ORMBase, ModelBase, ContentMixin,
 
         items: list[InvoiceItemMeta] = []
         extras_quantity = Decimal('0')
+        reservation_data = reservations[0].data or {}
+        extras_pricing_method = reservation_data.get(
+            'extras_pricing_method',
+            self.extras_pricing_method
+        )
+        discount_method = reservation_data.get(
+            'discount_method',
+            self.discount_method
+        )
+        cost_object = reservation_data.get(
+            'cost_object',
+            self.cost_object
+        )
         for reservation in reservations:
             # FIXME: We could speed this up by loading all of the
             #        targeted allocations ahead of time and passing
@@ -378,7 +392,7 @@ class Resource(ORMBase, ModelBase, ContentMixin,
                 items.append(item)
 
             if extras:
-                match self.extras_pricing_method:
+                match extras_pricing_method:
                     case 'one_off':
                         extras_quantity = Decimal('1')
 
@@ -411,7 +425,7 @@ class Resource(ORMBase, ModelBase, ContentMixin,
         total = InvoiceItemMeta.total(items)
         extras_total = InvoiceItemMeta.total(extras)
 
-        match self.discount_method:
+        match discount_method:
             case 'resource':
                 discount_total = total
             case 'extras':
@@ -454,11 +468,41 @@ class Resource(ORMBase, ModelBase, ContentMixin,
             items.append(InvoiceItemMeta(
                 text=reduced_amount_label,
                 group='reduced_amount',
-                cost_object=self.cost_object,
+                cost_object=cost_object,
                 unit=reduced_amount-total
             ))
 
         return items
+
+    def store_pricing_settings(
+        self,
+        data: dict[str, Any],
+        allocation: Allocation | None
+    ) -> None:
+        """ Stores the resource/allocation specific pricing settings on the
+        given reservation data, so pricing on that reservation remains stable,
+        regardless of what changes later happen to the resource/allocation.
+        """
+        allocation_data = allocation and allocation.data or {}
+        pricing_method = allocation_data.get('pricing_method', 'inherit')
+        if pricing_method == 'inherit':
+            data['pricing_method'] = self.pricing_method
+            data['price_per_hour'] = self.price_per_hour
+            data['price_per_item'] = self.price_per_item
+            data['pricing_scheme'] = pricing_scheme_name = self.pricing_scheme
+            data['currency'] = self.currency
+            if pricing_scheme_name and (
+                pricing_scheme := PRICING_SCHEMES.get(pricing_scheme_name)
+            ) is not None:
+                for name in pricing_scheme.content_names:
+                    data[name] = self.content.get(name)
+        else:
+            data['pricing_method'] = pricing_method
+            data['price_per_hour'] = allocation_data.get('price_per_hour', 0.0)
+            data['price_per_item'] = allocation_data.get('price_per_item', 0.0)
+            data['pricing_scheme'] = None
+            data['currency'] = allocation_data.get('currency') or self.currency
+        data['cost_object'] = self.cost_object
 
     def process_payment(
         self,

--- a/src/onegov/reservation/pricing_scheme.py
+++ b/src/onegov/reservation/pricing_scheme.py
@@ -27,21 +27,31 @@ class ResourcePricingScheme:
 
     __slots__ = ()
 
+    #: The internal name/identifier of the pricing scheme
     name: ClassVar[str]
+
+    #: The human readable label of the pricing scheme
     label: ClassVar[str]
+
+    #: A sequence of names stored in `resource.content`, that will be
+    #: accessed by this pricing scheme
+    content_names: ClassVar[tuple[str, ...]]
 
     def __init_subclass__(
         cls,
         name: str | None = None,
         label: str | None = None,
+        content_names: tuple[str, ...] | None = None,
         **kwargs: Any,
     ) -> None:
 
         if name is not None:
             assert name not in PRICING_SCHEMES
             assert label is not None
+            assert content_names is not None
             cls.name = name
             cls.label = label
+            cls.content_names = content_names
             PRICING_SCHEMES[name] = cls
 
         super().__init_subclass__(**kwargs)

--- a/src/onegov/reservation/upgrade.py
+++ b/src/onegov/reservation/upgrade.py
@@ -441,3 +441,67 @@ def resources_switch_to_parsed_form(context: UpgradeContext) -> None:
 
     # finally remove the old column
     context.operations.drop_column('resources', 'definition')
+
+
+@upgrade_task('Store pricing settings on reservations')
+def store_pricing_settings_on_reservations(context: UpgradeContext) -> None:
+    if not context.has_table('resources'):
+        return
+
+    context.session.execute(text("""
+        WITH adata AS (
+            SELECT "group",
+                   jsonb_build_object(
+                        'pricing_method',
+                        data->'pricing_method',
+                        'price_per_hour',
+                        COALESCE(data->'price_per_hour', '0.0'::jsonb),
+                        'price_per_item',
+                        COALESCE(data->'price_per_item', '0.0'::jsonb),
+                        'currency',
+                        COALESCE(data->'currency', '"CHF"'::jsonb)
+                   ) AS pricing
+              FROM allocations
+             WHERE resource = mirror_of
+               AND data->>'pricing_method' = 'price_per_item'
+                OR data->>'pricing_method' = 'price_per_hour'
+                OR data->>'pricing_method' = 'free'
+        )
+        UPDATE reservations
+           SET data = COALESCE(data, '{}'::jsonb) ||
+              CASE
+                WHEN EXISTS (SELECT 1 FROM adata WHERE adata."group" = target)
+                THEN
+                    (
+                        SELECT pricing
+                          FROM adata
+                         WHERE adata."group" = target
+                         LIMIT 1
+                    ) || jsonb_build_object(
+                        'cost_object',
+                        resources.content->'cost_object'
+                    )
+                ELSE
+                    jsonb_build_object(
+                        'pricing_method',
+                        resources.content->'pricing_method',
+                        'price_per_hour',
+                        COALESCE(
+                            resources.content->'price_per_hour',
+                            '0.0'::jsonb
+                        ),
+                        'price_per_item',
+                        COALESCE(
+                            resources.content->'price_per_item',
+                            '0.0'::jsonb
+                        ),
+                        'currency',
+                        resources.content->'currency',
+                        'cost_object',
+                        resources.content->'cost_object'
+                    )
+               END
+           FROM resources
+          WHERE resources.id = resource
+
+    """))


### PR DESCRIPTION
## Commit message

Org: Stores pricing settings on reservations, so they remain stable

Previously price calculations always referenced the current state of the
pricing settings on the targeted resource/allocation, which could lead
to issues in the transition period, when those settings change, since
old reservations should still calculate their prices according to the
rules when they were first made.

We now store the settings on each reservation, similar to how we store
custom form definitions along with each form submission, so old
submissions always remain valid.

TYPE: Bugfix
LINK: OGC-3382

## Checklist

- [x] I have performed a self-review of my code
- [x] I have tested my code thoroughly by hand
