### PR TITLE
Core: Removes `fs`/`PyFilesystem` dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -81,7 +81,6 @@ install_requires =
     feedgen
     filedepot
     firebase-admin
-    fs
     genshi
     hiredis
     html2text
@@ -147,7 +146,7 @@ install_requires =
     rjsmin
     sedate
     sentry_sdk
-    # FIXME: Blocked by fs2 dependency OGC-1607
+    # FIXME: https://github.com/morepath/more.transaction/issues/18
     setuptools<80
     sortedcontainers
     sqlalchemy>=2

--- a/src/onegov/agency/app.py
+++ b/src/onegov/agency/app.py
@@ -27,9 +27,8 @@ if TYPE_CHECKING:
     from collections.abc import Callable
     from collections.abc import Iterator
     from datetime import datetime
-    from fs.base import FS
-    from fs.base import SubFS
     from onegov.api import ApiEndpoint
+    from onegov.core.filestorage import Filestorage
     from onegov.core.types import RenderData
     from onegov.org.models import Organisation
 
@@ -40,9 +39,9 @@ class AgencyApp(TownApp):
 
     if TYPE_CHECKING:
         # FIXME: Maybe we should consider just raising an exception
-        #        if filestorage is accesed without it being configured
+        #        if filestorage is accessed without it being configured
         @property
-        def filestorage(self) -> SubFS[FS]: ...
+        def filestorage(self) -> Filestorage: ...
 
     @property
     def root_pdf_exists(self) -> bool:
@@ -55,13 +54,13 @@ class AgencyApp(TownApp):
     @property
     def root_pdf_modified(self) -> datetime | None:
         if self.root_pdf_exists:
-            return self.filestorage.getdetails('root.pdf').modified
+            return self.filestorage.getmodified('root.pdf')
         return None
 
     @property
     def people_xlsx_modified(self) -> datetime | None:
         if self.people_xlsx:
-            return self.filestorage.getdetails('people.xlsx').modified
+            return self.filestorage.getmodified('people.xlsx')
         return None
 
     @property
@@ -69,36 +68,30 @@ class AgencyApp(TownApp):
         result: bytes | None = None
         if self.filestorage.exists('root.pdf'):
             with self.filestorage.open('root.pdf', 'rb') as file:
-                # FS bug with mode=rb
-                result = file.read()  # type:ignore[assignment]
+                result = file.read()
         return result
 
-    # FIXME: asymmetric property
     @root_pdf.setter
     def root_pdf(self, value: SupportsRead[bytes] | bytes) -> None:
         with self.filestorage.open('root.pdf', 'wb') as file:
             if hasattr(value, 'read'):
                 value = value.read()
-            # FS bug with mode=wb
-            file.write(value)  # type:ignore
+            file.write(value)
 
     @property
     def people_xlsx(self) -> bytes | None:
         result: bytes | None = None
         if self.filestorage.exists('people.xlsx'):
             with self.filestorage.open('people.xlsx', 'rb') as file:
-                # FS bug with mode=rb
-                result = file.read()  # type:ignore[assignment]
+                result = file.read()
         return result
 
-    # FIXME: asymmetric property
     @people_xlsx.setter
     def people_xlsx(self, value: SupportsRead[bytes] | bytes) -> None:
         with self.filestorage.open('people.xlsx', 'wb') as file:
             if hasattr(value, 'read'):
                 value = value.read()
-            # FS bug with mode=wb
-            file.write(value)  # type:ignore
+            file.write(value)
 
     @property
     def pdf_class(self) -> type[AgencyPdfDefault]:

--- a/src/onegov/core/filestorage.py
+++ b/src/onegov/core/filestorage.py
@@ -49,7 +49,7 @@ class IllegalBackReference(ValueError):
         )
 
 
-_requires_normalization = re.compile(r'(^|/)\.\.($|/)|//').search
+_requires_normalization = re.compile(r'(^|/)\.\.?($|/)|//').search
 
 
 def normpath(path: str) -> str:
@@ -181,7 +181,18 @@ class Filestorage:
 
     def removetree(self, path: str) -> None:
         with self._lock:
-            shutil.rmtree(self.getsyspath(path))
+            sys_path = self.getsyspath(path)
+            if sys_path.rstrip('/') != self._root_path:
+                # simple case, since we don't need to preserve the root
+                shutil.rmtree(self.getsyspath(path))
+                return
+
+            with os.scandir(sys_path) as dir_iter:
+                for entry in dir_iter:
+                    if entry.is_dir(follow_symlinks=False):
+                        shutil.rmtree(entry.path)
+                    else:
+                        os.remove(entry.path)
 
     @overload
     def open(

--- a/src/onegov/core/filestorage.py
+++ b/src/onegov/core/filestorage.py
@@ -8,21 +8,300 @@ See :attr:`onegov.core.framework.Framework.filestorage` for more information.
 """
 from __future__ import annotations
 
-from fs.errors import IllegalBackReference
+import os
+import os.path
+import re
+import shutil
+
+from datetime import datetime, UTC
 from onegov.core.framework import Framework
 from onegov.core.crypto import random_token
 from onegov.core.utils import render_file
 from onegov.core.security import Public, Private
+from time import time
+from threading import RLock
 
 
-from typing import TYPE_CHECKING
+from typing import overload, Any, IO, Literal, Self, TYPE_CHECKING
 if TYPE_CHECKING:
+    import io
+    from _typeshed import (
+        OpenBinaryMode,
+        OpenBinaryModeReading,
+        OpenBinaryModeUpdating,
+        OpenBinaryModeWriting,
+        OpenTextMode,
+        StrOrBytesPath
+    )
     from .request import CoreRequest
 
 
 def random_filename() -> str:
     """ Returns a random filename that can't be guessed. """
     return random_token()
+
+
+class IllegalBackReference(ValueError):
+    """ Too many backrefs exist in a path. """
+    def __init__(self, path: str) -> None:
+        super().__init__(
+            f'path {path!r} contains back-references outside of filesystem'
+        )
+
+
+_requires_normalization = re.compile(r'(^|/)\.\.($|/)|//').search
+
+
+def normpath(path: str) -> str:
+    if path == '' or path == '/':
+        return path
+
+    if not _requires_normalization(path):
+        return path.rstrip('/')
+
+    components: list[str] = []
+    for component in path.split('/'):
+        if component == '..':
+            if not components:
+                raise IllegalBackReference(path)
+            components.pop()
+        elif component == '.' or component == '':
+            pass
+        else:
+            components.append(component)
+    normalized = '/'.join(components)
+    return '/' + normalized if path.startswith('/') else normalized
+
+
+class Filestorage:
+    """ A minimal implementation of ``fs``/``PyFilesystem``'s ``OSFS``
+    class, that can do everything we need in OneGov.
+
+    Since ``fs`` was no longer maintained and the maintained alternative
+    ``fsspec`` does not yet have type hints of any kind and we don't
+    really use anything other than ``OSFS`` in any of our deployments
+    this seemed like the most sensible solution.
+
+    We can always migrate to ``fsspec`` later, if we do end up needing
+    more control again.
+    """
+
+    def __init__(
+        self,
+        root_path: StrOrBytesPath,
+        create: bool = False,
+        create_mode: int = 0o777,
+        expand_vars: bool = True,
+    ) -> None:
+        self._lock = RLock()
+        self.root_path = root_path = os.fsdecode(root_path)
+        _root_path = root_path or '/'
+        if expand_vars:
+            _root_path = os.path.expandvars(_root_path)
+        self._root_path = os.path.normpath(
+            os.path.abspath(os.path.expanduser(_root_path))
+        )
+        if create:
+            os.makedirs(_root_path, mode=create_mode, exist_ok=True)
+        else:
+            if not os.path.isdir(_root_path):
+                raise RuntimeError('Missing filestorage root directory')
+
+    def hassyspath(self, path: str) -> bool:
+        return True
+
+    def validatepath(self, path: str) -> str:
+        if '\0' in path:
+            raise ValueError('Invalid path')
+
+        # TODO: Do we want to validate max path length?
+        return '/' + normpath(path).lstrip('/')
+
+    def getsyspath(self, path: str) -> str:
+        return os.path.join(
+            self._root_path,
+            self.validatepath(path).lstrip('/').replace('/', os.sep)
+        )
+
+    def hasurl(self, path: str) -> bool:
+        return True
+
+    def geturl(self, path: str) -> str:
+        return 'file://' + self.getsyspath(path)
+
+    def exists(self, path: str) -> bool:
+        return os.path.exists(self.getsyspath(path))
+
+    def isdir(self, path: str) -> bool:
+        return os.path.isdir(self.getsyspath(path))
+
+    def isfile(self, path: str) -> bool:
+        return os.path.isfile(self.getsyspath(path))
+
+    def opendir(self, path: str) -> Self:
+        subfs = type(self)(self.getsyspath(path))
+        # de-normalize the displayed root path
+        # but ensure we don't drop a required separator
+        subfs.root_path.replace(
+            self._root_path,
+            self.root_path if self.root_path.endswith(os.sep)
+            else self.root_path + os.sep
+        )
+        return subfs
+
+    def makedir(self, path: str, recreate: bool = False) -> Self:
+        sys_path = self.getsyspath(path)
+        if not (recreate and os.path.isdir(sys_path)):
+            os.mkdir(sys_path)
+        return self.opendir(path)
+
+    def listdir(self, path: str) -> list[str]:
+        return [
+            os.fsdecode(name)
+            for name in os.listdir(os.fsencode(self.getsyspath(path)))
+        ]
+
+    def create(self, path: str) -> bool:
+        with self._lock:
+            sys_path = self.getsyspath(path)
+            if os.path.exists(sys_path):
+                return False
+
+            with open(sys_path, mode='wb'):
+                return True
+
+    def touch(self, path: str) -> None:
+        with self._lock:
+            now = time()
+            if not self.create(path):
+                os.utime(self.getsyspath(path), (now, now))
+
+    def remove(self, path: str) -> None:
+        os.remove(self.getsyspath(path))
+
+    def removetree(self, path: str) -> None:
+        with self._lock:
+            shutil.rmtree(self.getsyspath(path))
+
+    @overload
+    def open(
+        self,
+        path: str,
+        mode: OpenTextMode = 'r',
+        buffering: int = -1,
+        encoding: str | None = None,
+        errors: str | None = None,
+        newline: str = '',
+    ) -> io.TextIOWrapper: ...
+    @overload
+    def open(
+        self,
+        path: str,
+        mode: OpenBinaryMode,
+        buffering: Literal[0],
+        encoding: None = None,
+        errors: None = None,
+        newline: str = '',
+    ) -> io.FileIO: ...
+    @overload
+    def open(
+        self,
+        path: str,
+        mode: OpenBinaryModeUpdating,
+        buffering: Literal[-1, 1] = -1,
+        encoding: None = None,
+        errors: None = None,
+        newline: str = '',
+    ) -> io.BufferedRandom: ...
+    @overload
+    def open(
+        self,
+        path: str,
+        mode: OpenBinaryModeWriting,
+        buffering: Literal[-1, 1] = -1,
+        encoding: None = None,
+        errors: None = None,
+        newline: str = '',
+    ) -> io.BufferedWriter: ...
+    @overload
+    def open(
+        self,
+        path: str,
+        mode: OpenBinaryModeReading,
+        buffering: Literal[-1, 1] = -1,
+        encoding: None = None,
+        errors: None = None,
+        newline: str = '',
+    ) -> io.BufferedReader: ...
+    @overload
+    def open(
+        self,
+        path: str,
+        mode: OpenBinaryMode,
+        buffering: int = -1,
+        encoding: None = None,
+        errors: None = None,
+        newline: str = '',
+    ) -> IO[bytes]: ...
+    @overload
+    def open(
+        self,
+        path: str,
+        mode: str,
+        buffering: int = -1,
+        encoding: str | None = None,
+        errors: str | None = None,
+        newline: str = '',
+    ) -> IO[Any]: ...
+
+    def open(
+        self,
+        path: str,
+        mode: str = 'r',
+        buffering: int = -1,
+        encoding: str | None = None,
+        errors: str | None = None,
+        newline: str = '',
+    ) -> IO[Any]:
+
+        is_binary = 'b' in mode
+        return open(
+            self.getsyspath(path),
+            mode=mode,
+            buffering=buffering,
+            encoding=None if is_binary else (encoding or 'utf-8'),
+            errors=errors,
+            newline=None if is_binary else newline,
+        )
+
+    def writebytes(self, path: str, contents: bytes) -> None:
+        with self.open(path, 'wb') as fp:
+            fp.write(contents)
+
+    def readbytes(self, path: str) -> bytes:
+        with self.open(path, 'rb') as fp:
+            return fp.read()
+
+    def writetext(self, path: str, contents: str) -> None:
+        with self.open(path, 'wt') as fp:
+            fp.write(contents)
+
+    def readtext(self, path: str) -> str:
+        with self.open(path, 'rt') as fp:
+            return fp.read()
+
+    # NOTE: This is not part of the FS interface, but modified is the
+    #       only info we ever access in our code, so we just added a
+    #       helper for that instead of implenting the whole info thing
+    def getmodified(self, path: str) -> datetime:
+        stat = os.stat(self.getsyspath(path))
+        return datetime.fromtimestamp(stat.st_mtime, UTC)
+
+    def __repr__(self) -> str:
+        return f'Filestorage({self.root_path!r})'
+
+    def __str__(self) -> str:
+        return f"<Filestorage '{self.root_path}'>"
 
 
 class FilestorageFile:

--- a/src/onegov/core/framework.py
+++ b/src/onegov/core/framework.py
@@ -53,7 +53,6 @@ from onegov.core import cache, log, utils
 from onegov.core import directives
 from onegov.core.crypto import stored_random_token
 from onegov.core.datamanager import FileDataManager
-from onegov.core.filestorage import Filestorage
 from onegov.core.mail import prepare_email
 from onegov.core.orm import (
     Base, SessionManager, debug, DB_CONNECTION_ERRORS)
@@ -84,6 +83,7 @@ if TYPE_CHECKING:
     from webob import Response
 
     from .analytics import AnalyticsProvider
+    from .filestorage import Filestorage
     from .layout import Layout
     from .mail import Attachment
     from .metadata import Metadata
@@ -145,6 +145,7 @@ class Framework(
     #       it makes sense to use this cache on its own
     schema_cache: dict[str, Any]
     _all_schema_caches: dict[str, Any]
+    _global_file_storage: Filestorage | None
 
     @property
     def version(self) -> str:
@@ -556,7 +557,7 @@ class Framework(
             assert cfg['filestorage'] == 'fs.osfs.OSFS', (
                 'We currently only support OS based filesystem support'
             )
-            filestorage_class = Filestorage
+            filestorage_class = self.modules.filestorage.Filestorage
             filestorage_options = cfg.get('filestorage_options', {})
 
             # legacy support for pyfilesystem 1.x parameters

--- a/src/onegov/core/framework.py
+++ b/src/onegov/core/framework.py
@@ -53,6 +53,7 @@ from onegov.core import cache, log, utils
 from onegov.core import directives
 from onegov.core.crypto import stored_random_token
 from onegov.core.datamanager import FileDataManager
+from onegov.core.filestorage import Filestorage
 from onegov.core.mail import prepare_email
 from onegov.core.orm import (
     Base, SessionManager, debug, DB_CONNECTION_ERRORS)
@@ -61,7 +62,6 @@ from onegov.core.orm.observer import ScopedPropertyObserver
 from onegov.core.request import CoreRequest
 from onegov.core.utils import batched, PostThread
 from onegov.server import Application as ServerApplication
-from onegov.server.utils import load_class
 from operator import itemgetter
 from psycopg import OperationalError as PostgresOperationalError
 from purl import URL
@@ -76,7 +76,6 @@ if TYPE_CHECKING:
     from _typeshed.wsgi import WSGIApplication, WSGIEnvironment, StartResponse
     from collections.abc import Callable, Iterable
     from email.headerregistry import Address
-    from fs.base import FS, SubFS
     from gettext import GNUTranslations
     from morepath.request import Request
     from morepath.settings import SettingRegistry
@@ -554,7 +553,10 @@ class Framework(
             return
 
         if 'filestorage' in cfg:
-            filestorage_class = load_class(cfg['filestorage'])
+            assert cfg['filestorage'] == 'fs.osfs.OSFS', (
+                'We currently only support OS based filesystem support'
+            )
+            filestorage_class = Filestorage
             filestorage_options = cfg.get('filestorage_options', {})
 
             # legacy support for pyfilesystem 1.x parameters
@@ -1356,11 +1358,8 @@ class Framework(
         )
 
     @property
-    def filestorage(self) -> SubFS[FS] | None:
+    def filestorage(self) -> Filestorage | None:
         """ A filestorage object bound to the current application.
-        Based on this nifty module:
-
-        `<https://docs.pyfilesystem.org/en/latest/>`_
 
         The file storage returned is guaranteed to be independent of other
         applications (the scope is the application_id, not just the class).
@@ -1371,11 +1370,6 @@ class Framework(
 
         Therefore, the urls for the file storage should always be acquired
         through :meth:`onegov.core.request.CoreRequest.filestorage_link`.
-
-        The backend is configured through :meth:`configure_application`.
-
-        For a list of methods available on the resulting object, consult this
-        list: `<https://docs.pyfilesystem.org/en/latest/interface.html>`_.
 
         If no filestorage is available, this returns None.
         See :attr:`self.has_filestorage`.
@@ -1410,7 +1404,7 @@ class Framework(
         return utils.makeopendir(self._global_file_storage, self.schema)
 
     @property
-    def themestorage(self) -> SubFS[FS] | None:
+    def themestorage(self) -> Filestorage | None:
         """ A storage object meant for themes, shared by all applications.
 
         Only use this for theming, nothing else!

--- a/src/onegov/core/theme.py
+++ b/src/onegov/core/theme.py
@@ -54,7 +54,7 @@ from onegov.core.filestorage import FilestorageFile
 from typing import Any, TYPE_CHECKING
 if TYPE_CHECKING:
     from collections.abc import Sequence
-    from fs.base import FS, SubFS
+    from onegov.core.filestorage import Filestorage
 
 
 class Theme:
@@ -132,7 +132,7 @@ def get_filename(theme: Theme, options: dict[str, Any] | None = None) -> str:
 
 
 def compile(
-    storage: FS | SubFS[FS],
+    storage: Filestorage,
     theme: Theme,
     options: dict[str, Any] | None = None,
     force: bool = False

--- a/src/onegov/core/utils.py
+++ b/src/onegov/core/utils.py
@@ -49,11 +49,11 @@ from typing import overload, Any, TYPE_CHECKING
 if TYPE_CHECKING:
     from _typeshed import SupportsRichComparison
     from collections.abc import Callable, Collection, Iterator, Mapping
-    from fs.base import FS, SubFS
     from re import Match
     from sqlalchemy.orm import InstrumentedAttribute, Session
     from types import ModuleType
     from webob import Response
+    from .filestorage import Filestorage
     from .request import CoreRequest
     from .types import FileDict, LaxFileDict
 
@@ -785,7 +785,7 @@ def get_unique_hstore_keys(
     return set(keys) if keys else set()
 
 
-def makeopendir(fs: FS, directory: str) -> SubFS[FS]:
+def makeopendir(fs: Filestorage, directory: str) -> Filestorage:
     """ Creates and opens the given directory in the given PyFilesystem. """
 
     if not fs.isdir(directory):

--- a/src/onegov/election_day/cli.py
+++ b/src/onegov/election_day/cli.py
@@ -188,9 +188,8 @@ def generate_archive() -> Processor:
         if not archive_zip:
             abort('generate_archive returned None.')
 
-        archive_filesize = archive_generator.archive_dir.getinfo(
-            archive_zip, namespaces=['details']).size
-
+        archive_stat = os.stat(archive_generator.archive_system_path)
+        archive_filesize = archive_stat.st_size
         if archive_filesize == 0:
             click.secho('Generated archive is empty', fg='red')
         else:

--- a/src/onegov/election_day/layouts/default.py
+++ b/src/onegov/election_day/layouts/default.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from babel import Locale
-from fs.errors import ResourceNotFound
 from functools import cached_property
 from onegov.core.i18n import SiteLocale
 from onegov.core.layout import ChameleonLayout
@@ -283,13 +282,8 @@ class DefaultLayout(ChameleonLayout):
 
     @property
     def last_archive_modification(self) -> datetime | None:
-        try:
-            filestorage = self.request.app.filestorage
-            assert filestorage is not None
-            filestorage_info = filestorage.getinfo(
-                'archive/zip/archive.zip', namespaces='details'
-            )
-            return filestorage_info.modified
-        except ResourceNotFound:
-            pass
-        return None
+        filestorage = self.request.app.filestorage
+        assert filestorage is not None
+        if not filestorage.isfile('archive/zip/archive.zip'):
+            return None
+        return filestorage.getmodified('archive/zip/archive.zip')

--- a/src/onegov/election_day/utils/archive_generator.py
+++ b/src/onegov/election_day/utils/archive_generator.py
@@ -1,13 +1,10 @@
 from __future__ import annotations
 
+import os
+import os.path
+
 from collections import defaultdict
-from fs import path
-from fs.copy import copy_dir
-from fs.copy import copy_file
-from fs.errors import NoSysPath
-from fs.osfs import OSFS
-from fs.tempfs import TempFS
-from fs.zipfs import WriteZipFS
+from glob import iglob
 from onegov.core.csv import convert_list_of_dicts_to_csv
 from onegov.core.utils import module_path
 from onegov.election_day.formats import export_internal
@@ -17,6 +14,8 @@ from onegov.election_day.models import ElectionCompound
 from onegov.election_day.models import ProporzElection
 from onegov.election_day.models import Vote
 from sqlalchemy import desc
+from shutil import copy2, make_archive
+from tempfile import TemporaryDirectory
 
 
 from typing import Any
@@ -24,8 +23,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from collections.abc import Collection
     from collections.abc import Iterable
-    from fs.subfs import FS
-    from fs.subfs import SubFS
+    from onegov.core.filestorage import Filestorage
     from onegov.election_day import ElectionDayApp
 
     type Entity = Election | ElectionCompound | Vote
@@ -38,18 +36,16 @@ class ArchiveGenerator:
     This creates a bunch of csv files, which are zipped and the path to
     the zip is returned.
     """
-    archive_dir: SubFS[FS]
+    archive_dir: Filestorage
 
     def __init__(self, app: ElectionDayApp):
         assert app.filestorage is not None
         self.app = app
         self.session = app.session()
         self.archive_dir = app.filestorage.makedir('archive', recreate=True)
-        self.temp_fs = TempFS()
-        self.archive_parent_dir = 'zip'
         self.MAX_FILENAME_LENGTH = 60
 
-    def generate_csv(self) -> None:
+    def generate_csv(self, temp_dir: str) -> bool:
         """
         Creates csv files with a directory structure like this::
 
@@ -66,8 +62,11 @@ class ArchiveGenerator:
                 └── 2022
                     └── vote1.csv
 
+        Returns whether or not any files have been written
+
         """
 
+        result = False
         votes = self.all_counted_votes_with_results()
         entities: Iterable[tuple[str, Collection[Entity]]] = [
             ('votes', votes),
@@ -80,19 +79,25 @@ class ArchiveGenerator:
             grouped_by_year = self.group_by_year(entity)
 
             for yearly_package in grouped_by_year:
+                result = True
                 year = str(yearly_package[0].date.year)
-                year_dir = f'{entity_name}/{year}'
-                self.temp_fs.makedirs(year_dir, recreate=True)
+                year_dir = os.path.join(temp_dir, entity_name, year)
+                os.makedirs(year_dir, exist_ok=True)
                 for item in yearly_package:
                     self.export_item(item, year_dir)
 
         # Additionally, create 'flat csv' containing all votes in a single file
         if votes:
+            result = True
             filename = 'all_votes.csv'
-            combined_path = path.combine('votes', filename)
-            with self.temp_fs.open(combined_path, 'w') as f:
+            votes_dir = os.path.join(temp_dir, 'votes')
+            os.makedirs(votes_dir, exist_ok=True)
+            combined_path = os.path.join(votes_dir, filename)
+            with open(combined_path, 'w') as f:
                 votes_exports = self.get_all_rows_for_votes(votes)
                 f.write(convert_list_of_dicts_to_csv(votes_exports))
+
+        return result
 
     def get_all_rows_for_votes(
         self,
@@ -132,7 +137,7 @@ class ArchiveGenerator:
             groups[entity.date.year].append(entity)
         return list(groups.values())
 
-    def zip_dir(self, base_dir: SubFS[FS]) -> str | None:
+    def zip_dir(self, temp_dir: str) -> str:
         """Recursively zips a directory (base_dir).
 
         :param base_dir: is a directory in a temporary file system.
@@ -142,34 +147,14 @@ class ArchiveGenerator:
         :returns path to the zipfile or None if base_dir doesn't exist
             or is empty.
         """
-        self.archive_dir.makedir(self.archive_parent_dir, recreate=True)
-        zip_path = f'{self.archive_parent_dir}/archive.zip'
-        self.archive_dir.create(zip_path)
-
-        with (
-            self.archive_dir.open(zip_path, mode='wb') as file,
-            WriteZipFS(file) as zip_filesystem  # type:ignore[arg-type]
-        ):
-            counts = base_dir.glob('**/*.csv').count()
-            if counts.files != 0:
-                if len(base_dir.listdir('/')) != 0:
-                    for entity in base_dir.listdir('/'):
-                        if base_dir.isdir(entity):
-                            copy_dir(
-                                src_fs=base_dir,
-                                src_path=entity,
-                                dst_fs=zip_filesystem,
-                                dst_path=entity,
-                            )
-                        if base_dir.isfile(entity):
-                            copy_file(
-                                src_fs=base_dir,
-                                src_path=entity,
-                                dst_fs=zip_filesystem,
-                                dst_path=entity,
-                            )
-                    return zip_path
-        return None
+        self.archive_dir.makedir('zip', recreate=True)
+        make_archive(
+            self.archive_system_path.removesuffix('.zip'),
+            'zip',
+            temp_dir,
+            '.'
+        )
+        return self.archive_path
 
     def all_counted_votes_with_results(self) -> list[Vote]:
         query = self.session.query(Vote).order_by(desc(Vote.date))
@@ -201,26 +186,19 @@ class ArchiveGenerator:
         ]
 
     @property
-    def archive_system_path(self) -> str | None:
-        zip_path = f'{self.archive_parent_dir}/archive.zip'
-        # syspath may not be available, depending on the actual filestorage
-        try:
-            sys_path = self.archive_dir.getsyspath(zip_path)
-            return sys_path
-        except NoSysPath:
-            return None
+    def archive_path(self) -> str:
+        return 'zip/archive.zip'
 
-    def include_docs(self) -> None:
+    @property
+    def archive_system_path(self) -> str:
+        return self.archive_dir.getsyspath(self.archive_path)
+
+    def include_docs(self, temp_dir: str) -> None:
         api = module_path('onegov.election_day', 'static/docs/api')
-        native_fs = OSFS(api)
-
-        for match in native_fs.glob('**/open_data*.md'):
-            copy_file(
-                src_fs=native_fs,
-                src_path=match.path,
-                dst_fs=self.temp_fs,
-                dst_path=match.path,
-            )
+        for path in iglob('**/open_data*.md', root_dir=api, recursive=True):
+            dst = os.path.join(temp_dir, path)
+            os.makedirs(os.path.dirname(dst), exist_ok=True)
+            copy2(os.path.join(api, path), dst)
 
     def export_item(self, item: Entity, dir: str) -> None:
         locales = sorted(self.app.locales)
@@ -229,26 +207,27 @@ class ArchiveGenerator:
 
         # results
         filename = item.id[:self.MAX_FILENAME_LENGTH] + '.csv'
-        combined_path = path.combine(dir, filename)
+        combined_path = os.path.join(dir, filename)
         rows = export_internal(item, locales)
-        with self.temp_fs.open(combined_path, 'w') as f:
+        with open(combined_path, 'w') as f:
             f.write(convert_list_of_dicts_to_csv(rows))
 
         # party results
         if getattr(item, 'has_party_results', False):
             assert isinstance(item, (ProporzElection, ElectionCompound))
             filename = item.id[:self.MAX_FILENAME_LENGTH + 8] + '-parties.csv'
-            combined_path = path.combine(dir, filename)
+            combined_path = os.path.join(dir, filename)
             rows = export_parties_internal(
                 item,
                 locales,
                 default_locale=default_locale,
             )
-            with self.temp_fs.open(combined_path, 'w') as f:
+            with open(combined_path, 'w') as f:
                 f.write(convert_list_of_dicts_to_csv(rows))
 
     def generate_archive(self) -> str | None:
-        self.generate_csv()
-        self.include_docs()
-        root = self.temp_fs.opendir('/')
-        return self.zip_dir(root)
+        with TemporaryDirectory() as temp_dir:
+            if not self.generate_csv(temp_dir):
+                return None
+            self.include_docs(temp_dir)
+            return self.zip_dir(temp_dir)

--- a/src/onegov/election_day/views/archive.py
+++ b/src/onegov/election_day/views/archive.py
@@ -1,10 +1,7 @@
 from __future__ import annotations
 
 from operator import itemgetter
-
 from morepath import redirect
-
-from fs.errors import ResourceNotFound
 from morepath.request import Response
 from onegov.election_day import ElectionDayApp
 from onegov.election_day.collections import (
@@ -367,7 +364,6 @@ def view_archive_download(
         raise HTTPNotFound()
     try:
         zip_dir = filestorage.opendir('archive/zip')
-        content = None
         with zip_dir.open('archive.zip', mode='rb') as zipfile:
             content = zipfile.read()
         if not content:
@@ -377,5 +373,5 @@ def view_archive_download(
             content_type='application/zip',
             content_disposition='inline; filename=Archive.zip'
         )
-    except (FileNotFoundError, ResourceNotFound) as exception:
+    except FileNotFoundError as exception:
         raise HTTPNotFound() from exception

--- a/src/onegov/winterthur/app.py
+++ b/src/onegov/winterthur/app.py
@@ -187,12 +187,10 @@ class WinterthurApp(OrgApp):
                     (path / 'preview.png').open('rb') as input,
                     fs.open(filename, 'wb') as output
                 ):
-                    # NOTE: Bug in type hints of FS
-                    output.write(input.read())  # type:ignore
+                    output.write(input.read())
 
         with fs.open(filename, 'rb') as input:
-            # NOTE: Bug in type hints of FS
-            return BytesIO(input.read())  # type:ignore
+            return BytesIO(input.read())
 
 
 @WinterthurApp.tween_factory()

--- a/tests/onegov/core/test_filestorage.py
+++ b/tests/onegov/core/test_filestorage.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 import morepath
 import os.path
+import pytest
 
 from onegov.core.framework import Framework
 from onegov.core import utils
+from onegov.core.filestorage import Filestorage, IllegalBackReference
 from webtest import TestApp as Client
 
 
@@ -12,6 +14,75 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from onegov.core.request import CoreRequest
     from webob import Response
+
+
+def test_validatepath(temporary_directory: str) -> None:
+    filestorage = Filestorage(temporary_directory)
+
+    with pytest.raises(ValueError, match=r'Invalid path'):
+        filestorage.validatepath('\0null_byte.txt')
+
+    with pytest.raises(IllegalBackReference):
+        filestorage.validatepath('../cannot_escape')
+
+    assert filestorage.validatepath(
+        'but/can/../../mess/../around'
+    ) == '/around'
+
+    assert filestorage.validatepath('.') == '/'
+
+
+def test_create(temporary_directory: str) -> None:
+    filestorage = Filestorage(temporary_directory)
+    assert filestorage.create('foo')
+    modified = filestorage.getmodified('foo')
+    assert not filestorage.create('foo')
+    assert filestorage.getmodified('foo') == modified
+
+
+def test_touch(temporary_directory: str) -> None:
+    filestorage = Filestorage(temporary_directory)
+    assert not filestorage.exists('foo')
+    filestorage.touch('foo')
+    assert filestorage.exists('foo')
+    modified = filestorage.getmodified('foo')
+    filestorage.touch('foo')
+    assert filestorage.getmodified('foo') > modified
+
+
+def test_repr_and_str(temporary_directory: str) -> None:
+    filestorage = Filestorage(temporary_directory)
+    assert repr(temporary_directory) in repr(filestorage)
+    assert temporary_directory in str(filestorage)
+    assert str(filestorage) != repr(filestorage)
+
+
+def test_removetree(temporary_directory: str) -> None:
+    filestorage = Filestorage(temporary_directory)
+    foo = filestorage.makedir('foo')
+    bar = filestorage.makedir('bar')
+    baz = foo.makedir('baz')
+    filestorage.writetext('root.txt', 'root')
+    foo.writetext('foo.txt', 'foo')
+    bar.writetext('bar.txt', 'bar')
+    baz.writetext('baz.txt', 'baz')
+
+    assert set(filestorage.listdir('.')) == {'root.txt', 'foo', 'bar'}
+    assert set(filestorage.listdir('foo')) == {'foo.txt', 'baz'}
+    assert set(filestorage.listdir('bar')) == {'bar.txt'}
+    assert set(filestorage.listdir('foo/baz')) == {'baz.txt'}
+
+    filestorage.removetree('bar')
+    assert not filestorage.exists('bar')
+    assert set(filestorage.listdir('.')) == {'root.txt', 'foo'}
+    assert set(filestorage.listdir('foo')) == {'foo.txt', 'baz'}
+    assert set(filestorage.listdir('foo/baz')) == {'baz.txt'}
+
+    filestorage.removetree('.')
+    assert not filestorage.listdir('.')
+    assert not filestorage.exists('foo')
+    assert not filestorage.exists('bar')
+    assert not filestorage.exists('root.txt')
 
 
 def test_independence(temporary_directory: str) -> None:
@@ -120,6 +191,14 @@ def test_filestorage(temporary_directory: str, redis_url: str) -> None:
     client = Client(app)
     assert client.get('/?file=test.txt').text == ''
     assert client.get('/?file=asdf.txt').text == ''
+
+    assert client.get('/files/test.txt', expect_errors=True).status_code == 404
+
+    # we can't access files from the other schema via backreferences
+    assert client.get(
+        '/files/../foo/test.txt',
+        expect_errors=True
+    ).status_code == 404
 
     app.set_application_id('tests/foo')
     assert client.get('/files/readme').status_code == 200

--- a/tests/onegov/election_day/test_cli.py
+++ b/tests/onegov/election_day/test_cli.py
@@ -412,8 +412,8 @@ def test_generate_archive_total_package(
 
     assert run_command(
         cfg_path, 'govikon', ['generate-archive']).exit_code == 1
-    assert os.path.exists(archive_path)
-    assert "archive.zip" in os.listdir(archive_path)
+    # NOTE: We no longer create empty archives
+    assert not os.path.exists(archive_path)
 
     add_vote(1, session_manager)
 

--- a/tests/onegov/election_day/utils/test_archive_generator.py
+++ b/tests/onegov/election_day/utils/test_archive_generator.py
@@ -2,22 +2,18 @@ from __future__ import annotations
 
 from collections import Counter
 from datetime import date
-from fs.copy import copy_file
-from fs.osfs import OSFS
-from fs.tempfs import TempFS
-from fs.walk import Walker
-from fs.zipfs import ReadZipFS
-from onegov.core.utils import module_path
 from onegov.election_day.models import ArchivedResult
 from onegov.election_day.models import BallotResult
 from onegov.election_day.models import Municipality
 from onegov.election_day.models import Vote
 from onegov.election_day.utils import add_local_results
 from onegov.election_day.utils.archive_generator import ArchiveGenerator
+from zipfile import ZipFile, Path as ZipPath
 
 
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:
+    from pathlib import Path
     from ..conftest import ImportTestDatasets, TestApp
 
 
@@ -127,76 +123,68 @@ def test_archive_generation_from_scratch(election_day_app_zg: TestApp) -> None:
     zip_path = archive_generator.generate_archive()
     assert zip_path is not None
 
-    with archive_generator.archive_dir.open(zip_path, mode="rb") as fi:
-        with ReadZipFS(fi) as zip_fs:
-            votes_dir = zip_fs.listdir("votes")
-            years = [str(year) for year in votes_dir]
-            assert len(zip_fs.listdir("votes")) == 3
-            assert {"all_votes.csv", "2022", "2013"} == set(years)
+    with (
+        archive_generator.archive_dir.open(zip_path, mode="rb") as fi,
+        ZipFile(fi) as zf
+    ):
+        path = ZipPath(zf)
+        assert {p.name for p in (path / 'votes').iterdir()} == {
+            "all_votes.csv", "2022", "2013"
+        }
 
-            votes = zip_fs.opendir("votes")
-            counter: Counter[str] = Counter()
-            total_bytes_csv = 0
-            walker = Walker()
-            for _, _, files in walker.walk(
-                    votes, namespaces=["basic", "details"]
-            ):
-                for file in files:
-                    counter[file.name] += 1
+        counter: Counter[str] = Counter()
+        total_bytes_csv = 0
+        for info in zf.infolist():
+            if info.is_dir():
+                continue
+            if not info.filename.startswith('votes/'):
+                continue
 
-                total_bytes_csv += sum(info.size for info in files)
-            # We expect 3 csv because we have 3 votes,
-            # Plus a csv that contains everything = 4
-            assert sum(counter.values()) == 4
-            assert total_bytes_csv > 10  # check to ensure files are not empty
+            counter[info.filename.rsplit('/', 1)[-1]] += 1
+            total_bytes_csv += info.file_size
+
+        # We expect 3 csv because we have 3 votes,
+        # Plus a csv that contains everything = 4
+        assert sum(counter.values()) == 4
+        assert total_bytes_csv > 10  # check to ensure files are not empty
 
 
-def test_zipping_multiple_directories(election_day_app_zg: TestApp) -> None:
+def test_zipping_multiple_directories(
+    election_day_app_zg: TestApp,
+    tmp_path: Path
+) -> None:
     archive_generator = ArchiveGenerator(election_day_app_zg)
-    tmp_fs = TempFS()
-    empty_dir = tmp_fs.opendir("/")
 
-    zip_path = archive_generator.zip_dir(empty_dir)
-    # empty directory should not create a zip
-    assert zip_path is None
+    root = tmp_path / 'test1'
+    root.mkdir()
+    votes = (root / 'votes')
+    votes.mkdir()
+    elections = (root / 'elections')
+    elections.mkdir()
+    for year in ('2020', '2021', '2022'):
+        year_dir = (votes / year)
+        year_dir.mkdir()
+        (year_dir / 'testfile-votes.csv').touch()
+    (elections / '2022').mkdir()
+    (elections / '2022' / 'testfile-elections.csv').touch()
+    zip_path = archive_generator.zip_dir(str(root))
 
-    tmp_fs.makedir("/test1")
-    root = tmp_fs.opendir("/test1")
-    root.makedir("votes")
-    root.makedir("elections")
-    for year in {"2020", "2021", "2022"}:
-        root.makedir(f"votes/{year}")
-    root.makedir("elections/2022")
-    # archive should not be generated
-    assert zip_path is None
-    for year in {"2020", "2021", "2022"}:
-        root.create(f"votes/{year}/testfile-votes.csv", wipe=True)
-    root.create("elections/2022/testfile-elections.csv", wipe=True)
-    zip_path = archive_generator.zip_dir(root)
-    # unless it actually contains .csv files
-    assert zip_path is not None
+    archive_generator.include_docs(str(root))
+    zip_path = archive_generator.zip_dir(str(root))
 
-    api = module_path("onegov.election_day", "static/docs/api")
-    native_fs = OSFS(api)
-    for match in native_fs.glob("**/open_data*.md"):
-        copy_file(
-            src_fs=native_fs,
-            src_path=match.path,
-            dst_fs=root,
-            dst_path=match.path,
-        )
+    with (
+        archive_generator.archive_dir.open(zip_path, mode="rb") as fi,
+        ZipFile(fi) as zf
+    ):
+        additional_files = [
+            info
+            for info in zf.infolist()
+            if info.filename.endswith('.md')
+        ]
 
-    zip_path = archive_generator.zip_dir(root)
-    assert zip_path is not None
-
-    with archive_generator.archive_dir.open(zip_path, mode="rb") as fi:
-        with ReadZipFS(fi) as zip_fs:
-            additional_files = (match for match in zip_fs.glob(
-                "*.md", namespaces=["details"]))
-
-            assert len(list(additional_files)) != 0
-            for zip_path in additional_files:
-                assert zip_path.info.size > 100
+        assert len(additional_files) != 0
+        for info in additional_files:
+            assert info.file_size > 100
 
 
 def test_long_filenames_are_truncated(election_day_app_zg: TestApp) -> None:
@@ -232,14 +220,15 @@ def test_long_filenames_are_truncated(election_day_app_zg: TestApp) -> None:
 
     zip_path = archive_generator.generate_archive()
     assert zip_path is not None
-    with archive_generator.archive_dir.open(zip_path, mode="rb") as fi:
-        with ReadZipFS(fi) as zip_fs:
-            csv = [csv for csv in zip_fs.scandir("votes/2022",
-                                                 namespaces=["basic"])]
-            first_file = csv[0]
-            filename = first_file.name
-            assert "bundesbeschluss-vom-28-september" in filename
-            assert len(filename) <= archive_generator.MAX_FILENAME_LENGTH + 4
+    with (
+        archive_generator.archive_dir.open(zip_path, mode="rb") as fi,
+        ZipFile(fi) as zf
+    ):
+        path = ZipPath(zf)
+        first_file = next((path / 'votes' / '2022').iterdir())
+        filename = first_file.name
+        assert "bundesbeschluss-vom-28-september" in filename
+        assert len(filename) <= archive_generator.MAX_FILENAME_LENGTH + 4
 
 
 def test_election_generation(
@@ -276,20 +265,14 @@ def test_election_generation(
     archive_generator = ArchiveGenerator(election_day_app_zg)
     zip_path = archive_generator.generate_archive()
     assert zip_path is not None
-    with archive_generator.archive_dir.open(zip_path, mode="rb") as fi:
-        with ReadZipFS(fi) as zip_fs:
-            top_level_dir = zip_fs.listdir(".")
-            assert "elections" in top_level_dir
-
-            elections = zip_fs.opendir("elections")
-            years = {year for year in elections.listdir(".")}
-            assert years == {"2015"}
-
-            files = {
-                csv.name for csv
-                in zip_fs.scandir("elections/2015", namespaces=["basic"])
-            }
-            assert files == {
-                'proporz_internal_nationalratswahlen-2015.csv',
-                'proporz_internal_nationalratswahlen-2015-parties.csv'
-            }
+    with (
+        archive_generator.archive_dir.open(zip_path, mode="rb") as fi,
+        ZipFile(fi) as zf
+    ):
+        path = ZipPath(zf)
+        assert 'elections' in [p.name for p in path.iterdir()]
+        assert {p.name for p in (path / 'elections').iterdir()} == {'2015'}
+        assert {p.name for p in (path / 'elections' / '2015').iterdir()} == {
+            'proporz_internal_nationalratswahlen-2015.csv',
+            'proporz_internal_nationalratswahlen-2015-parties.csv'
+        }

--- a/tests/onegov/election_day/views/test_views.py
+++ b/tests/onegov/election_day/views/test_views.py
@@ -403,7 +403,7 @@ def test_view_pdf(election_day_app_zg: TestApp) -> None:
     assert election_day_app_zg.filestorage is not None
     election_day_app_zg.filestorage.makedir('pdf')
     with election_day_app_zg.filestorage.open('pdf/test.pdf', 'wb') as f:
-        f.write(pdf)  # type: ignore[arg-type]
+        f.write(pdf)
 
     filenames = []
     with patch('onegov.election_day.layouts.vote.pdf_filename',
@@ -499,7 +499,7 @@ def test_view_svg(election_day_app_zg: TestApp) -> None:
     assert election_day_app_zg.filestorage is not None
     election_day_app_zg.filestorage.makedir('svg')
     with election_day_app_zg.filestorage.open('svg/test.svg', 'wb') as f:
-        f.write(svg)  # type: ignore[arg-type]
+        f.write(svg)
 
     filenames = []
     with patch('onegov.election_day.layouts.vote.svg_filename',

--- a/tests/onegov/org/test_layout.py
+++ b/tests/onegov/org/test_layout.py
@@ -22,6 +22,7 @@ from typing import Any, TYPE_CHECKING
 if TYPE_CHECKING:
     from onegov.core.types import RenderData
     from onegov.org.request import OrgRequest
+    from pathlib import Path
     from sqlalchemy.orm import Session
 
 
@@ -167,7 +168,11 @@ def test_page_layout_breadcrumbs(session: Session) -> None:
     assert links[2].attrs['href'] == 'grandma/ma'
 
 
-def test_template_layout(postgres_dsn: str, redis_url: str) -> None:
+def test_template_layout(
+    postgres_dsn: str,
+    redis_url: str,
+    tmp_path: Path,
+) -> None:
 
     class Mock:
         pass
@@ -217,7 +222,8 @@ def test_template_layout(postgres_dsn: str, redis_url: str) -> None:
     app.namespace = 'tests'
     app.configure_application(
         dsn=postgres_dsn,
-        filestorage='fs.memoryfs.MemoryFS',
+        filestorage='fs.osfs.OSFS',
+        filestorage_options={'root_path': tmp_path},
         enable_elasticsearch=False,
         depot_backend='depot.io.memory.MemoryFileStorage',
         redis_url=redis_url,

--- a/tests/onegov/town6/test_layout.py
+++ b/tests/onegov/town6/test_layout.py
@@ -19,6 +19,7 @@ from typing import Any, TYPE_CHECKING
 if TYPE_CHECKING:
     from onegov.core.types import RenderData
     from onegov.town6.request import TownRequest
+    from pathlib import Path
     from sqlalchemy.orm import Session
 
 
@@ -166,7 +167,11 @@ def test_page_layout_breadcrumbs(session: Session) -> None:
     assert links[2].attrs['href'] == 'grandma/ma'
 
 
-def test_template_layout(postgres_dsn: str, redis_url: str) -> None:
+def test_template_layout(
+    postgres_dsn: str,
+    redis_url: str,
+    tmp_path: Path
+) -> None:
 
     class Mock:
         homepage_structure = ''
@@ -219,7 +224,8 @@ def test_template_layout(postgres_dsn: str, redis_url: str) -> None:
     app.namespace = 'tests'
     app.configure_application(
         dsn=postgres_dsn,
-        filestorage='fs.memoryfs.MemoryFS',
+        filestorage='fs.osfs.OSFS',
+        filestorage_options={'root_path': tmp_path},
         enable_elasticsearch=False,
         depot_backend='depot.io.memory.MemoryFileStorage',
         redis_url=redis_url,

--- a/tests/shared/fixtures.py
+++ b/tests/shared/fixtures.py
@@ -13,11 +13,11 @@ import urllib3
 from _pytest.monkeypatch import MonkeyPatch
 from asyncio import run
 from contextlib import suppress
-from fs.tempfs import TempFS
 from functools import lru_cache
 from libres.db.models import ORMBase
 from mirakuru import TCPExecutor
 from onegov.core.crypto import hash_password
+from onegov.core.filestorage import Filestorage
 from onegov.core.orm import Base, SessionManager
 from onegov.websockets.server import main
 from pathlib import Path
@@ -331,8 +331,9 @@ def test_password() -> str:
 
 
 @pytest.fixture(scope="session")
-def long_lived_filestorage() -> TempFS:
-    return TempFS()
+def long_lived_filestorage() -> Iterator[Filestorage]:
+    with tempfile.TemporaryDirectory() as root:
+        yield Filestorage(root)
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
## Commit message

Core: Removes `fs`/`PyFilesystem` dependency

`fs` is no longer maintained and its spiritual successor does not have
any type hints yet. So we replaced it with a minimal implementation that
only supports OS based filesystems.

This also eventually gets rid of a dependency on `setuptools < 82`,
since this is one of the only two remaining packages that uses old-style
`pkg_resources` based namespace packages.

TYPE: Feature
LINK: OGC-1607

## Checklist

- [x] I have performed a self-review of my code
