### PR TITLE
Api: undefer/eaglerly load directory entry preventing n+1 queries

### DIFF
--- a/src/onegov/org/api.py
+++ b/src/onegov/org/api.py
@@ -28,7 +28,7 @@ from onegov.search import SearchIndex
 from onegov.search.utils import language_from_locale
 from sqlalchemy import and_, func, or_
 from sqlalchemy.exc import SQLAlchemyError
-from sqlalchemy.orm import contains_eager, undefer
+from sqlalchemy.orm import contains_eager, selectinload, undefer
 from uuid import UUID
 
 
@@ -665,7 +665,12 @@ class DirectoryEntryApiEndpoint(ApiEndpoint[ExtendedDirectoryEntry, UUID]):
                     term
                 )
         result.batch_size = 25
-        return result
+
+        # eager-load the serialized entry data, batch only
+        return result.set_query_options(
+            undefer(ExtendedDirectoryEntry.content),
+            selectinload(ExtendedDirectoryEntry.files),
+        )
 
     def for_page(self, page: int | None) -> DirectoryEntryApiEndpoint:
         """ Return a new endpoint instance with the given page while keeping

--- a/src/onegov/org/api.py
+++ b/src/onegov/org/api.py
@@ -646,7 +646,8 @@ class DirectoryEntryApiEndpoint(ApiEndpoint[ExtendedDirectoryEntry, UUID]):
             self.directory,
             request=self.request,
             page=self.page or 0,
-            published_only=True
+            published_only=True,
+            undefer_content=True
         )
         for key, values in self.extra_parameters.items():
             self.assert_valid_filter(key)

--- a/src/onegov/org/api.py
+++ b/src/onegov/org/api.py
@@ -646,8 +646,7 @@ class DirectoryEntryApiEndpoint(ApiEndpoint[ExtendedDirectoryEntry, UUID]):
             self.directory,
             request=self.request,
             page=self.page or 0,
-            published_only=True,
-            undefer_content=True
+            published_only=True
         )
         for key, values in self.extra_parameters.items():
             self.assert_valid_filter(key)

--- a/src/onegov/org/models/directory.py
+++ b/src/onegov/org/models/directory.py
@@ -26,7 +26,7 @@ from onegov.org.utils import narrowest_access
 from onegov.pay import Price
 from onegov.ticket import Ticket
 from sqlalchemy import and_, or_, func, text
-from sqlalchemy.orm import object_session, undefer, selectinload
+from sqlalchemy.orm import object_session
 from sqlalchemy.orm.attributes import set_committed_value
 
 
@@ -702,13 +702,3 @@ class ExtendedDirectoryEntryCollection(
 
     def query(self) -> Query[ExtendedDirectoryEntry]:
         return self.apply_common_filters(super().query())
-
-    def transform_batch_query(
-        self,
-        query: Query[ExtendedDirectoryEntry]
-    ) -> Query[ExtendedDirectoryEntry]:
-        # eager-load per-entry data (e.g. API) to avoid N+1 on the batch
-        return query.options(
-            undefer(ExtendedDirectoryEntry.content),
-            selectinload(ExtendedDirectoryEntry.files),
-        )

--- a/src/onegov/org/models/directory.py
+++ b/src/onegov/org/models/directory.py
@@ -633,8 +633,6 @@ class ExtendedDirectoryEntryCollection(
         #        than filtering access after the fact, for now we'll only
         #        use it in the API.
         request: OrgRequest | None = None,
-        # eager-load deferred content to avoid N+1 when iterating (e.g. API)
-        undefer_content: bool = False,
     ) -> None:
 
         self.request = request
@@ -642,7 +640,6 @@ class ExtendedDirectoryEntryCollection(
         self.published_only = published_only
         self.past_only = past_only
         self.upcoming_only = upcoming_only
-        self.undefer_content = undefer_content
 
     if TYPE_CHECKING:
         directory: ExtendedDirectory
@@ -704,10 +701,14 @@ class ExtendedDirectoryEntryCollection(
         return query
 
     def query(self) -> Query[ExtendedDirectoryEntry]:
-        query = self.apply_common_filters(super().query())
-        if self.undefer_content:
-            query = query.options(
-                undefer(ExtendedDirectoryEntry.content),
-                selectinload(ExtendedDirectoryEntry.files),
-            )
-        return query
+        return self.apply_common_filters(super().query())
+
+    def transform_batch_query(
+        self,
+        query: Query[ExtendedDirectoryEntry]
+    ) -> Query[ExtendedDirectoryEntry]:
+        # eager-load per-entry data (e.g. API) to avoid N+1 on the batch
+        return query.options(
+            undefer(ExtendedDirectoryEntry.content),
+            selectinload(ExtendedDirectoryEntry.files),
+        )

--- a/src/onegov/org/models/directory.py
+++ b/src/onegov/org/models/directory.py
@@ -26,7 +26,7 @@ from onegov.org.utils import narrowest_access
 from onegov.pay import Price
 from onegov.ticket import Ticket
 from sqlalchemy import and_, or_, func, text
-from sqlalchemy.orm import object_session
+from sqlalchemy.orm import object_session, undefer, selectinload
 from sqlalchemy.orm.attributes import set_committed_value
 
 
@@ -633,6 +633,8 @@ class ExtendedDirectoryEntryCollection(
         #        than filtering access after the fact, for now we'll only
         #        use it in the API.
         request: OrgRequest | None = None,
+        # eager-load deferred content to avoid N+1 when iterating (e.g. API)
+        undefer_content: bool = False,
     ) -> None:
 
         self.request = request
@@ -640,6 +642,7 @@ class ExtendedDirectoryEntryCollection(
         self.published_only = published_only
         self.past_only = past_only
         self.upcoming_only = upcoming_only
+        self.undefer_content = undefer_content
 
     if TYPE_CHECKING:
         directory: ExtendedDirectory
@@ -701,4 +704,10 @@ class ExtendedDirectoryEntryCollection(
         return query
 
     def query(self) -> Query[ExtendedDirectoryEntry]:
-        return self.apply_common_filters(super().query())
+        query = self.apply_common_filters(super().query())
+        if self.undefer_content:
+            query = query.options(
+                undefer(ExtendedDirectoryEntry.content),
+                selectinload(ExtendedDirectoryEntry.files),
+            )
+        return query

--- a/tests/onegov/org/test_api.py
+++ b/tests/onegov/org/test_api.py
@@ -833,8 +833,9 @@ def test_api_directory_content_hash(client: Client) -> None:
 
 
 def test_api_directory_no_n_plus_one_content(client: Client) -> None:
-    from onegov.org.models.directory import ExtendedDirectoryEntryCollection
-    from sqlalchemy import event
+    from sqlalchemy import event as sa_event
+    from onegov.core.utils import Bunch
+    from onegov.org.api import DirectoryEntryApiEndpoint
 
     session = client.app.session()
     directory: ExtendedDirectory = DirectoryCollection(
@@ -848,30 +849,26 @@ def test_api_directory_no_n_plus_one_content(client: Client) -> None:
         directory.add(values={'name': f'Club {i}'})
     transaction.commit()
 
-    session = client.app.session()
-    directory = DirectoryCollection(
-        session, type='extended'
-    ).by_name('clubs')  # type: ignore[assignment]
-
-    collection = ExtendedDirectoryEntryCollection(
-        directory, published_only=True
+    request: Any = Bunch(
+        app=client.app, session=client.app.session(), identity=None
     )
-    entries = collection.batch  # eager-loads content + files
+    entries = DirectoryEntryApiEndpoint(request, 'clubs').collection.batch
     assert len(entries) == 5
 
     statements: list[str] = []
+    engine = client.app.session().get_bind()
 
-    def count_query(*args: Any) -> None:
-        statements.append(args[2])
+    def count(conn: Any, cursor: Any, statement: str, *args: Any) -> None:
+        statements.append(statement)
 
-    connection = session.connection()
-    event.listen(connection, 'before_cursor_execute', count_query)
+    sa_event.listen(engine, 'before_cursor_execute', count)
     try:
+        # what the API serializer touches per row
         for entry in entries:
-            entry.content  # must not emit a query
+            entry.content
             entry.files
     finally:
-        event.remove(connection, 'before_cursor_execute', count_query)
+        sa_event.remove(engine, 'before_cursor_execute', count)
 
     content_loads = [s for s in statements if 'directory_entries.content' in s]
     assert content_loads == [], f'N+1 on content: {len(content_loads)} queries'

--- a/tests/onegov/org/test_api.py
+++ b/tests/onegov/org/test_api.py
@@ -708,3 +708,48 @@ def test_api_directory_content_hash(client: Client) -> None:
     items = api_items(client, '/api/clubs')
     item_data = api_item_data(items[0])
     assert item_data['content_hash'] != first_hash
+
+
+def test_api_directory_no_n_plus_one_content(client: Client) -> None:
+    from onegov.org.models.directory import ExtendedDirectoryEntryCollection
+    from sqlalchemy import event
+
+    session = client.app.session()
+    directory: ExtendedDirectory = DirectoryCollection(
+        session, type='extended'
+    ).add(
+        title='Clubs',
+        structure='Name *= ___',
+        configuration=DirectoryConfiguration(title='Name', order=['Name']),
+    )
+    for i in range(5):
+        directory.add(values={'name': f'Club {i}'})
+    transaction.commit()
+
+    session = client.app.session()
+    directory = DirectoryCollection(
+        session, type='extended'
+    ).by_name('clubs')  # type: ignore[assignment]
+
+    collection = ExtendedDirectoryEntryCollection(
+        directory, published_only=True, undefer_content=True
+    )
+    entries = collection.batch  # eager-loads content
+    assert len(entries) == 5
+
+    statements: list[str] = []
+
+    def count_query(*args: Any) -> None:
+        statements.append(args[2])
+
+    connection = session.connection()
+    event.listen(connection, 'before_cursor_execute', count_query)
+    try:
+        for entry in entries:
+            entry.content  # must not emit a query
+            entry.files
+    finally:
+        event.remove(connection, 'before_cursor_execute', count_query)
+
+    content_loads = [s for s in statements if 'directory_entries.content' in s]
+    assert content_loads == [], f'N+1 on content: {len(content_loads)} queries'

--- a/tests/onegov/org/test_api.py
+++ b/tests/onegov/org/test_api.py
@@ -732,9 +732,9 @@ def test_api_directory_no_n_plus_one_content(client: Client) -> None:
     ).by_name('clubs')  # type: ignore[assignment]
 
     collection = ExtendedDirectoryEntryCollection(
-        directory, published_only=True, undefer_content=True
+        directory, published_only=True
     )
-    entries = collection.batch  # eager-loads content
+    entries = collection.batch  # eager-loads content + files
     assert len(entries) == 5
 
     statements: list[str] = []
@@ -753,3 +753,5 @@ def test_api_directory_no_n_plus_one_content(client: Client) -> None:
 
     content_loads = [s for s in statements if 'directory_entries.content' in s]
     assert content_loads == [], f'N+1 on content: {len(content_loads)} queries'
+    file_loads = [s for s in statements if 'files_for_directory_entries' in s]
+    assert len(file_loads) <= 1, f'N+1 on files: {len(file_loads)} queries'


### PR DESCRIPTION
Api: undefer/eaglerly load directory entry preventing n+1 queries

TYPE: Performance
LINK: ONEGOV-CLOUD-5YF
LINK: ONEGOV-CLOUD-5YD