### PR TITLE
Org: Switches dormakaba integration from exivo API to resivo API

### DIFF
--- a/src/onegov/org/forms/settings.py
+++ b/src/onegov/org/forms/settings.py
@@ -1854,13 +1854,13 @@ class KabaConfigurationForm(Form):
         label=_('Site ID'),
     )
 
-    api_key = StringField(
-        label='API_KEY',
+    client_id = StringField(
+        label='Client ID (M2M)',
         depends_on=('site_id', '!'),
     )
 
-    api_secret = PasswordField(
-        label='API_SECRET',
+    client_secret = PasswordField(
+        label='Client Secret (M2M)',
         depends_on=('site_id', '!'),
     )
 
@@ -1895,18 +1895,18 @@ class KabaConfigurationsField(FieldBase):
         assert hasattr(obj, 'meta')
 
         previous_secrets = {
-            config['site_id']: config['api_secret']
+            config['site_id']: config['client_secret']
             for config in obj.meta.get('kaba_configurations', [])
         }
         obj.meta['kaba_configurations'] = [
             {
                 'site_id': site_id,
-                'api_key': item['api_key'],
+                'client_id': item['client_id'],
                 # if we already submitted this then just use the existing
                 # key, unless we specified a new one
-                'api_secret':
-                    self.meta.request.app.encrypt(item['api_secret']).hex()
-                    if item['api_secret'] else previous_secrets[site_id]
+                'client_secret':
+                    self.meta.request.app.encrypt(item['client_secret']).hex()
+                    if item['client_secret'] else previous_secrets[site_id]
             }
             for item in self.data
             # skip de-selected entries
@@ -2003,12 +2003,12 @@ class KabaSettingsForm(Form):
 
             seen.add(site_id)
 
-            if not field.form.api_key.data:
+            if not field.form.client_id.data:
                 assert isinstance(self.kaba_configurations.errors, list)
                 msg = _(
                     '${field} for site ID ${site_id} is required',
                     mapping={
-                        'field': 'API_KEY',
+                        'field': field.form.client_id.label.text,
                         'site_id': field.form.site_id.data
                     }
                 )
@@ -2017,14 +2017,14 @@ class KabaSettingsForm(Form):
                 )
                 return False
 
-            if field.form.api_secret.data:
-                api_secret = field.form.api_secret.data
+            if field.form.client_secret.data:
+                client_secret = field.form.client_secret.data
             elif (cfg := self.model.get_kaba_configuration(site_id)) is None:
                 assert isinstance(self.kaba_configurations.errors, list)
                 msg = _(
                     '${field} for site ID ${site_id} is required',
                     mapping={
-                        'field': 'API_SECRET',
+                        'field': field.form.client_secret.label.text,
                         'site_id': field.form.site_id.data
                     }
                 )
@@ -2032,19 +2032,19 @@ class KabaSettingsForm(Form):
                     self.kaba_configurations.gettext(msg)
                 )
                 return False
-            elif cfg.api_key == field.form.api_key.data:
+            elif cfg.client_id == field.form.client_id.data:
                 # no need to re-validate
                 return None
             else:
                 # decrypt existing API secret
-                api_secret = self.request.app.decrypt(
-                    bytes.fromhex(cfg.api_secret)
+                client_secret = self.request.app.decrypt(
+                    bytes.fromhex(cfg.client_secret)
                 )
 
-            api_key = field.form.api_key.data
-            assert site_id is not None and api_key is not None
+            client_id = field.form.client_id.data
+            assert site_id is not None and client_id is not None
 
-            client = KabaClient(site_id, api_key, api_secret)
+            client = KabaClient(site_id, client_id, client_secret)
             try:
                 client.site_name()
             except KabaApiError:

--- a/src/onegov/org/kaba.py
+++ b/src/onegov/org/kaba.py
@@ -3,12 +3,13 @@ from __future__ import annotations
 import niquests
 import secrets
 import string
+from datetime import datetime, timedelta, UTC
 from sedate import to_timezone
+from urllib3.util import Retry
 
 
 from typing import Self, TYPE_CHECKING
 if TYPE_CHECKING:
-    from datetime import datetime
     from onegov.org.app import OrgApp
     from onegov.org.models.organisation import KabaConfiguration
     from onegov.reservation import Resource
@@ -27,20 +28,38 @@ class KabaClient:
     def __init__(
         self,
         site_id: str,
-        api_key: str,
-        api_secret: str
+        client_id: str,
+        client_secret: str
     ) -> None:
 
         self.site_id = site_id
-        self.session = niquests.Session(timeout=(5, 10))
-        self.session.auth = (api_key, api_secret)
-        self.base_url = 'https://api.exivo.io/v1'
+        self.client_id = client_id
+        self.client_secret = client_secret
+        self.session = niquests.Session(
+            retries=Retry(
+                total=3,
+                read=0,
+                connect=3,
+                status=3,
+                other=0,
+                backoff_factor=3,
+                allowed_methods=None,
+                status_forcelist=[429, 500, 502, 503, 504],
+                respect_retry_after_header=True,
+                retry_after_max=30,
+            ),
+            timeout=(5, 10)
+        )
+        self.base_url = 'https://api.resivo.io'
+        self.api_version = 'v8'
+        self.access_token: str
+        self.access_token_expires = datetime.now(UTC)
 
     @classmethod
     def from_config(cls, config: KabaConfiguration | None) -> Self | None:
         if config is None:
             return None
-        return cls(config.site_id, config.api_key, config.api_secret)
+        return cls(config.site_id, config.client_id, config.client_secret)
 
     @classmethod
     def from_app(cls, app: OrgApp) -> dict[str, Self]:
@@ -66,6 +85,28 @@ class KabaClient:
             if (client := cls.from_config(raw_config.decrypt(app)))
         }
 
+    def maybe_refresh_access_token(self) -> None:
+        if self.access_token_expires <= (now := datetime.now(UTC)):
+            res = self.session.post(
+                f'{self.base_url}/oauth2/token',
+                data={
+                    'grant_type': 'client_credentials',
+                    'client_id': self.client_id,
+                    'client_secret': self.client_secret,
+                },
+                timeout=(5, 10)
+            )
+            self.raise_for_status(res)
+            payload = res.json()
+            self.access_token = payload['access_token']
+            self.access_token_expires = now + timedelta(
+                # NOTE: We expire the token slightly earlier than we would
+                #       need to in order to avoid a race condition between
+                #       checking if we need to refresh and emitting the
+                #       request that uses the access token
+                seconds=payload.get('expires_in', 300) - 30
+            )
+
     def raise_for_status(self, res: niquests.Response) -> None:
         if res.ok:
             return
@@ -74,21 +115,25 @@ class KabaClient:
         raise KabaApiError(error['message'], res)
 
     def site_name(self) -> str:
+        self.maybe_refresh_access_token()
         res = self.session.get(
-            f'{self.base_url}/{self.site_id}/info',
+            f'{self.base_url}/{self.api_version}/sites/{self.site_id}',
+            auth=self.access_token,
             timeout=(5, 10)
         )
         self.raise_for_status(res)
-        return res.json()['name']
+        return res.json()['displayName']
 
     def component_choices(self) -> list[_Choice]:
+        self.maybe_refresh_access_token()
         res = self.session.get(
-            f'{self.base_url}/{self.site_id}/component',
+            f'{self.base_url}/{self.site_id}/components?scope=all',
+            auth=self.access_token,
             timeout=(5, 10)
         )
         self.raise_for_status(res)
         return [
-            ([self.site_id, item['id']], item['identifier'])
+            ([self.site_id, item['id']], item['displayName'])
             for item in res.json()
         ]
 
@@ -96,7 +141,7 @@ class KabaClient:
     def random_code() -> str:
         return ''.join(secrets.choice(string.digits) for _ in range(4))
 
-    def create_visit(
+    def create_pin_access(
         self,
         code: str,
         name: str,
@@ -105,41 +150,55 @@ class KabaClient:
         end: datetime,
         components: list[str]
     ) -> str:
+        self.maybe_refresh_access_token()
         res = self.session.post(
-            f'{self.base_url}/{self.site_id}/visit',
+            f'{self.base_url}/{self.site_id}/authorizations/pin-access',
             json={
-                'code': code,
-                # NOTE: The API claims to support ISO 8601, but in fact it only
-                #       supports UTC times with Z postfix instead of an offset.
-                'validFrom': to_timezone(
-                    start, 'UTC'
-                ).isoformat(timespec='microseconds')[:-6] + 'Z',
-                'validTo': to_timezone(
-                    end, 'UTC'
-                ).isoformat(timespec='microseconds')[:-6] + 'Z',
-                'components': components,
-                'name': name,
-                'message': message,
+                'displayName': name,
+                'pinCodes': [{'pinCode': code, 'displayName': f'{name} PIN'}],
+                'componentIds': components,
+                'restrictions': {
+                    # NOTE: We may no longer need to normalize the ISO format
+                    #       like we did with exivo, double check and simplify
+                    #       if possible.
+                    'validFrom': to_timezone(
+                        start, 'UTC'
+                    ).isoformat(timespec='microseconds')[:-6] + 'Z',
+                    'validTo': to_timezone(
+                        end, 'UTC'
+                    ).isoformat(timespec='microseconds')[:-6] + 'Z',
+                },
+                'accessRequestMessage': message,
             },
+            auth=self.access_token,
             timeout=(5, 10)
         )
         self.raise_for_status(res)
         data = res.json()
         return data['id']
 
-    def revoke_visit(self, visit_id: str) -> None:
+    def revoke_pin_access(self, auth_id: str) -> None:
+        self.maybe_refresh_access_token()
         res = self.session.get(
-            f'{self.base_url}/{self.site_id}/visit/{visit_id}',
+            f'{self.base_url}/{self.site_id}/authorizations/{auth_id}',
+            auth=self.access_token,
             timeout=(5, 10)
         )
         self.raise_for_status(res)
         data = res.json()
-        if data.get('revoked') is True or data.get('expired') is True:
+        if data.get('status') != 'active' or all(
+            credential.get('isExpired') is True
+            or credential.get('status') != 'active'
+            for credential in data.get('credentials', ())
+        ):
             return
 
-        res = self.session.post(
-            f'{self.base_url}/{self.site_id}/visit/{visit_id}/revoke',
+        # NOTE: Just in case the previous request was slow
+        self.maybe_refresh_access_token()
+        res = self.session.delete(
+            f'{self.base_url}/{self.site_id}/authorizations/{auth_id}/revoke',
             json={},
+            auth=self.access_token,
             timeout=(5, 10)
         )
         self.raise_for_status(res)

--- a/src/onegov/org/models/organisation.py
+++ b/src/onegov/org/models/organisation.py
@@ -33,25 +33,25 @@ if TYPE_CHECKING:
 
 class KabaConfiguration(NamedTuple):
     site_id: str
-    api_key: str
-    api_secret: str
+    client_id: str
+    client_secret: str
 
 
 class RawKabaConfiguration(NamedTuple):
     site_id: str
-    api_key: str
-    api_secret: str
+    client_id: str
+    client_secret: str
 
     def decrypt(self, app: Framework) -> KabaConfiguration | None:
         try:
-            api_secret = app.decrypt(bytes.fromhex(self.api_secret))
+            client_secret = app.decrypt(bytes.fromhex(self.client_secret))
         except InvalidToken:
             return None
 
         return KabaConfiguration(
             site_id=self.site_id,
-            api_key=self.api_key,
-            api_secret=api_secret
+            client_id=self.client_id,
+            client_secret=client_secret
         )
 
 

--- a/src/onegov/org/upgrade.py
+++ b/src/onegov/org/upgrade.py
@@ -1082,3 +1082,22 @@ def refresh_zeroed_reservation_invoices(context: UpgradeContext) -> None:
             'refreshed (non-manual or non-open payment): %s',
             len(skipped), ', '.join(skipped)
         )
+
+
+@upgrade_task('Clear deprecated exivo credentials and kaba components')
+def clear_exivo_credentials_and_kaba_components(
+    context: UpgradeContext
+) -> None:
+    if not context.has_table('resources'):
+        return
+
+    org = context.session.query(Organisation).first()
+    if not org or 'kaba_configurations' not in org.meta:
+        return
+
+    del org.meta['kaba_configurations']
+    context.session.execute(text("""
+        UPDATE resources
+           SET meta = meta - 'kaba_components'
+         wHERE meta ? 'kaba_components'
+    """))

--- a/src/onegov/org/views/reservation.py
+++ b/src/onegov/org/views/reservation.py
@@ -1058,12 +1058,12 @@ def accept_reservation(
             # NOTE: We can only create future visits
             start = reservation.display_start() - lead_delta
             if clients and start > now:
-                visit_ids = {}
+                auth_ids = {}
                 end = reservation.display_end() + lag_delta
                 for site_id, group in components.items():
                     assert code is not None
                     try:
-                        visit_id = clients[site_id].create_visit(
+                        auth_id = clients[site_id].create_pin_access(
                             code=code,
                             name=ticket.number,
                             message='Managed through OneGov Cloud',
@@ -1088,11 +1088,11 @@ def accept_reservation(
 
                         return request.redirect(request.link(self))
                     else:
-                        visit_ids[site_id] = visit_id
+                        auth_ids[site_id] = auth_id
 
                 data['kaba'] = {
                     'code': code,
-                    'visit_ids': visit_ids,
+                    'auth_ids': auth_ids,
                 }
 
         ReservationMessage.create(
@@ -1502,7 +1502,7 @@ def _remove_reservation(
         ticket.create_snapshot(request)
         ticket.state = orginal_state
 
-    kaba_visits_to_revoke: list[tuple[str, str]] = []
+    kaba_auths_to_revoke: list[tuple[str, str]] = []
     for reservation in targeted:
         if payment:
             # remove the link to the payment
@@ -1513,7 +1513,7 @@ def _remove_reservation(
         if (
             clients
             and (kaba := (reservation.data or {}).get('kaba'))
-            and (visit_ids := kaba.get('visit_ids'))
+            and (auth_ids := kaba.get('auth_ids'))
         ):
             lead_delta = timedelta(minutes=ticket.handler.data.get(
                 'key_code_lead_time',
@@ -1522,7 +1522,7 @@ def _remove_reservation(
             start = reservation.display_start() - lead_delta
             # we can only revoke future visits
             if start > sedate.utcnow():
-                kaba_visits_to_revoke.extend(visit_ids.items())
+                kaba_auths_to_revoke.extend(auth_ids.items())
         resource.scheduler.remove_reservation(token, reservation.id)
 
     if len(excluded) == 0 and submission:
@@ -1540,9 +1540,9 @@ def _remove_reservation(
         # the kaba visits until now, since we didn't hook this change
         # into the transaction system
         failed_to_revoke = False
-        for site_id, visit_id in kaba_visits_to_revoke:
+        for site_id, auth_id in kaba_auths_to_revoke:
             try:
-                clients[site_id].revoke_visit(visit_id)
+                clients[site_id].revoke_pin_access(auth_id)
             except (KeyError, KabaApiError) as kaba_exc:
                 if isinstance(kaba_exc, KabaApiError):
                     log.info('Kaba API error', exc_info=True)
@@ -2082,10 +2082,10 @@ def add_reservation(
                 request.app.org.default_key_code_lag_time
             ))
             end = reservation.display_end() + lag_delta
-            visit_ids = {}
+            auth_ids = {}
             for site_id, group in components.items():
                 try:
-                    visit_ids[site_id] = clients[site_id].create_visit(
+                    auth_ids[site_id] = clients[site_id].create_pin_access(
                         code=code,
                         name=ticket.number,
                         message='Managed through OneGov Cloud',
@@ -2110,7 +2110,7 @@ def add_reservation(
 
                 data['kaba'] = {
                     'code': code,
-                    'visit_ids': visit_ids,
+                    'auth_ids': auth_ids,
                 }
 
     ReservationMessage.create(
@@ -2347,24 +2347,24 @@ def adjust_reservation(
             old_start = reservation.display_start() - lead_delta
             start = new_reservation.display_start() - lead_delta
             end = new_reservation.display_end() + lag_delta
-            old_visit_ids = kaba.get('visit_ids')
+            old_auth_ids = kaba.get('auth_ids')
             now = sedate.utcnow()
-            visit_ids = {}
+            auth_ids = {}
             for site_id, group in components.items():
                 try:
                     code = kaba['code']
                     # NOTE: We can only revoke existing future visits
-                    old_visit_id = old_visit_ids.get(site_id)
-                    if old_visit_id and old_start > now:
+                    old_auth_id = old_auth_ids.get(site_id)
+                    if old_auth_id and old_start > now:
                         try:
-                            clients[site_id].revoke_visit(old_visit_id)
+                            clients[site_id].revoke_pin_access(old_auth_id)
                         except (KeyError, KabaApiError) as e:
                             if isinstance(e, KabaApiError):
                                 log.info('Kaba API error', exc_info=True)
                             failed_to_revoke = True
                     # NOTE: We can only create future visits
                     if start > now:
-                        visit_ids[site_id] = clients[site_id].create_visit(
+                        auth_ids[site_id] = clients[site_id].create_pin_access(
                             code=code,
                             name=ticket.number,
                             message='Managed through OneGov Cloud',
@@ -2388,7 +2388,7 @@ def adjust_reservation(
 
                 data['kaba'] = {
                     'code': code,
-                    'visit_ids': visit_ids,
+                    'auth_ids': auth_ids,
                 }
 
         ReservationAdjustedMessage.create(
@@ -2559,22 +2559,22 @@ def edit_kaba(
             start = reservation.display_start() - lead_delta
             end = reservation.display_end() + lag_delta
             kaba = data.get('kaba') or {}
-            old_visit_ids = kaba.get('visit_ids', {})
-            visit_ids = {}
+            old_auth_ids = kaba.get('auth_ids', {})
+            auth_ids = {}
             for site_id, group in components.items():
                 try:
                     # if there is an old visit, revoke it
-                    old_visit_id = old_visit_ids.get(site_id)
-                    if old_visit_id and old_start > now:
+                    old_auth_id = old_auth_ids.get(site_id)
+                    if old_auth_id and old_start > now:
                         try:
-                            clients[site_id].revoke_visit(old_visit_id)
+                            clients[site_id].revoke_pin_access(old_auth_id)
                         except (KeyError, KabaApiError) as e:
                             if isinstance(e, KabaApiError):
                                 log.info('Kaba API error', exc_info=True)
                             failed_to_revoke = True
 
                     if start > now:
-                        visit_ids[site_id] = clients[site_id].create_visit(
+                        auth_ids[site_id] = clients[site_id].create_pin_access(
                             code=code,
                             name=ticket.number,
                             message='Managed through OneGov Cloud',
@@ -2598,7 +2598,7 @@ def edit_kaba(
 
                 data['kaba'] = {
                     'code': code,
-                    'visit_ids': visit_ids,
+                    'auth_ids': auth_ids,
                 }
 
     if failed_to_revoke:


### PR DESCRIPTION
## Commit message

Org: Switches dormakaba integration from exivo API to resivo API

There is no automated migration of old visits/components/credentials
the integration will need to be reconfigured and components re-linked
afterwards visits/authorizations can be recreated for all future
reservations using a CLI command.

TYPE: Feature
LINK: OGC-2904
HINT: `onegov-org --select '/onegov_town6/stadt_zug' recreate-future-kaba-authorizations` after reconfiguring integration and updating selected doors for all resources

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added an upgrade hint such as data migration commands to be run
- [x] I have tested my code thoroughly by hand
