### PR TITLE
Reservations: Fix wrong time when selecting slot in second half of day

### DIFF
--- a/src/onegov/org/assets/js/reservationlist.jsx
+++ b/src/onegov/org/assets/js/reservationlist.jsx
@@ -78,8 +78,8 @@ $.fn.reservationList = function(options) {
                 rl.reserve(
                     list,
                     event.reserveurl,
-                    event.start.format('hh:mm'),
-                    event.end.format('hh:mm'),
+                    event.start.format('HH:mm'),
+                    event.end.format('HH:mm'),
                     1,
                     event.wholeDay,
                     !singleSelect


### PR DESCRIPTION
Reservations: Fix wrong time when selecting slot in second half of day

Use 24h format for slot times 

TYPE: Bugfix
LINK: ogc-3425