### PR TITLE
Org: Allows form submissions to be entered via the forms API

### DIFF
--- a/src/onegov/api/form.py
+++ b/src/onegov/api/form.py
@@ -1,0 +1,434 @@
+from __future__ import annotations
+
+import humanize
+
+from abc import abstractmethod, ABC
+from datetime import date, time
+from dateutil.relativedelta import relativedelta
+from decimal import Decimal
+from onegov.core.utils import binary_to_dictionary
+from onegov.form.fields import HoneyPotField
+from onegov.form.validators import FileSizeLimit
+from onegov.form.validators import If
+from onegov.form.validators import Stdnum
+from onegov.form.validators import ValidDateRange
+from onegov.form.validators import WhitelistedMimeType
+from pydantic import create_model, model_validator
+from pydantic import AfterValidator, BaseModel, Field
+from pydantic import AwareDatetime, Base64Bytes, EmailStr, HttpUrl
+from wtforms import HiddenField
+from wtforms.validators import DataRequired, InputRequired, Optional
+from wtforms.validators import Email, Length, NumberRange, Regexp
+
+
+from typing import Annotated, Any, Literal, TypeVar, TYPE_CHECKING
+if TYPE_CHECKING:
+    from collections.abc import Callable, Generator, Sequence
+    from onegov.core.types import FileDict
+    from onegov.form import Form
+    from onegov.form.core import FieldDependency
+    from onegov.form.types import Validator
+    from typing_extensions import TypeForm
+    from wtforms import Field as WTField
+
+
+type ValidatorAdapter[T: Validator[Any, Any]] = Callable[[T], Any]
+
+_A = TypeVar('_A', bound='BaseAdapter')
+_V = TypeVar('_V', bound='ValidatorAdapter[Any]')
+
+
+class AdapterRegistry:
+    """ Keeps track of all the adapters and WTForms field types
+    they are registered for, making sure each adapter is only
+    instantiated once.
+
+    """
+    adapter_map: dict[str, BaseAdapter]
+    validator_map: dict[type[Any], ValidatorAdapter[Any]]
+
+    def __init__(self) -> None:
+        self.adapter_map = {}
+        self.validator_map = {}
+
+    def register_for(self, *types: str) -> Callable[[type[_A]], type[_A]]:
+        """ Decorator to register a field adapter. """
+        def wrapper(adapter: type[_A]) -> type[_A]:
+            instance = adapter()
+
+            for type in types:
+                assert type not in self.adapter_map
+                self.adapter_map[type] = instance
+            return adapter
+        return wrapper
+
+    def validator(self, validator: type[Any]) -> Callable[[_V], _V]:
+        """ Decorator to register a validator adapter. """
+        def wrapper(adapter: _V) -> _V:
+            assert validator not in self.validator_map
+            self.validator_map[validator] = adapter
+            return adapter
+        return wrapper
+
+    def adapt(self, field: WTField) -> Generator[Any]:
+        """ Adapts the WTForms field to a pydantic field yielding a
+        sequence of values starting with a type form, followed by
+        any number of pydantic metadata objects.
+
+        This output will get unpacked into `Annotated`.
+
+        """
+        adapter = self.adapter_map[field.type]
+        return adapter(field)
+
+    def adapt_validator(self, validator: Validator[Any, Any]) -> Any:
+        adapter = self.validator_map[validator.__class__]
+        return adapter(validator)
+
+
+registry = AdapterRegistry()
+
+
+@registry.validator(Length)
+def adapt_length(validator: Length) -> Any:
+    return Field(
+        min_length=None if validator.min < 0 else validator.min,
+        max_length=None if validator.max < 0 else validator.max
+    )
+
+
+@registry.validator(Regexp)
+def adapt_regexp(validator: Regexp) -> Any:
+    return Field(pattern=validator.regex)
+
+
+@registry.validator(NumberRange)
+def adapt_number_range(validator: NumberRange) -> Any:
+    return Field(ge=validator.min, le=validator.max)
+
+
+@registry.validator(ValidDateRange)
+def adapt_valid_date_range(validator: ValidDateRange) -> Any:
+    ge = validator.min
+    if isinstance(ge, relativedelta):
+        ge = date.today() + ge
+    # NOTE: In order to get the correct behavior for datetimes
+    #       we convert to an exclusive end
+    # FIXME: Will automatic coercion work for datetime, even
+    #        though the datetimes will be timezone aware? If
+    #        not we may need to emit a custom AfterValidator instead
+    lt = validator.max
+    if isinstance(lt, relativedelta):
+        lt = date.today() + lt
+    if lt is not None:
+        lt += relativedelta(days=1)
+    return Field(ge=ge, lt=lt)
+
+
+@registry.validator(Stdnum)
+def adapt_stdnum(validator: Stdnum) -> Any:
+    def validate_stdnum(value: str | None) -> str | None:
+        if value is None:
+            return None
+        validator.format.validate(value)
+        return value
+    return AfterValidator(validate_stdnum)
+
+
+@registry.validator(FileSizeLimit)
+def adapt_file_size_limit(validator: FileSizeLimit) -> Any:
+    def validate_file_size(value: FileDict) -> FileDict:
+        if not value:
+            return value  # type: ignore[unreachable]
+        if value.get('size', 0) > validator.max_bytes:
+            raise ValueError(str(validator.message).format(
+                humanize.naturalsize(validator.max_bytes)
+            ))
+        return value
+    return AfterValidator(validate_file_size)
+
+
+class BaseAdapter(ABC):
+    """ Provides utility functions for all adapters. """
+
+    def handle_scalar_field_type(
+        self,
+        t: TypeForm[Any],
+        field: WTField
+    ) -> tuple[Any, ...]:
+        if not hasattr(field, 'depends_on') and any(
+            isinstance(validator, (InputRequired, DataRequired))
+            for validator in field.validators
+        ):
+            # NOTE: This is a bit of a hack to avoid emitting an
+            #       Annotated without metadata
+            return t, Field()
+
+        default = field.default
+        if callable(default):
+            default = default()
+
+        if default is None:
+            return t | None, Field(default=None)
+        if callable(field.default):
+            return t, Field(default_factory=field.default)
+        return t, Field(default=default)
+
+    def handle_sequence_field_type(
+        self,
+        t: TypeForm[Any],
+        field: WTField
+    ) -> Generator[Any]:
+
+        yield list[t]  # type: ignore[valid-type]
+
+        if not hasattr(field, 'depends_on') and any(
+            isinstance(validator, (InputRequired, DataRequired))
+            for validator in field.validators
+        ):
+            yield Field(min_length=1)
+            return
+
+        if callable(default := field.default):
+            yield Field(default_factory=default)
+        else:
+            yield Field(default=default)
+
+    def adapt_validators(
+        self,
+        validators: Sequence[Validator[Any, Any]] | None
+    ) -> Generator[Any]:
+        if not validators:
+            return
+
+        if isinstance(validators[0], If):
+            validators = validators[0].validators
+
+        for validator in validators:
+            if isinstance(validator, (
+                # already handled via maybe_optional
+                Optional, InputRequired, DataRequired,
+                # already special-cased in Email field adapter
+                Email,
+                # already special-cased in upload field adapter
+                WhitelistedMimeType,
+            )):
+                continue
+
+            yield registry.adapt_validator(validator)
+
+    @abstractmethod
+    def __call__(self, field: WTField) -> Generator[Any]:
+        raise NotImplementedError
+
+
+@registry.register_for(
+    'StringField',
+    'TextAreaField',
+    'PasswordField'
+)
+class StringFieldAdapter(BaseAdapter):
+    def __call__(self, field: WTField) -> Generator[Any]:
+        yield from self.handle_scalar_field_type(str, field)
+        yield from self.adapt_validators(field.validators)
+
+
+@registry.register_for('EmailField')
+class EmailFieldAdapter(BaseAdapter):
+    def __call__(self, field: WTField) -> Generator[Any]:
+        yield from self.handle_scalar_field_type(EmailStr, field)
+        yield from self.adapt_validators(field.validators)
+
+
+@registry.register_for(
+    'URLField',
+    'VideoURLField'
+)
+class URLFieldAdapter(BaseAdapter):
+    def __call__(self, field: WTField) -> Generator[Any]:
+        yield from self.handle_scalar_field_type(HttpUrl, field)
+        # NOTE: Coerce from HttpUrl | None back to str | None
+        yield AfterValidator(lambda v: None if v is None else str(v))
+        yield from self.adapt_validators(field.validators)
+
+
+@registry.register_for('DateField')
+class DateFieldAdapter(BaseAdapter):
+    def __call__(self, field: WTField) -> Generator[Any]:
+        yield from self.handle_scalar_field_type(date, field)
+        yield from self.adapt_validators(field.validators)
+
+
+@registry.register_for(
+    'DateTimeLocalField',
+    'TimezoneDateTimeField'
+)
+class DateTimeFieldAdapter(BaseAdapter):
+    def __call__(self, field: WTField) -> Generator[Any]:
+        yield from self.handle_scalar_field_type(AwareDatetime, field)
+        yield from self.adapt_validators(field.validators)
+
+
+@registry.register_for('TimeField')
+class TimeFieldAdapter(BaseAdapter):
+    def __call__(self, field: WTField) -> Generator[Any]:
+        yield from self.handle_scalar_field_type(time, field)
+        yield from self.adapt_validators(field.validators)
+
+
+@registry.register_for('DecimalField')
+class DecimalFieldAdapter(BaseAdapter):
+    def __call__(self, field: WTField) -> Generator[Any]:
+        yield from self.handle_scalar_field_type(Decimal, field)
+        yield from self.adapt_validators(field.validators)
+
+
+@registry.register_for('IntegerField')
+class IntegerFieldAdapter(BaseAdapter):
+    def __call__(self, field: WTField) -> Generator[Any]:
+        yield from self.handle_scalar_field_type(int, field)
+        yield from self.adapt_validators(field.validators)
+
+
+@registry.register_for('RadioField')
+class RadioFieldAdapter(BaseAdapter):
+    def __call__(self, field: WTField) -> Generator[Any]:
+        yield from self.handle_scalar_field_type(Literal[*(  # type: ignore[arg-type]
+            value
+            for value, _ in field.choices  # type: ignore[attr-defined]
+            if value
+        )], field)
+        yield from self.adapt_validators(field.validators)
+
+
+@registry.register_for('MultiCheckboxField')
+class MultiCheckboxFieldAdapter(BaseAdapter):
+    def __call__(self, field: WTField) -> Generator[Any]:
+        yield from self.handle_sequence_field_type(Literal[*(  # type: ignore[arg-type]
+            value
+            for value, _ in field.choices  # type: ignore[attr-defined]
+            if value
+        )], field)
+        yield from self.adapt_validators(field.validators)
+
+
+class FileUpload(BaseModel):
+    filename: str
+    data: Base64Bytes
+
+
+def mimetypes_validator(
+    mimetypes: set[str]
+) -> Callable[[FileDict], FileDict]:
+    def validate_mimetype(value: FileDict) -> FileDict:
+        if not value:
+            return value  # type: ignore[unreachable]
+        if value['mimetype'] not in mimetypes:
+            raise ValueError(
+                f'Unsupported mimetype. '
+                f'Allowed mimetypes are {", ".join(mimetypes)}.'
+            )
+        return value
+    return validate_mimetype
+
+
+@registry.register_for('UploadField')
+class UploadFieldAdapter(BaseAdapter):
+    def __call__(self, field: WTField) -> Generator[Any]:
+        yield from self.handle_scalar_field_type(FileUpload, field)
+        # NOTE: Coerce from FileUpload to FileDict
+        yield AfterValidator(
+            lambda v: {} if v is None  # type: ignore[typeddict-item]
+            else binary_to_dictionary(v.data, v.filename)
+        )
+        yield AfterValidator(mimetypes_validator(field.mimetypes))  # type: ignore[attr-defined]
+        yield from self.adapt_validators(field.validators)
+
+
+@registry.register_for('UploadMultipleField')
+class UploadMultipleFieldAdapter(BaseAdapter):
+    def __call__(self, field: WTField) -> Generator[Any]:
+        yield from self.handle_sequence_field_type(
+            Annotated[
+                FileUpload,
+                # NOTE: Coerce from FileUpload to FileDict
+                AfterValidator(
+                    lambda v: {} if v is None
+                    else binary_to_dictionary(v.data, v.filename)
+                ),
+                AfterValidator(mimetypes_validator(field.mimetypes)),
+                *self.adapt_validators(field.unbound_field.kwargs['validators'])
+            ],
+            field
+        )
+
+
+def dependency_fulfilled(self: FieldDependency, obj: object) -> bool:
+    result = True
+    for dependency in self.dependencies:
+        data = getattr(obj, dependency['field_id'])
+        choice = dependency['choice']
+        invert = dependency['invert']
+
+        if isinstance(data, bool) and choice in ('y', 'n'):
+            choice = choice == 'y' and True or False
+
+        result = result and ((data == choice) ^ invert)
+    return result
+
+
+def model_from_form(form: Form) -> type[BaseModel]:
+    validators: dict[str, Any] = {}
+    maybe_required_dependent_fields = {
+        name: field.depends_on
+        for name, field in form._fields.items()
+        if hasattr(field, 'depends_on')
+        if isinstance(field.validators[0], If)
+        if any(
+            isinstance(v, (InputRequired, DataRequired))
+            for v in field.validators[0].validators
+        )
+    }
+    if maybe_required_dependent_fields:
+        @model_validator(mode='after')
+        def validate_required_dependent_fields(self: Any) -> Any:
+            for name, depends_on in maybe_required_dependent_fields.items():
+                # if the value is something that will satisfy LaxDataRequired
+                # then we accept it regardless of whether the dependency is
+                # fulfilled
+                value = getattr(self, name)
+                if value is False:
+                    # NOTE: we need to special-case this since bool is
+                    #       an instance of int
+                    pass
+                elif isinstance(value, (int, float, Decimal)):
+                    continue
+
+                if isinstance(value, str) and value.strip():
+                    continue
+
+                if dependency_fulfilled(depends_on, self):
+                    raise ValueError(
+                        f'{name} is required due to your other submitted data'
+                    )
+            return self
+
+        validators[
+            'validate_required_dependent_fields'
+        ] = validate_required_dependent_fields
+
+    return create_model(
+        f'{form.__class__.__name__}Model',
+        __base__=None,
+        __module__=form.__class__.__module__,
+        __qualname__=None,
+        __doc__=None,
+        __config__={'frozen': True},
+        __validators__=validators,
+        __cls_kwargs__=None,
+        **{
+            name: Annotated[*registry.adapt(field)]
+            for name, field in form._fields.items()
+            if not isinstance(field, (HiddenField, HoneyPotField))
+        }
+    )

--- a/src/onegov/api/form.py
+++ b/src/onegov/api/form.py
@@ -18,7 +18,8 @@ from pydantic import AfterValidator, BaseModel, Field
 from pydantic import AwareDatetime, Base64Bytes, EmailStr, HttpUrl
 from wtforms import HiddenField
 from wtforms.validators import DataRequired, InputRequired, Optional
-from wtforms.validators import Email, Length, NumberRange, Regexp
+from wtforms.validators import Email, Length, NumberRange, Regexp, URL
+from wtforms.validators import HostnameValidation
 
 
 from typing import Annotated, Any, Literal, TypeVar, TYPE_CHECKING
@@ -148,6 +149,9 @@ def adapt_file_size_limit(validator: FileSizeLimit) -> Any:
     return AfterValidator(validate_file_size)
 
 
+REQUIRED_DEPENDENT = object()
+
+
 class BaseAdapter(ABC):
     """ Provides utility functions for all adapters. """
 
@@ -155,24 +159,42 @@ class BaseAdapter(ABC):
         self,
         t: TypeForm[Any],
         field: WTField
-    ) -> tuple[Any, ...]:
-        if not hasattr(field, 'depends_on') and any(
+    ) -> Generator[Any]:
+        is_dependent = hasattr(field, 'depends_on')
+        if not is_dependent and any(
             isinstance(validator, (InputRequired, DataRequired))
             for validator in field.validators
         ):
+            yield t
             # NOTE: This is a bit of a hack to avoid emitting an
             #       Annotated without metadata
-            return t, Field()
+            yield object()
+            return
 
-        default = field.default
-        if callable(default):
-            default = default()
-
+        default = field.data
         if default is None:
-            return t | None, Field(default=None)
-        if callable(field.default):
-            return t, Field(default_factory=field.default)
-        return t, Field(default=default)
+            yield t | None
+            yield Field(default=None)
+        else:
+            yield t
+            if isinstance(default, (list, dict)):
+                yield Field(default_factory=lambda: default.copy())
+            else:
+                yield Field(default=default)
+
+        if (
+            is_dependent
+            and field.validators
+            and isinstance(field.validators[0], If)
+            and any(
+                isinstance(validator, (InputRequired, DataRequired))
+                for validator in field.validators[0].validators
+            )
+        ):
+            # we use this marker in the model validator to detect
+            # fields that become dependent when their dependency
+            # is fulfilled
+            yield REQUIRED_DEPENDENT
 
     def handle_sequence_field_type(
         self,
@@ -182,17 +204,41 @@ class BaseAdapter(ABC):
 
         yield list[t]  # type: ignore[valid-type]
 
-        if not hasattr(field, 'depends_on') and any(
+        is_dependent = hasattr(field, 'depends_on')
+        min_length = getattr(field, 'min_entries', 0)
+        if not is_dependent and (min_length > 0 or any(
             isinstance(validator, (InputRequired, DataRequired))
             for validator in field.validators
-        ):
-            yield Field(min_length=1)
+        )):
+            yield Field(min_length=min_length or 1)
             return
 
-        if callable(default := field.default):
-            yield Field(default_factory=default)
+        if default := field.data:
+            yield Field(default_factory=lambda: default.copy())
         else:
-            yield Field(default=default)
+            yield Field(default_factory=list)
+
+        if (
+            is_dependent
+            and ((validators := field.validators) or (
+                hasattr(field, 'unbound_field')
+                and (validators := field.unbound_field.kwargs.get(
+                    'validators'
+                ))
+            ))
+            and isinstance(validators[0], If)
+            and any(
+                isinstance(validator, (InputRequired, DataRequired))
+                for validator in validators[0].validators
+            )
+        ):
+            # we use this marker in the model validator to detect
+            # fields that become dependent when their dependency
+            # is fulfilled
+            # TODO: Should we validate min_lengths > 1? Currently
+            #       there's no use-case for this, required always
+            #       means at least 1 entry, never more
+            yield REQUIRED_DEPENDENT
 
     def adapt_validators(
         self,
@@ -210,6 +256,8 @@ class BaseAdapter(ABC):
                 Optional, InputRequired, DataRequired,
                 # already special-cased in Email field adapter
                 Email,
+                # already special-cased in URL field adapter
+                URL,
                 # already special-cased in upload field adapter
                 WhitelistedMimeType,
             )):
@@ -240,15 +288,38 @@ class EmailFieldAdapter(BaseAdapter):
         yield from self.adapt_validators(field.validators)
 
 
+validate_hostname = HostnameValidation(require_tld=True, allow_ip=True)
+
+
+def validate_and_coerce_url(value: HttpUrl | None) -> str | None:
+    if value is None:
+        return None
+
+    if value.host is None:  # pragma: no cover
+        # NOTE: I don't think it's possible for this to happen with HttpUrl
+        #       since the scheme is required, so relative urls don't work
+        #       despite the validation error claiming it does...
+        raise ValueError('hostname is required')
+
+    if not validate_hostname(value.host):
+        raise ValueError('hostname is not valid')
+
+    # NOTE: Coerce from HttpUrl back to str, since that's what we will
+    #       store in our database
+    return str(value)
+
+
 @registry.register_for(
     'URLField',
     'VideoURLField'
 )
 class URLFieldAdapter(BaseAdapter):
     def __call__(self, field: WTField) -> Generator[Any]:
+        # NOTE: HttpUrl normalizes the URL to some degree, which doesn't
+        #       happen in the actual form, maybe we should use `str`
+        #       type and rely on the wtforms URL validator instead?
         yield from self.handle_scalar_field_type(HttpUrl, field)
-        # NOTE: Coerce from HttpUrl | None back to str | None
-        yield AfterValidator(lambda v: None if v is None else str(v))
+        yield AfterValidator(validate_and_coerce_url)
         yield from self.adapt_validators(field.validators)
 
 
@@ -373,26 +444,30 @@ def dependency_fulfilled(self: FieldDependency, obj: object) -> bool:
         if isinstance(data, bool) and choice in ('y', 'n'):
             choice = choice == 'y' and True or False
 
-        result = result and ((data == choice) ^ invert)
+        if isinstance(data, list):
+            value = choice in data
+        else:
+            value = data == choice
+
+        result = result and (value ^ invert)
     return result
 
 
 def model_from_form(form: Form) -> type[BaseModel]:
     validators: dict[str, Any] = {}
-    maybe_required_dependent_fields = {
+    dependent_fields = {
         name: field.depends_on
         for name, field in form._fields.items()
         if hasattr(field, 'depends_on')
-        if isinstance(field.validators[0], If)
-        if any(
-            isinstance(v, (InputRequired, DataRequired))
-            for v in field.validators[0].validators
-        )
     }
-    if maybe_required_dependent_fields:
+    if dependent_fields:
         @model_validator(mode='after')
         def validate_required_dependent_fields(self: Any) -> Any:
-            for name, depends_on in maybe_required_dependent_fields.items():
+            model_fields = type(self).model_fields
+            for name, depends_on in dependent_fields.items():
+                if REQUIRED_DEPENDENT not in model_fields[name].metadata:
+                    continue
+
                 # if the value is something that will satisfy LaxDataRequired
                 # then we accept it regardless of whether the dependency is
                 # fulfilled

--- a/src/onegov/api/form.py
+++ b/src/onegov/api/form.py
@@ -205,12 +205,12 @@ class BaseAdapter(ABC):
         yield list[t]  # type: ignore[valid-type]
 
         is_dependent = hasattr(field, 'depends_on')
-        min_length = getattr(field, 'min_entries', 0)
-        if not is_dependent and (min_length > 0 or any(
+        upload_required = getattr(field, 'upload_required', False)
+        if not is_dependent and (upload_required or any(
             isinstance(validator, (InputRequired, DataRequired))
             for validator in field.validators
         )):
-            yield Field(min_length=min_length or 1)
+            yield Field(min_length=1)
             return
 
         if default := field.data:
@@ -218,9 +218,8 @@ class BaseAdapter(ABC):
         else:
             yield Field(default_factory=list)
 
-        if (
-            is_dependent
-            and ((validators := field.validators) or (
+        if is_dependent and (upload_required or (
+            ((validators := field.validators) or (
                 hasattr(field, 'unbound_field')
                 and (validators := field.unbound_field.kwargs.get(
                     'validators'
@@ -231,13 +230,10 @@ class BaseAdapter(ABC):
                 isinstance(validator, (InputRequired, DataRequired))
                 for validator in validators[0].validators
             )
-        ):
+        )):
             # we use this marker in the model validator to detect
             # fields that become dependent when their dependency
             # is fulfilled
-            # TODO: Should we validate min_lengths > 1? Currently
-            #       there's no use-case for this, required always
-            #       means at least 1 entry, never more
             yield REQUIRED_DEPENDENT
 
     def adapt_validators(

--- a/src/onegov/api/form.py
+++ b/src/onegov/api/form.py
@@ -192,7 +192,7 @@ class BaseAdapter(ABC):
             )
         ):
             # we use this marker in the model validator to detect
-            # fields that become dependent when their dependency
+            # fields that become required when their dependency
             # is fulfilled
             yield REQUIRED_DEPENDENT
 
@@ -232,7 +232,7 @@ class BaseAdapter(ABC):
             )
         )):
             # we use this marker in the model validator to detect
-            # fields that become dependent when their dependency
+            # fields that become required when their dependency
             # is fulfilled
             yield REQUIRED_DEPENDENT
 

--- a/src/onegov/api/models.py
+++ b/src/onegov/api/models.py
@@ -6,10 +6,10 @@ from functools import cached_property
 from json import JSONDecodeError
 from logging import getLogger
 from logging import NullHandler
+from onegov.api.form import model_from_form
 from onegov.core.orm import Base
-from onegov.form.fields import HoneyPotField
-from onegov.form.utils import get_fields_from_class
 from onegov.user import User
+from pydantic import ValidationError
 from sqlalchemy import ForeignKey
 from sqlalchemy.orm import mapped_column
 from sqlalchemy.orm import relationship
@@ -17,7 +17,6 @@ from sqlalchemy.orm import Mapped
 from uuid import uuid4, UUID
 from webob.exc import HTTPException
 from webob.multidict import MultiDict
-from wtforms import HiddenField
 
 
 from typing import TYPE_CHECKING, Any, ClassVar, NoReturn, Self, overload
@@ -29,7 +28,6 @@ if TYPE_CHECKING:
     from onegov.form import Form
     from sqlalchemy.orm import DeclarativeBase, Query, Session
     from typing import Protocol
-    from webob.request import _FieldStorageWithFile
 
     class PaginationWithById[
         M: DeclarativeBase,
@@ -359,6 +357,18 @@ class ApiEndpoint[M: DeclarativeBase, IdT: PKType]:
 
         raise NotImplementedError()
 
+    def item_form_class(self, item: M) -> type[Form] | None:
+        """ Return the form class specific to this endpoint item.
+
+        Cannot be combined with ApiEndpoint.form_class, if that attribute
+        is set to something other than `None`, then this method will never
+        be called.
+
+        Set the attribute when all items share the same form_class and
+        override this method when each item has its own form_class
+        """
+        return None
+
     def item_links(self, item: M) -> dict[str, Any]:
         """ Return the link properties of the collection item as a dictionary.
         Links can either be string or a linkable object.
@@ -383,35 +393,47 @@ class ApiEndpoint[M: DeclarativeBase, IdT: PKType]:
         """ Return a form for editing items of this collection. """
 
         if self.form_class is None:
-            return None
+            if item is None:
+                return None
 
-        def malformed_payload() -> NoReturn:
-            raise ApiException(
-                'Malformed collection+json payload',
-                status_code=400
-            )
+            form_class = self.item_form_class(item)
+            if form_class is None:
+                return None
+        else:
+            form_class = self.form_class
+
+        form = request.get_form(
+            form_class,
+            csrf_support=False,
+            model=item
+        )
 
         # NOTE: In addition to form encoded data we also allow a JSON
-        #       payload, although the support for this is currenty
-        #       very limited
-        formdata: MultiDict[str, str | _FieldStorageWithFile] | None
+        #       payload, as long as we can generate a valid pydantic
+        #       model for it.
         if request.method in ('POST', 'PUT') and not request.POST:
-            settable_fields = {
-                name
-                for name, field in get_fields_from_class(self.form_class)
-                if not issubclass(
-                    field.field_class,
-                    (HiddenField, HoneyPotField)
-                )
-            }
+            try:
+                model_class = model_from_form(form)
+            except Exception as exc:
+                raise ApiException(
+                    'This endpoint only supports multipart/form-data or '
+                    'application/x-www-form-urlencoded form submissions',
+                    status_code=400
+                ) from exc
 
-            formdata = MultiDict()
+            data: dict[str, Any] = {}
             with ApiException.capture_exceptions(
                 exception_type=JSONDecodeError,
                 default_message='Malformed payload',
                 default_status_code=400,
             ):
                 json_data = request.json
+
+            def malformed_payload() -> NoReturn:
+                raise ApiException(
+                    'Malformed collection+json payload',
+                    status_code=400
+                )
 
             if not isinstance(json_data, dict):
                 malformed_payload()
@@ -428,34 +450,40 @@ class ApiEndpoint[M: DeclarativeBase, IdT: PKType]:
                 if not isinstance(name, str):
                     malformed_payload()
 
-                if name not in settable_fields:
+                if name in data:
+                    raise ApiException(
+                        f'Field "{name}" was supplied more than once',
+                        status_code=400
+                    )
+
+                if name not in model_class.model_fields:
                     raise ApiException(
                         f'Invalid field "{name}" supplied', status_code=400
                     )
 
-                # TOOD: It would be more robust to use something like pydantic
-                #       for parsing/validating the JSON payload, rather than
-                #       try to convert the JSON to formdata. For now the only
-                #       form we support only has text data, so keep it simple.
-                value = field.get('value')
-                if value is None:
-                    continue
-                elif isinstance(value, (str, int, float)):
-                    formdata[name] = str(value)
-                else:
-                    raise ApiException(
-                        f'{name}: Unsupported value format', status_code=400
-                    )
+                data[name] = field.get('value')
 
-        else:
-            formdata = None
+            try:
+                model = model_class.model_validate(data)
+            except ValidationError as exc:
+                raise ApiException(
+                    ', '.join(
+                        f'{'.'.join(str(l) for l in err['loc'])}: {err['msg']}'
+                        for err in exc.errors(
+                            include_url=False,
+                            include_input=False,
+                        )
+                    ),
+                    status_code=400
+                ) from exc
 
-        return request.get_form(
-            self.form_class,
-            csrf_support=False,
-            formdata=formdata,
-            model=item
-        )
+            form.process(obj=model)
+            # NOTE: We already validated the data using pydantic, so we
+            #       bypass the validation on the form itself. This way
+            #       we don't have to construct valid formdata.
+            form.validate = lambda *a, **kw: True  # type: ignore[method-assign]
+
+        return form
 
     def apply_changes(self, item: M, form: Any) -> None:
         """ Apply the changes to the item based on the given form data. """

--- a/src/onegov/api/models.py
+++ b/src/onegov/api/models.py
@@ -485,8 +485,13 @@ class ApiEndpoint[M: DeclarativeBase, IdT: PKType]:
 
         return form
 
-    def apply_changes(self, item: M, form: Any) -> None:
-        """ Apply the changes to the item based on the given form data. """
+    def apply_changes(self, item: M, form: Any) -> dict[str, Any] | None:
+        """ Apply the changes to the item based on the given form data.
+
+        May optionally return a valid Collection+JSON payload which will
+        be included in the response.
+
+        """
 
         raise NotImplementedError()
 

--- a/src/onegov/api/views.py
+++ b/src/onegov/api/views.py
@@ -230,7 +230,7 @@ def view_api_endpoint_item(
 )
 def edit_api_endpoint_item(
     self: ApiEndpointItem[Any, Any], request: CoreRequest
-) -> None:
+) -> dict[str, Any] | None:
 
     with ApiException.capture_exceptions():
         endpoint = self.api_endpoint
@@ -274,7 +274,7 @@ def edit_api_endpoint_item(
                 status_code=400
             )
 
-        endpoint.apply_changes(self.item, form)
+        return endpoint.apply_changes(self.item, form)
 
 
 @ApiApp.json(model=AuthEndpoint, permission=Public, open_data=False)

--- a/src/onegov/form/core.py
+++ b/src/onegov/form/core.py
@@ -362,13 +362,6 @@ class Form(BaseForm):
 
         yield
 
-        # NOTE: We currently assume that the only time we have different
-        #       prefixes for the same form is in a FieldList, technically
-        #       we would need to always do this step below to be fully
-        #       robust
-        if not self._prefix:
-            return
-
         for field_id, field in self._unbound_fields:
             if not hasattr(field, 'depends_on'):
                 continue
@@ -379,6 +372,9 @@ class Form(BaseForm):
             f.render_kw.update(
                 field.depends_on.html_data(self._prefix)
             )
+            # NOTE: For introspection we copy the dependency object
+            #       to the bound field
+            f.depends_on = field.depends_on  # type: ignore[attr-defined]
 
     def process_pricing(self) -> Iterator[None]:
         """ Processes the pricing parameter on the fields, which adds the
@@ -1018,7 +1014,12 @@ class FieldDependency:
             if isinstance(data, bool) and choice in ('y', 'n'):
                 choice = choice == 'y' and True or False
 
-            result = result and ((data == choice) ^ invert)
+            if isinstance(data, list):
+                value = choice in data
+            else:
+                value = data == choice
+
+            result = result and (value ^ invert)
         return result
 
     def unfulfilled(self, form: Form, field: Field) -> bool:

--- a/src/onegov/form/fields.py
+++ b/src/onegov/form/fields.py
@@ -559,7 +559,10 @@ class UploadMultipleField(UploadMultipleBase, FileField):
         super().__init__(
             unbound_field,
             label,
-            min_entries=0,
+            min_entries=1 if any(
+                isinstance(validator, (InputRequired, DataRequired))
+                for validator in validators or ()
+            ) else 0,
             max_entries=None,
             id=id,
             default=default,

--- a/src/onegov/form/fields.py
+++ b/src/onegov/form/fields.py
@@ -56,6 +56,7 @@ from wtforms.fields.core import UnboundField
 from wtforms.utils import unset_value
 from wtforms.validators import DataRequired
 from wtforms.validators import InputRequired
+from wtforms.validators import StopValidation
 from wtforms.validators import URL
 from wtforms.validators import ValidationError
 from wtforms.widgets import CheckboxInput, ColorInput, TextInput
@@ -556,13 +557,14 @@ class UploadMultipleField(UploadMultipleBase, FileField):
             validators=validators,  # type: ignore[arg-type]
             **extra_arguments
         )
+        self.upload_required = any(
+            isinstance(validator, (InputRequired, DataRequired))
+            for validator in validators or ()
+        )
         super().__init__(
             unbound_field,
             label,
-            min_entries=1 if any(
-                isinstance(validator, (InputRequired, DataRequired))
-                for validator in validators or ()
-            ) else 0,
+            min_entries=0,
             max_entries=None,
             id=id,
             default=default,
@@ -627,6 +629,14 @@ class UploadMultipleField(UploadMultipleBase, FileField):
 
             if hasattr(value, 'file') or hasattr(value, 'stream'):
                 self.append_entry_from_field_storage(value)
+
+    def pre_validate(self, form: BaseForm) -> None:
+        if self.upload_required and not any(
+            field.action != 'delete'
+            for field in self
+            if hasattr(field, 'action')
+        ):
+            raise StopValidation(self.gettext('This field is required.'))
 
 
 class _DummyFile:

--- a/src/onegov/form/widgets.py
+++ b/src/onegov/form/widgets.py
@@ -301,7 +301,6 @@ class UploadMultipleWidget(FileInput):
 
         force_simple = kwargs.pop('force_simple', False)
         resend_upload = kwargs.pop('resend_upload', False)
-        input_html = self.render_input(field, **kwargs)
         simple_template = Markup("""
             <div class="upload-widget without-data">
                 {}
@@ -309,11 +308,15 @@ class UploadMultipleWidget(FileInput):
         """)
 
         if force_simple or len(field) == 0:
+            if getattr(field, 'upload_required', False):
+                kwargs.setdefault('required', True)
+            input_html = self.render_input(field, **kwargs)
             return simple_template.format(input_html) + Markup('\n').join(
                 Markup('<small class="error">{}</small>').format(error)
                 for error in field.errors
             )
         else:
+            input_html = self.render_input(field, **kwargs)
             existing_html = Markup('').join(
                 subfield(
                     force_simple=force_simple,

--- a/src/onegov/org/api.py
+++ b/src/onegov/org/api.py
@@ -5,11 +5,11 @@ import transaction
 from datetime import date
 from functools import cached_property
 from onegov.api.models import ApiEndpoint, ApiEndpointItem
-from onegov.api.models import ApiInvalidParamException
+from onegov.api.models import ApiException, ApiInvalidParamException
 from onegov.core.collection import Pagination
 from onegov.core.converters import extended_date_decode
 from onegov.event.collections import OccurrenceCollection
-from onegov.form import FormCollection
+from onegov.form import Form, FormCollection
 from onegov.form.models import FormDefinition
 from onegov.gis import Coordinates
 from onegov.org import _
@@ -19,6 +19,7 @@ from onegov.org.models.directory import (
 from onegov.org.models.external_link import (
     ExternalFormLink, ExternalLinkCollection, ExternalResourceLink)
 from onegov.org.models.page import News, NewsCollection, Topic, TopicCollection
+from onegov.org.views.form_submission import do_complete_submission
 from onegov.people import Person
 from onegov.people.collections import PersonCollection
 from onegov.reservation.collection import ResourceCollection
@@ -806,6 +807,53 @@ class FormApiEndpoint(ApiEndpoint[FormOrExternalLink, UUID | str]):
         if isinstance(item, ExternalFormLink):
             return {'html': item.url}
         return {'html': item}
+
+    def item_form_class(self, item: FormOrExternalLink) -> type[Form] | None:
+        if isinstance(item, ExternalFormLink):
+            return None
+
+        # Check whether the form still accepts submissions
+        window = item.current_registration_window
+        if window and not window.accepts_submissions(1):
+            return None
+
+        # Forms that require online payments may not be submitted via API
+        if item.payment_method == 'cc':
+            return None
+        # NOTE: If there are any options in the form that require credit
+        #       card payment we will emit an ApiError in apply_changes
+        #       instead of disallowing submissions altogether
+        return item.form_class
+
+    def apply_changes(self, item: FormOrExternalLink, form: Form) -> None:
+        assert not isinstance(item, ExternalFormLink)
+
+        for name, price in form.prices():
+            if price.credit_card_payment:
+                raise ApiException(
+                    f'Based on the submitted value for "{name}", '
+                    f'online payment is required for this submission, '
+                    f'which is not supported through the API.',
+                    status_code=400
+                )
+
+        # Add the submission first so we can re-use the finalize
+        # submission logic
+        submission = FormCollection(self.session).submissions.add(
+            item.name,
+            form,
+            state='pending',
+            spots=1 if item.current_registration_window else 0,
+        )
+        form.model = submission
+        try:
+            do_complete_submission(
+                submission, form, self.request,
+                raises=True,
+                no_messages=True,
+            )
+        except ValueError as exc:
+            raise ApiException(str(exc), status_code=400) from exc
 
 
 class ResourceApiEndpoint(ApiEndpoint[ResourceOrExternalLink, UUID]):

--- a/src/onegov/org/api.py
+++ b/src/onegov/org/api.py
@@ -19,7 +19,6 @@ from onegov.org.models.directory import (
 from onegov.org.models.external_link import (
     ExternalFormLink, ExternalLinkCollection, ExternalResourceLink)
 from onegov.org.models.page import News, NewsCollection, Topic, TopicCollection
-from onegov.org.views.form_submission import do_complete_submission
 from onegov.people import Person
 from onegov.people.collections import PersonCollection
 from onegov.reservation.collection import ResourceCollection
@@ -846,6 +845,8 @@ class FormApiEndpoint(ApiEndpoint[FormOrExternalLink, UUID | str]):
             spots=1 if item.current_registration_window else 0,
         )
         form.model = submission
+        # FIXME: circular import
+        from onegov.org.views.form_submission import do_complete_submission
         try:
             do_complete_submission(
                 submission, form, self.request,

--- a/src/onegov/org/api.py
+++ b/src/onegov/org/api.py
@@ -824,7 +824,11 @@ class FormApiEndpoint(ApiEndpoint[FormOrExternalLink, UUID | str]):
         #       instead of disallowing submissions altogether
         return item.form_class
 
-    def apply_changes(self, item: FormOrExternalLink, form: Form) -> None:
+    def apply_changes(
+        self,
+        item: FormOrExternalLink,
+        form: Form
+    ) -> dict[str, Any]:
         assert not isinstance(item, ExternalFormLink)
 
         for name, price in form.prices():
@@ -848,13 +852,33 @@ class FormApiEndpoint(ApiEndpoint[FormOrExternalLink, UUID | str]):
         # FIXME: circular import
         from onegov.org.views.form_submission import do_complete_submission
         try:
-            do_complete_submission(
+            ticket = do_complete_submission(
                 submission, form, self.request,
                 raises=True,
                 no_messages=True,
+                return_ticket=True
             )
         except ValueError as exc:
             raise ApiException(str(exc), status_code=400) from exc
+
+        return {
+            'collection': {
+                'version': '1.0',
+                'href': self.request.link(self),
+                'links': [
+                    {
+                        'rel': 'ticket',
+                        'href': self.request.link(ticket),
+                        'prompt': 'View Ticket (for supporters)',
+                    },
+                    {
+                        'rel': 'ticket_status',
+                        'href': self.request.link(ticket, 'status'),
+                        'prompt': 'View Ticket (for customers)',
+                    },
+                ],
+            }
+        }
 
 
 class ResourceApiEndpoint(ApiEndpoint[ResourceOrExternalLink, UUID]):

--- a/src/onegov/org/views/form_submission.py
+++ b/src/onegov/org/views/form_submission.py
@@ -44,7 +44,7 @@ from typing import Literal, TYPE_CHECKING
 if TYPE_CHECKING:
     from collections.abc import Iterable
     from onegov.core.types import RenderData
-    from onegov.form import FormSubmission
+    from onegov.form import Form, FormSubmission
     from onegov.org.request import OrgRequest
     from onegov.ticket import Ticket
     from webob import Response
@@ -280,6 +280,167 @@ def handle_edit_submission_from_ticket(
     )
 
 
+def do_complete_submission(
+    self: FormSubmission,
+    form: Form,
+    request: OrgRequest,
+    raises: bool = False,
+    no_messages: bool = False,
+) -> Response:
+
+    provider = request.app.default_payment_provider
+    token = provider.get_token(request) if provider else None
+    invoice_meta = InvoiceMeta(
+        invoice_items_for_submission(request, form, self),
+        rounding_base=request.app.org.price_rounding,
+        rounding_text=request.translate(_('Rounding difference')),
+    )
+    amount = invoice_meta.total
+    price = request.app.adjust_price(Price(
+        amount=amount,
+        currency=currency_for_submission(form, self),
+        credit_card_payment=any(
+            price.credit_card_payment
+            for __, price in form.prices()
+        )
+    )) if amount > 0.0 else None
+    payment = self.process_payment(price, provider, token)
+
+    # FIXME: Custom error message for PaymentError?
+    if not payment or isinstance(payment, PaymentError):
+        if raises:
+            raise ValueError('Payment processing failed')
+        if not no_messages:
+            request.alert(_('Your payment could not be processed'))
+        return morepath.redirect(request.link(self))
+
+    if payment is not True:
+        request.session.add(payment)
+        request.session.flush()
+        request.session.refresh(payment)
+        self.payment = payment
+
+    window = self.registration_window
+    if window and not window.accepts_submissions(self.spots):
+        if raises:
+            raise ValueError('Registrations are no longer possible')
+        if not no_messages:
+            request.alert(_('Registrations are no longer possible'))
+        return morepath.redirect(request.link(self))
+
+    show_submission = request.params.get('send_by_email') == 'yes'
+
+    self.meta['show_submission'] = show_submission
+    self.meta.changed()  # type:ignore[attr-defined]
+
+    collection = FormCollection(request.session)
+    submission_id = self.id
+
+    # Expunges the submission from the session
+    collection.submissions.complete_submission(self)
+
+    # make sure accessing the submission doesn't flush it, because
+    # it uses sqlalchemy utils observe, which doesn't like premature
+    # flushing at all
+    with collection.session.no_autoflush:
+        ticket = TicketCollection(request.session).open_ticket(
+            handler_code=self.meta.get('handler_code', 'FRM'),
+            handler_id=self.id.hex
+        )
+        TicketMessage.create(ticket, request, 'opened', 'external')
+
+        if invoice_meta:
+            invoice = TicketInvoice(id=uuid4())
+            invoice.invoicing_party = self.invoicing_party
+            request.session.add(invoice)
+
+            for item_meta in invoice_meta:
+                item = item_meta.add_to_invoice(invoice)
+                if payment is not True:
+                    if provider and payment.source == provider.type:
+                        item.payment_date = date.today()
+                    item.payments.append(payment)
+                    item.paid = payment.state == 'paid'
+
+            ticket.invoice = invoice
+
+    assert self.email is not None
+    submission = collection.submissions.by_id(
+        submission_id, current_only=True
+    )
+    custom_above_footer = (
+        self.form.custom_above_footer if self.form else None)
+    send_ticket_mail(
+        request=request,
+        template='mail_ticket_opened.pt',
+        subject=_('Your request has been registered'),
+        ticket=ticket,
+        receivers=(self.email, ),
+        content={
+            'model': ticket,
+            'form': form,
+            'show_submission': self.meta['show_submission'],
+            'custom_above_footer': custom_above_footer
+        }
+    )
+    for email in emails_for_new_ticket(request, ticket):
+        send_ticket_mail(
+            request=request,
+            template='mail_ticket_opened_info.pt',
+            subject=_('New ticket'),
+            ticket=ticket,
+            receivers=(email, ),
+            content={'model': ticket},
+        )
+
+    request.app.send_websocket(
+        channel=request.app.websockets_private_channel,
+        message={
+            'event': 'browser-notification',
+            'title': request.translate(_('New ticket')),
+            'created': ticket.created.isoformat()
+        },
+        groupids=request.app.groupids_for_ticket(ticket),
+    )
+
+    if request.auto_accept(ticket):
+        try:
+            # FIXME: Was the auto_accept_user being None the only
+            #        way this could raise ValueError previously?
+            #        If so refactor this to a simple if/else
+            if request.auto_accept_user is None:
+                raise ValueError()
+
+            ticket.accept_ticket(request.auto_accept_user)
+            # We need to reload the object with the correct polymorphic
+            # type
+            submission = collection.submissions.by_id(
+                submission_id, state='complete', current_only=True
+            )
+            assert isinstance(submission, CompleteFormSubmission)
+            handle_submission_action(
+                submission, request, 'confirmed',
+                ignore_csrf=True,
+                raises=True,
+                no_messages=no_messages,
+                owner=request.auto_accept_owner()
+            )
+
+        except ValueError:
+            if not no_messages and request.is_manager:
+                request.warning(_('Your request could not be '
+                                  'accepted automatically!'))
+        else:
+            close_ticket(
+                ticket, request.auto_accept_user, request
+            )
+
+    if not no_messages:
+        request.success(_('Thank you for your submission!'))
+
+    return morepath.redirect(request.link(ticket, 'status'))
+
+
 @OrgApp.view(model=PendingFormSubmission, name='complete',
              permission=Public, request_method='GET')
 @OrgApp.view(model=PendingFormSubmission, name='complete',
@@ -315,158 +476,18 @@ def handle_complete_submission(
 
     if form.errors:
         return morepath.redirect(request.link(self))
-    else:
-        if self.state == 'complete':
-            self.data.changed()  # type:ignore[attr-defined]  # trigger updates
-            request.success(_('Your changes were saved'))
 
-            assert self.name is not None
-            return morepath.redirect(request.link(
-                FormCollection(request.session).scoped_submissions(
-                    self.name, ensure_existance=False)
-            ))
-        else:
-            provider = request.app.default_payment_provider
-            token = provider.get_token(request) if provider else None
-            invoice_meta = InvoiceMeta(
-                invoice_items_for_submission(request, form, self),
-                rounding_base=request.app.org.price_rounding,
-                rounding_text=request.translate(_('Rounding difference')),
-            )
-            amount = invoice_meta.total
-            price = request.app.adjust_price(Price(
-                amount=amount,
-                currency=currency_for_submission(form, self),
-                credit_card_payment=any(
-                    price.credit_card_payment
-                    for __, price in form.prices()
-                )
-            )) if amount > 0.0 else None
-            payment = self.process_payment(price, provider, token)
+    if self.state == 'complete':
+        self.data.changed()  # type:ignore[attr-defined]  # trigger updates
+        request.success(_('Your changes were saved'))
 
-            # FIXME: Custom error message for PaymentError?
-            if not payment or isinstance(payment, PaymentError):
-                request.alert(_('Your payment could not be processed'))
-                return morepath.redirect(request.link(self))
+        assert self.name is not None
+        return morepath.redirect(request.link(
+            FormCollection(request.session).scoped_submissions(
+                self.name, ensure_existance=False)
+        ))
 
-            if payment is not True:
-                request.session.add(payment)
-                request.session.flush()
-                request.session.refresh(payment)
-                self.payment = payment
-
-            window = self.registration_window
-            if window and not window.accepts_submissions(self.spots):
-                request.alert(_('Registrations are no longer possible'))
-                return morepath.redirect(request.link(self))
-
-            show_submission = request.params.get('send_by_email') == 'yes'
-
-            self.meta['show_submission'] = show_submission
-            self.meta.changed()  # type:ignore[attr-defined]
-
-            collection = FormCollection(request.session)
-            submission_id = self.id
-
-            # Expunges the submission from the session
-            collection.submissions.complete_submission(self)
-
-            # make sure accessing the submission doesn't flush it, because
-            # it uses sqlalchemy utils observe, which doesn't like premature
-            # flushing at all
-            with collection.session.no_autoflush:
-                ticket = TicketCollection(request.session).open_ticket(
-                    handler_code=self.meta.get('handler_code', 'FRM'),
-                    handler_id=self.id.hex
-                )
-                TicketMessage.create(ticket, request, 'opened', 'external')
-
-                if invoice_meta:
-                    invoice = TicketInvoice(id=uuid4())
-                    invoice.invoicing_party = self.invoicing_party
-                    request.session.add(invoice)
-
-                    for item_meta in invoice_meta:
-                        item = item_meta.add_to_invoice(invoice)
-                        if payment is not True:
-                            if provider and payment.source == provider.type:
-                                item.payment_date = date.today()
-                            item.payments.append(payment)
-                            item.paid = payment.state == 'paid'
-
-                    ticket.invoice = invoice
-
-            assert self.email is not None
-            submission = collection.submissions.by_id(
-                submission_id, current_only=True
-            )
-            custom_above_footer = (
-                self.form.custom_above_footer if self.form else None)
-            send_ticket_mail(
-                request=request,
-                template='mail_ticket_opened.pt',
-                subject=_('Your request has been registered'),
-                ticket=ticket,
-                receivers=(self.email, ),
-                content={
-                    'model': ticket,
-                    'form': form,
-                    'show_submission': self.meta['show_submission'],
-                    'custom_above_footer': custom_above_footer
-                }
-            )
-            for email in emails_for_new_ticket(request, ticket):
-                send_ticket_mail(
-                    request=request,
-                    template='mail_ticket_opened_info.pt',
-                    subject=_('New ticket'),
-                    ticket=ticket,
-                    receivers=(email, ),
-                    content={'model': ticket},
-                )
-
-            request.app.send_websocket(
-                channel=request.app.websockets_private_channel,
-                message={
-                    'event': 'browser-notification',
-                    'title': request.translate(_('New ticket')),
-                    'created': ticket.created.isoformat()
-                },
-                groupids=request.app.groupids_for_ticket(ticket),
-            )
-
-            if request.auto_accept(ticket):
-                try:
-                    # FIXME: Was the auto_accept_user being None the only
-                    #        way this could raise ValueError previously?
-                    #        If so refactor this to a simple if/else
-                    if request.auto_accept_user is None:
-                        raise ValueError()
-
-                    ticket.accept_ticket(request.auto_accept_user)
-                    # We need to reload the object with the correct polymorphic
-                    # type
-                    submission = collection.submissions.by_id(
-                        submission_id, state='complete', current_only=True
-                    )
-                    assert isinstance(submission, CompleteFormSubmission)
-                    handle_submission_action(
-                        submission, request, 'confirmed', True, raises=True,
-                        owner=request.auto_accept_owner()
-                    )
-
-                except ValueError:
-                    if request.is_manager:
-                        request.warning(_('Your request could not be '
-                                          'accepted automatically!'))
-                else:
-                    close_ticket(
-                        ticket, request.auto_accept_user, request
-                    )
-
-            request.success(_('Thank you for your submission!'))
-
-            return morepath.redirect(request.link(ticket, 'status'))
+    return do_complete_submission(self, form, request)
 
 
 @OrgApp.view(model=CompleteFormSubmission, name='ticket', permission=Private)

--- a/src/onegov/org/views/form_submission.py
+++ b/src/onegov/org/views/form_submission.py
@@ -40,7 +40,7 @@ from uuid import uuid4
 from webob.exc import HTTPMethodNotAllowed, HTTPNotFound
 
 
-from typing import Literal, TYPE_CHECKING
+from typing import overload, Literal, TYPE_CHECKING
 if TYPE_CHECKING:
     from collections.abc import Iterable
     from onegov.core.types import RenderData
@@ -280,13 +280,47 @@ def handle_edit_submission_from_ticket(
     )
 
 
+@overload
 def do_complete_submission(
     self: FormSubmission,
     form: Form,
     request: OrgRequest,
+    *,
     raises: bool = False,
     no_messages: bool = False,
-) -> Response:
+    return_ticket: Literal[False] = False,
+) -> Response: ...
+@overload
+def do_complete_submission(
+    self: FormSubmission,
+    form: Form,
+    request: OrgRequest,
+    *,
+    raises: Literal[True],
+    no_messages: bool = False,
+    return_ticket: Literal[True],
+) -> Ticket: ...
+@overload
+def do_complete_submission(
+    self: FormSubmission,
+    form: Form,
+    request: OrgRequest,
+    *,
+    raises: Literal[False] = False,
+    no_messages: bool = False,
+    return_ticket: Literal[True],
+) -> Ticket | None: ...
+
+
+def do_complete_submission(
+    self: FormSubmission,
+    form: Form,
+    request: OrgRequest,
+    *,
+    raises: bool = False,
+    no_messages: bool = False,
+    return_ticket: bool = False,
+) -> Response | Ticket | None:
 
     provider = request.app.default_payment_provider
     token = provider.get_token(request) if provider else None
@@ -312,6 +346,8 @@ def do_complete_submission(
             raise ValueError('Payment processing failed')
         if not no_messages:
             request.alert(_('Your payment could not be processed'))
+        if return_ticket:
+            return None
         return morepath.redirect(request.link(self))
 
     if payment is not True:
@@ -326,6 +362,8 @@ def do_complete_submission(
             raise ValueError('Registrations are no longer possible')
         if not no_messages:
             request.alert(_('Registrations are no longer possible'))
+        if return_ticket:
+            return None
         return morepath.redirect(request.link(self))
 
     show_submission = request.params.get('send_by_email') == 'yes'
@@ -438,6 +476,8 @@ def do_complete_submission(
     if not no_messages:
         request.success(_('Thank you for your submission!'))
 
+    if return_ticket:
+        return ticket
     return morepath.redirect(request.link(ticket, 'status'))
 
 

--- a/tests/onegov/agency/test_api.py
+++ b/tests/onegov/agency/test_api.py
@@ -472,7 +472,7 @@ def test_view_api(
     )
     assert response.status_code == 400
     parsed = Collection.from_json(response.text)
-    assert 'submitter_email: Das ist ein Pflichtfeld' in parsed.error.message
+    assert 'submitter_email: Field required' in parsed.error.message
 
     # test submitting a valid change
     payload = Template(data=[

--- a/tests/onegov/api/test_form.py
+++ b/tests/onegov/api/test_form.py
@@ -1,0 +1,451 @@
+from __future__ import annotations
+
+import pytest
+
+from base64 import b64encode
+from datetime import date, datetime, time, UTC
+from decimal import Decimal
+from freezegun import freeze_time
+from onegov.api.form import model_from_form
+from onegov.core.utils import dictionary_to_binary
+from onegov.form import parse_form
+from pydantic import ValidationError
+from tests.shared.utils import create_pdf
+from textwrap import dedent
+
+
+from typing import Any, TYPE_CHECKING
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def test_text_fields() -> None:
+    text = dedent("""
+        First name * = ___
+        Last name = ___
+        Country = ___[50]
+        Comment = ...
+        Zipcode = ___[4]/^[0-9]*$
+        Currency = ___/^[A-Z]{3}$
+    """)
+
+    form = parse_form(text)()
+    model = model_from_form(form)
+
+    with pytest.raises(ValidationError, match=r'first_name\s+Field required'):
+        model.model_validate({})
+
+    with pytest.raises(
+        ValidationError,
+        match=r'country\s+String should have at most 50 characters'
+    ):
+        model.model_validate({'first_name': 'John', 'country': 'a'*51})
+
+    with pytest.raises(
+        ValidationError,
+        match=r'zipcode\s+String should have at most 4 characters'
+    ):
+        model.model_validate({'first_name': 'John', 'zipcode': '12345'})
+
+    with pytest.raises(
+        ValidationError,
+        match=r'zipcode\s+String should match pattern'
+    ):
+        model.model_validate({'first_name': 'John', 'zipcode': 'ABCD'})
+
+    with pytest.raises(
+        ValidationError,
+        match=r'currency\s+String should match pattern'
+    ):
+        model.model_validate({'first_name': 'John', 'currency': 'AB'})
+
+    with pytest.raises(
+        ValidationError,
+        match=r'currency\s+String should match pattern'
+    ):
+        model.model_validate({'first_name': 'John', 'currency': 'ABCD'})
+
+    result: Any = model.model_validate({'first_name': 'John'})
+    assert result.first_name == 'John'
+    assert result.last_name is None
+    assert result.country is None
+    assert result.comment is None
+    assert result.zipcode is None
+    assert result.currency is None
+
+    result = model.model_validate({
+        'first_name': 'John',
+        'last_name': 'Doe',
+        'country': 'Switzerland',
+        'comment': 'Oh so important',
+        'zipcode': '6003',
+        'currency': 'CHF',
+    })
+    assert result.first_name == 'John'
+    assert result.last_name == 'Doe'
+    assert result.country == 'Switzerland'
+    assert result.comment == 'Oh so important'
+    assert result.zipcode == '6003'
+    assert result.currency == 'CHF'
+
+
+def test_email_field() -> None:
+    form = parse_form("E-Mail = @@@")()
+    model = model_from_form(form)
+
+    with pytest.raises(ValidationError, match=r'not a valid email address'):
+        model.model_validate({'e_mail': 'bogus'})
+
+    result: Any = model.model_validate({'e_mail': 'john.doe@example.com'})
+    assert result.e_mail == 'john.doe@example.com'
+
+
+def test_url_field() -> None:
+    form = parse_form("Url = http://")()
+    model = model_from_form(form)
+
+    with pytest.raises(ValidationError, match=r'should be a valid URL'):
+        model.model_validate({'url': 'bogus'})
+
+    with pytest.raises(ValidationError, match=r'hostname is not valid'):
+        model.model_validate({'url': 'http://localhost'})
+
+    result: Any = model.model_validate({'url': 'https://example.com'})
+    assert result.url == 'https://example.com/'
+
+
+def test_video_url_field() -> None:
+    form = parse_form("Url = video-url")()
+    model = model_from_form(form)
+
+    with pytest.raises(ValidationError, match=r'should be a valid URL'):
+        model.model_validate({'url': 'bogus'})
+
+    with pytest.raises(ValidationError, match=r'hostname is not valid'):
+        model.model_validate({'url': 'http://localhost'})
+
+    result: Any = model.model_validate({'url': 'https://example.com'})
+    assert result.url == 'https://example.com/'
+
+
+@freeze_time('2022-10-10')
+def test_date_field() -> None:
+    form = parse_form("Date = YYYY.MM.DD (today..+1 months)")()
+    model = model_from_form(form)
+
+    with pytest.raises(ValidationError, match=r'should be a valid date'):
+        model.model_validate({'date': 'bogus'})
+
+    with pytest.raises(ValidationError, match=r'should be greater'):
+        model.model_validate({'date': '2022-10-09'})
+
+    with pytest.raises(ValidationError, match=r'should be less'):
+        model.model_validate({'date': '2022-11-11'})
+
+    result: Any = model.model_validate({'date': '2022-10-10'})
+    assert result.date == date(2022, 10, 10)
+
+
+@freeze_time('2022-10-10')
+def test_datetime_field() -> None:
+    form = parse_form("Date = YYYY.MM.DD HH:MM (today..+1 months)")()
+    model = model_from_form(form)
+
+    with pytest.raises(ValidationError, match=r'should be a valid date'):
+        model.model_validate({'date': 'bogus'})
+
+    with pytest.raises(ValidationError, match=r'should be greater'):
+        model.model_validate({'date': '2022-10-09T08:00:00Z'})
+
+    with pytest.raises(ValidationError, match=r'should be less'):
+        model.model_validate({'date': '2022-11-11T08:00:00Z'})
+
+    result: Any = model.model_validate({'date': '2022-10-10T08:00:00Z'})
+    assert result.date == datetime(2022, 10, 10, 8, tzinfo=UTC)
+
+
+def test_time_field() -> None:
+    form = parse_form("Time = HH:MM")()
+    model = model_from_form(form)
+
+    with pytest.raises(ValidationError, match=r'should be in a valid time'):
+        model.model_validate({'time': 'bogus'})
+
+    result: Any = model.model_validate({'time': '08:24'})
+    assert result.time == time(8, 24)
+
+
+def create_pdf_file_dict(path: Path, filename: str) -> dict[str, str]:
+    pdf_path = path / filename
+    create_pdf(str(pdf_path))
+    with open(pdf_path, mode='rb') as fp:
+        return {
+            'filename': filename,
+            'data': b64encode(fp.read()).decode('ascii')
+        }
+
+
+def test_fileinput_field(tmp_path: Path) -> None:
+    form = parse_form("File * = *.pdf|*.doc")()
+    model = model_from_form(form)
+
+    with pytest.raises(ValidationError, match=r'should be a valid dict'):
+        model.model_validate({'file': 'bogus'})
+
+    with pytest.raises(
+        ValidationError,
+        match=r'file\.filename\s+Field required'
+    ):
+        model.model_validate({'file': {}})
+
+    with pytest.raises(
+        ValidationError,
+        match=r'file\.data\s+Field required'
+    ):
+        model.model_validate({'file': {'filename': 'test.txt'}})
+
+    with pytest.raises(
+        ValidationError,
+        match=r'file\.data\s+Base64 decoding error'
+    ):
+        model.model_validate({
+            'file': {
+                'filename': 'test.txt',
+                'data': 'bogus'
+            }
+        })
+
+    with pytest.raises(
+        ValidationError,
+        match=r'file\s+Value error, Unsupported mimetype'
+    ):
+        model.model_validate({
+            'file': {
+                'filename': 'test.txt',
+                'data': b64encode(b'Hello world').decode('ascii')
+            }
+        })
+
+
+    result: Any = model.model_validate({
+        'file': create_pdf_file_dict(tmp_path, 'test.pdf')
+    })
+    assert result.file['filename'] == 'test.pdf'
+    assert result.file['mimetype'] == 'application/pdf'
+    assert result.file['size'] > 0
+    assert dictionary_to_binary(result.file)
+
+
+def test_multiplefileinput_field(tmp_path: Path) -> None:
+    form = parse_form("Files * = *.pdf|*.doc (multiple)")()
+    model = model_from_form(form)
+
+    with pytest.raises(ValidationError, match=r'should be a valid list'):
+        model.model_validate({'files': 'bogus'})
+
+    with pytest.raises(ValidationError, match=r'at least 1 item'):
+        model.model_validate({'files': []})
+
+    with pytest.raises(
+        ValidationError,
+        match=r'files\.0\.filename\s+Field required'
+    ):
+        model.model_validate({'files': [{}]})
+
+    with pytest.raises(
+        ValidationError,
+        match=r'files\.0\.data\s+Field required'
+    ):
+        model.model_validate({'files': [{'filename': 'test.txt'}]})
+
+    with pytest.raises(
+        ValidationError,
+        match=r'files\.0\.data\s+Base64 decoding error'
+    ):
+        model.model_validate({
+            'files': [{
+                'filename': 'test.txt',
+                'data': 'bogus'
+            }]
+        })
+
+    with pytest.raises(
+        ValidationError,
+        match=r'files\.0\s+Value error, Unsupported mimetype'
+    ):
+        model.model_validate({
+            'files': [{
+                'filename': 'test.txt',
+                'data': b64encode(b'Hello world').decode('ascii')
+            }]
+        })
+
+
+    result: Any = model.model_validate({
+        'files': [
+            create_pdf_file_dict(tmp_path, 'test1.pdf'),
+            create_pdf_file_dict(tmp_path, 'test2.pdf'),
+        ]
+    })
+    assert len(result.files) == 2
+    assert result.files[0]['filename'] == 'test1.pdf'
+    assert result.files[0]['mimetype'] == 'application/pdf'
+    assert result.files[0]['size'] > 0
+    assert dictionary_to_binary(result.files[0])
+    assert result.files[1]['filename'] == 'test2.pdf'
+    assert result.files[1]['mimetype'] == 'application/pdf'
+    assert result.files[1]['size'] > 0
+    assert dictionary_to_binary(result.files[1])
+
+
+def test_integer_field() -> None:
+    form = parse_form("Age = 21..150")()
+    model = model_from_form(form)
+
+    with pytest.raises(ValidationError, match=r'should be a valid integer'):
+        model.model_validate({'age': 'bogus'})
+
+    with pytest.raises(ValidationError, match=r'should be greater'):
+        model.model_validate({'age': 20})
+
+    with pytest.raises(ValidationError, match=r'should be less'):
+        model.model_validate({'age': 151})
+
+    result: Any = model.model_validate({'age': 25})
+    assert result.age == 25
+
+
+def test_decimal_field() -> None:
+    form = parse_form("Percentage = 0.00..100.00")()
+    model = model_from_form(form)
+
+    with pytest.raises(ValidationError, match=r'should be a valid decimal'):
+        model.model_validate({'percentage': 'bogus'})
+
+    with pytest.raises(ValidationError, match=r'should be greater'):
+        model.model_validate({'percentage': '-1.00'})
+
+    with pytest.raises(ValidationError, match=r'should be less'):
+        model.model_validate({'percentage': '100.01'})
+
+    result: Any = model.model_validate({'percentage': '50.00'})
+    assert result.percentage == Decimal('50.00')
+
+
+def test_stdnum_field() -> None:
+    form = parse_form("Bank Account = # iban")()
+    model = model_from_form(form)
+
+    with pytest.raises(ValidationError):
+        model.model_validate({'bank_account': 'bogus'})
+
+    result: Any = model.model_validate({
+        'bank_account': 'CH93 0076 2011 6238 5295 7'
+    })
+    assert result.bank_account == 'CH93 0076 2011 6238 5295 7'
+
+
+def test_radio_field() -> None:
+    text = dedent("""
+        Gender =
+            ( ) Male
+            (x) Female
+    """)
+    form = parse_form(text)()
+    model = model_from_form(form)
+
+    with pytest.raises(ValidationError, match=r"should be 'Male' or 'Female'"):
+        model.model_validate({'gender': 'bogus'})
+
+    result: Any = model.model_validate({'gender': 'Female'})
+    assert result.gender == 'Female'
+
+
+def test_checkbox_field() -> None:
+    text = dedent("""
+        Required * =
+            [ ] A
+            [ ] B
+            [ ] C
+        Defaults =
+            [x] D
+            [ ] E
+            [x] F
+    """)
+    form = parse_form(text)()
+    model = model_from_form(form)
+
+    with pytest.raises(ValidationError, match=r'required\s+Field required'):
+        model.model_validate({})
+
+    with pytest.raises(ValidationError, match=r'at least 1 item'):
+        model.model_validate({'required': []})
+
+    with pytest.raises(ValidationError, match=r"should be 'A', 'B' or 'C'"):
+        model.model_validate({'required': ['bogus']})
+
+    result: Any = model.model_validate({'required': ['A', 'B']})
+    assert result.required == ['A', 'B']
+    assert result.defaults == ['D', 'F']
+
+    result = model.model_validate({
+        'required': ['A', 'B'],
+        'defaults': [],
+    })
+    assert result.required == ['A', 'B']
+    assert result.defaults == []
+
+
+def test_dependency_validation_chain() -> None:
+    text = dedent("""
+        Say * =
+            ( ) Yes
+                This * = ___
+            (x) No
+        Select =
+            [x] A
+                That * = ___
+            [ ] B
+            [ ] C
+                Email * = @@@
+    """)
+    form = parse_form(text)()
+    model = model_from_form(form)
+
+    with pytest.raises(ValidationError, match=r'say_this is required'):
+        model.model_validate({'say': 'Yes'})
+
+    with pytest.raises(ValidationError, match=r'select_that is required'):
+        model.model_validate({'say': 'No'})
+
+    with pytest.raises(ValidationError, match=r'select_email is required'):
+        model.model_validate({'say': 'No', 'select': ['C']})
+
+    # NOTE: Even though e-mail is not required with this selection
+    #       we will error if bogus data was submitted
+    with pytest.raises(ValidationError, match=r'not a valid email address'):
+        model.model_validate({
+            'say': 'No',
+            'select': ['B'],
+            'select_email': 'bogus'
+        })
+
+    result: Any = model.model_validate({'say': 'No', 'select': ['B']})
+    assert result.say == 'No'
+    assert result.say_this is None
+    assert result.select == ['B']
+    assert result.select_that is None
+    assert result.select_email is None
+
+    result = model.model_validate({
+        'say': 'Yes',
+        'say_this': 'Something',
+        'select': ['A', 'C'],
+        'select_that': 'Nothing',
+        'select_email': 'john.doe@example.com'
+    })
+    assert result.say == 'Yes'
+    assert result.say_this == 'Something'
+    assert result.select == ['A', 'C']
+    assert result.select_that == 'Nothing'
+    assert result.select_email == 'john.doe@example.com'

--- a/tests/onegov/org/test_api.py
+++ b/tests/onegov/org/test_api.py
@@ -4,7 +4,7 @@ import json
 import transaction
 from base64 import b64encode
 from datetime import timedelta
-from collection_json import Collection  # type: ignore[import-untyped]
+from collection_json import Collection, Template  # type: ignore[import-untyped]
 from onegov.directory import DirectoryCollection, DirectoryConfiguration
 from onegov.form import FormCollection
 from onegov.form.parser import ParsedForm
@@ -211,6 +211,99 @@ def test_view_api(
         data(item)['title']
         for item in collection('/api/topics').items
     } == {'Organisation', 'Themen', 'Kontakt'}
+
+
+@patch('onegov.websockets.integration.connect')
+@patch('onegov.websockets.integration.broadcast')
+@patch('onegov.websockets.integration.authenticate')
+def test_api_submitting_forms(
+    authenticate: MagicMock,
+    broadcast: MagicMock,
+    connect: MagicMock,
+    client: Client
+) -> None:
+
+    client.login_admin()  # allow access to PUT endpoint
+
+    def collection(url: str) -> Collection:
+        return Collection.from_json(client.get(url).body)
+
+    def data(item: Any) -> dict[str, Any]:
+        return {x.name: x.value for x in item.data}
+
+    def filters(item: Any) -> dict[str, Any]:
+        return {x.name: x.values or x.prompt for x in item.data}
+
+    def links(item: Any) -> dict[str, str]:
+        return {x.rel: x.href for x in item.links}
+
+    def template(item: Any) -> set[str]:
+        return {x.name for x in item.template.data}
+
+    forms_collection = collection('/api/forms')
+    forms = {
+        data(item)['title']: item.href
+        for item in forms_collection.items
+    }
+    assert set(forms) == {'Anmeldung'}
+    # Forms are different for every item so there is no shared template
+    assert forms_collection.template is None
+    anmeldung_collection = collection(forms['Anmeldung'])
+    assert template(anmeldung_collection) == {
+        'personalien_vorname',
+        'personalien_name',
+        'personalien_e_mail',
+        'personalien_geburtsdatum',
+        'personalien_ahv_nummer',
+        'adresse_strasse_inkl_hausnummer_',
+        'adresse_plz_ort',
+        'personliches_ernahrung',
+        'personliches_musikstile',
+        'sonstiges_bemerkungen',
+    }
+
+    # test submitting an invalid change (missing fields)
+    payload = Template(data=[
+        {'name': 'personalien_vorname', 'value': 'Nick'}
+    ]).to_dict()
+    response = client.put_json(
+        forms['Anmeldung'],
+        payload,
+        expect_errors=True
+    )
+    assert response.status_code == 400
+    parsed = Collection.from_json(response.text)
+    message = parsed.error.message
+    assert 'personalien_e_mail: Field required' in message
+    assert 'personalien_name: Field required' in message
+    assert 'personalien_geburtsdatum: Field required' in message
+    assert 'adresse_strasse_inkl_hausnummer_: Field required' in message
+    assert 'adresse_plz_ort: Field required' in message
+
+    # test submitting a valid change
+    payload = Template(data=[
+        {'name': 'personalien_vorname', 'value': 'Nick'},
+        {'name': 'personalien_name', 'value': 'Riviera'},
+        {'name': 'personalien_e_mail', 'value': 'nick.riviera@example.org'},
+        {'name': 'personalien_geburtsdatum', 'value': '1987-10-10'},
+        {'name': 'adresse_strasse_inkl_hausnummer_', 'value': 'Strasse 15'},
+        {'name': 'adresse_plz_ort', 'value': '6003 Luzern'},
+    ]).to_dict()
+    response = client.put_json(forms['Anmeldung'], payload)
+    assert response.status_code == 200
+    parsed = Collection.from_json(response.text)
+    assert links(parsed).keys() == {'ticket', 'ticket_status'}
+
+    assert connect.call_count == 1
+    assert authenticate.call_count == 1
+    assert broadcast.call_count == 1
+    assert broadcast.call_args[0][3]['event'] == 'browser-notification'
+    assert broadcast.call_args[0][3]['title'] == 'Neues Ticket'
+    assert broadcast.call_args[0][3]['created']
+
+    # the ticket links are both valid
+    assert 'Riviera' in client.get(links(parsed)['ticket'])
+    assert 'Offen' in client.get(links(parsed)['ticket_status'])
 
 
 @patch('onegov.websockets.integration.connect')


### PR DESCRIPTION
## Commit message

Org: Allows form submissions to be entered via the forms API

This also solidifies the existing rudimentary support for submitting
form data as a Collection+JSON payload by converting a given form into
a pydantic model and validating the JSON payload based on that model.

TYPE: Feature
LINK: OGC-3410

## Checklist

- [ ] I have performed a self-review of my code
- [x] I have tested my code thoroughly by hand
- [x] I have added tests for my changes/features
