### PR TITLE
Core: Fix moving pages above the first item.

### DIFF
--- a/src/onegov/core/orm/abstract/adjacency_list.py
+++ b/src/onegov/core/orm/abstract/adjacency_list.py
@@ -349,9 +349,7 @@ def calculuate_midpoint_order[L: AdjacencyList](
         )  # Increment from left
     elif right:
         # Before first item (based on key)
-        new_item.order = (
-            Decimal(str(right.order)) / 2
-        )  # Half of the first item's order
+        new_item.order = Decimal(str(right.order)) - Decimal('1')
     else:
         # Only item in the list (or all others filtered out)
         new_item.order = Decimal('65536')  # Default middle value
@@ -678,7 +676,7 @@ class AdjacencyListCollection[L: AdjacencyList]:
             subject.order = Decimal(str(left.order)) + Decimal('1')
         elif right:
             # Place before right (target was right, or target was first)
-            subject.order = Decimal(str(right.order)) / 2
+            subject.order = Decimal(str(right.order)) - Decimal('1')
         else:
             # This case (no left and no right) should only happen if the target
             # is the only sibling (excluding subject). Place subject with

--- a/src/onegov/user/auth/clients/ldap.py
+++ b/src/onegov/user/auth/clients/ldap.py
@@ -97,7 +97,7 @@ class LDAPClient:
 
         # disconnect if necessary
         with suppress(LDAPCommunicationError, socket.error):
-            self.connection.unbind()  # type: ignore[no-untyped-call]
+            self.connection.unbind()
 
         # clear cache
         del self.__dict__['connection']

--- a/tests/onegov/core/test_adjacency_list.py
+++ b/tests/onegov/core/test_adjacency_list.py
@@ -200,6 +200,17 @@ def test_move_root(session: Session) -> None:
     assert family.query(ordered=True).all() == [a, b]
 
 
+def test_move_above_zero_order(session: Session) -> None:
+    family = FamilyMemberCollection(session)
+    a = family.add_root('a', order=Decimal('0'))
+    b = family.add_root('b', order=Decimal('1'))
+
+    family.move_above(target=a, subject=b)
+
+    assert family.query(ordered=True).all() == [b, a]
+    assert b.order == Decimal('-1')
+
+
 def test_move(session: Session) -> None:
 
     family = FamilyMemberCollection(session)
@@ -386,7 +397,7 @@ def test_add_uses_binary_gap(session: Session) -> None:
     order_b2 = b.order
     assert order_a1 < order_b2  # 'a' got order less than 'b'
     assert order_b2 == order_b1  # 'b's order didn't change
-    assert order_a1 == order_b1 / 2  # Specifically, half of 'b's original
+    assert order_a1 == order_b1 - Decimal('1')
 
     c = family.add(parent=root, title='c')  # Should go after 'b'
     order_a2 = a.order

--- a/tests/onegov/town6/test_views_topics.py
+++ b/tests/onegov/town6/test_views_topics.py
@@ -31,6 +31,25 @@ def test_sort_topics(client: Client) -> None:
     assert "Zurück zur Seite" in page
 
 
+def test_sort_root_topics(client: Client) -> None:
+    client.login_admin().follow()
+
+    page = client.get('/')
+    page = page.click('Sortieren')
+    url = page.pyquery('ul[data-sortable]').attr('data-sortable-url')
+    items = {
+        item.text_content().strip(): item.attrib['data-sortable-id']
+        for item in page.pyquery('ul[data-sortable] li')
+    }
+    url = url.replace('%7Bsubject_id%7D', items['Kontakt'])
+    url = url.replace('%7Bdirection%7D', 'above')
+    url = url.replace('%7Btarget_id%7D', items['Organisation'])
+    client.put(url)
+
+    links = client.get('/').pyquery('.side-navigation > li > a span')
+    assert links.text() == 'Kontakt Organisation Themen Aktuelles'
+
+
 def get_select_option_id_by_text(
     select_form: Select,
     search_text: str


### PR DESCRIPTION
Root pages start with order 0. Moving a page above the first one used 0 / 2, leaving both pages at order 0. Use first_order - 1 instead.

TYPE: Bugfix
LINK: OGC-3419

## Checklist

- [x] I have performed a self-review of my code

