### PR TITLE
Remove stale volunteer state

### DIFF
--- a/src/onegov/activity/upgrade.py
+++ b/src/onegov/activity/upgrade.py
@@ -997,3 +997,17 @@ def add_indexes_to_speed_up_activity_filters(context: UpgradeContext) -> None:
             ['occasion_id'],
             if_not_exists=True
         )
+
+
+@upgrade_task('Reset stale cancelled volunteer states')
+def reset_stale_cancelled_volunteer_states(context: UpgradeContext) -> None:
+    # The reverted "Volunteer Ticket" feature left behind volunteers with a
+    # 'canceled' state that is no longer part of the volunteer_state enum,
+    # causing a LookupError when loading them on the demo instance. Reset
+    # them to 'open'. Compare on ::text since most schemas never gained the
+    # 'canceled' enum label.
+    if context.has_table('volunteers'):
+        context.session.execute(text(
+            "UPDATE volunteers SET state = 'open' "
+            "WHERE state::text = 'cancelled'"
+        ))


### PR DESCRIPTION
Feriennet: Remove stale volunteer state

On the feriennet demo instance `cancelled` volunteer state reached the db. The commit was later reverted, data remains

TYPE: Bugfix
LINK: ONEGOV-CLOUD-5FX