### PR TITLE
Org: Allow wildcard CSP domains for iFrame URLs

### DIFF
--- a/src/onegov/org/forms/page.py
+++ b/src/onegov/org/forms/page.py
@@ -144,14 +144,18 @@ class IframeForm(PageBaseForm):
             return
 
         domain = '/'.join(field.data.split('/', 3)[:3])
-        allowed_domains = {
-            d.rstrip('/')
-            for d in self.allowed_domains
-        }
-        if domain not in allowed_domains:
-            raise ValidationError(
-                _('The domain of the URL is not allowed for iFrames.')
-            )
+        for allowed in self.allowed_domains:
+            allowed = allowed.rstrip('/')
+            # CSP child_src entries may use a wildcard host (*.vimeo.com)
+            if '*' in allowed:
+                prefix, _sep, suffix = allowed.partition('*')
+                if domain.startswith(prefix) and domain.endswith(suffix):
+                    return
+            elif domain == allowed:
+                return
+        raise ValidationError(
+            _('The domain of the URL is not allowed for iFrames.')
+        )
 
 
 class PageUrlForm(ChangeAdjacencyListUrlForm):

--- a/tests/onegov/org/test_views_pages.py
+++ b/tests/onegov/org/test_views_pages.py
@@ -729,6 +729,35 @@ def test_add_iframe(client: Client) -> None:
     assert 'Die Domäne der URL ist für iFrames nicht zulässig.' in page
 
 
+def test_add_iframe_csp_wildcard_domain(client: Client) -> None:
+    # wildcard CSP domains (https://*.vimeo.com) must match concrete hosts
+    client.login_admin()
+
+    for url in (
+        'https://player.vimeo.com/video/76979871',
+        'https://www.youtube.com/embed/dQw4w9WgXcQ',
+    ):
+        page = client.get('/topics/organisation').click('iFrame')
+        page.form['title'] = "Wildcard"
+        page.form['url'] = url
+        page = page.form.submit().follow()
+        assert 'Die Domäne der URL ist für iFrames nicht zulässig.' not in page
+        assert 'iFrame wurde hinzugefügt' in page
+
+    # the wildcard must not match spoofed hosts, bare apex or wrong scheme
+    for url in (
+        'https://vimeo.com.evil.org/video/1',
+        'https://evilvimeo.com/video/1',
+        'https://vimeo.com/76979871',
+        'http://player.vimeo.com/video/1',
+    ):
+        page = client.get('/topics/organisation').click('iFrame')
+        page.form['title'] = "Spoof"
+        page.form['url'] = url
+        page = page.form.submit()
+        assert 'Die Domäne der URL ist für iFrames nicht zulässig.' in page
+
+
 def test_open_graph_description_fallback(client: 'Client') -> None:
     client.login_admin()
 


### PR DESCRIPTION
Org: Allow wildcard CSP domains for iFrame URLs

TYPE: Bugfix
LINK: pro-1583