### PR TITLE
Directory: Gracefully handle invalid export format (sentry: ONEGOV-CLOUD-5XS)

### DIFF
--- a/src/onegov/org/views/directory.py
+++ b/src/onegov/org/views/directory.py
@@ -44,7 +44,7 @@ from onegov.core.elements import Link
 from purl import URL
 from tempfile import NamedTemporaryFile
 from webob import Response
-from webob.exc import HTTPForbidden
+from webob.exc import HTTPForbidden, HTTPBadRequest
 from sedate import utcnow
 from wtforms import TextAreaField
 from wtforms.validators import InputRequired
@@ -1151,6 +1151,8 @@ def view_zip_file(
     format = request.params.get('format')
     if not isinstance(format, str):
         format = 'json'
+    if format not in ('xlsx', 'csv', 'json'):
+        raise HTTPBadRequest('Invalid export format: ' + format)
     formatter = layout.export_formatter(format)
 
     def transform(key: object, value: object) -> tuple[Any, Any]:

--- a/tests/onegov/org/test_views_directory.py
+++ b/tests/onegov/org/test_views_directory.py
@@ -830,6 +830,18 @@ def test_directory_export(client: Client) -> None:
     assert count == 1
     assert directory.meta == events.meta
 
+    # an invalid format is rejected with a 400 instead of crashing
+    resp = client.get(
+        '/directories/events/+zip?format=xml', expect_errors=True
+    )
+    assert resp.status_code == 400
+    assert 'Invalid export format: xml' in resp
+    resp = client.get(
+        '/directories/events/+zip?format=abc', expect_errors=True
+    )
+    assert resp.status_code == 400
+    assert 'Invalid export format: abc' in resp
+
 
 def test_add_directory_entries_with_duplicate_names(client: Client) -> None:
     client.login_admin()


### PR DESCRIPTION
Directory: Gracefully handle invalid export format 

TYPE: Bugfix
LINK: ONEGOV-CLOUD-5XS